### PR TITLE
Add contract event log inspector

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -53,6 +53,14 @@ pub struct RunArgs {
     /// Enable verbose output
     #[arg(short, long)]
     pub verbose: bool,
+
+    /// Show contract events emitted during execution
+    #[arg(long)]
+    pub show_events: bool,
+
+    /// Filter events by topic
+    #[arg(long)]
+    pub filter_topic: Option<String>,
 }
 
 #[derive(Parser)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -54,6 +54,31 @@ pub fn run(args: RunArgs) -> Result<()> {
 
     println!("Result: {:?}", result);
 
+    // Display events if requested
+    if args.show_events {
+        println!("\n--- Events ---");
+        let events = engine.executor().get_events()?;
+        let filtered_events = if let Some(topic) = &args.filter_topic {
+            crate::inspector::events::EventInspector::filter_events(&events, topic)
+        } else {
+            events
+        };
+
+        if filtered_events.is_empty() {
+            println!("No events captured.");
+        } else {
+            for (i, event) in filtered_events.iter().enumerate() {
+                println!("Event #{}:", i);
+                if let Some(contract_id) = &event.contract_id {
+                    println!("  Contract: {}", contract_id);
+                }
+                println!("  Topics: {:?}", event.topics);
+                println!("  Data: {}", event.data);
+                println!();
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/src/inspector/events.rs
+++ b/src/inspector/events.rs
@@ -1,0 +1,93 @@
+use crate::Result;
+use soroban_env_host::{xdr::ContractEventBody, Host};
+
+/// Represents a captured contract event
+#[derive(Debug, Clone)]
+pub struct ContractEvent {
+    pub contract_id: Option<String>,
+    pub topics: Vec<String>,
+    pub data: String,
+}
+
+pub struct EventInspector;
+
+impl EventInspector {
+    /// Extract events from the host and convert them to a friendly format
+    pub fn get_events(host: &Host) -> Result<Vec<ContractEvent>> {
+        let events = host.get_events()?.0;
+        let mut contract_events = Vec::new();
+
+        for host_event in events.iter() {
+            let event = &host_event.event;
+
+            // Extract topics and data from event body
+            let (topics, data) = match &event.body {
+                ContractEventBody::V0(v0) => {
+                    let mut topics = Vec::new();
+                    for topic in v0.topics.iter() {
+                        topics.push(format!("{:?}", topic));
+                    }
+                    let data = format!("{:?}", v0.data);
+                    (topics, data)
+                }
+            };
+
+            // Parse contract ID
+            // contract_id is Option<Hash>
+            let contract_id = event.contract_id.as_ref().map(|h| format!("{:?}", h));
+
+            contract_events.push(ContractEvent {
+                contract_id,
+                topics,
+                data,
+            });
+        }
+
+        Ok(contract_events)
+    }
+
+    /// Filter events by a topic string
+    pub fn filter_events(events: &[ContractEvent], topic_filter: &str) -> Vec<ContractEvent> {
+        events
+            .iter()
+            .filter(|e| e.topics.iter().any(|t| t.contains(topic_filter)))
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_events() {
+        let events = vec![
+            ContractEvent {
+                contract_id: None,
+                topics: vec!["topic1".to_string(), "common".to_string()],
+                data: "data1".to_string(),
+            },
+            ContractEvent {
+                contract_id: None,
+                topics: vec!["topic2".to_string(), "common".to_string()],
+                data: "data2".to_string(),
+            },
+            ContractEvent {
+                contract_id: None,
+                topics: vec!["topic3".to_string()],
+                data: "data3".to_string(),
+            },
+        ];
+
+        let filtered = EventInspector::filter_events(&events, "topic1");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].data, "data1");
+
+        let filtered = EventInspector::filter_events(&events, "common");
+        assert_eq!(filtered.len(), 2);
+
+        let filtered = EventInspector::filter_events(&events, "nonexistent");
+        assert_eq!(filtered.len(), 0);
+    }
+}

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -1,4 +1,5 @@
 pub mod budget;
+pub mod events;
 pub mod stack;
 pub mod storage;
 

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -114,4 +114,8 @@ impl ContractExecutor {
         info!("Argument parsing not yet implemented");
         Ok(vec![])
     }
+    /// Get events captured during execution
+    pub fn get_events(&self) -> Result<Vec<crate::inspector::events::ContractEvent>> {
+        crate::inspector::events::EventInspector::get_events(self.env.host())
+    }
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::prelude::*;
 
 #[test]
 fn test_help_command() {
@@ -19,4 +20,25 @@ fn test_upgrade_check_help_command() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_soroban-debug"));
     cmd.arg("upgrade-check").arg("--help");
     cmd.assert().success();
+}
+
+#[test]
+fn test_run_command_event_flags() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soroban-debug"));
+    cmd.arg("run")
+        .arg("--contract")
+        .arg("test.wasm") // File doesn't need to exist for argument parsing check if we just check help or similar, but here we might fail on file read.
+        .arg("--show-events")
+        .arg("--filter-topic")
+        .arg("my-topic");
+
+    // We expect failure because test.wasm doesn't exist, but valid flags should be parsed.
+    // Actually, clap fails if required args are missing.
+    // Let's just check help to see if flags are listed.
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soroban-debug"));
+    cmd.arg("run").arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("--show-events"))
+        .stdout(predicate::str::contains("--filter-topic"));
 }


### PR DESCRIPTION

## Description
This PR introduces a new feature to the `run` command that allows developers to inspect events emitted by their Soroban contracts during execution. This makes debugging much easier by providing visibility into contract logs and state changes.

## New Features
- **Capture Events**: Automatically captures all events emitted via `env.events().publish()`.
- **Display Events**: New `--show-events` flag to print events in a readable format after execution.
- **Filter by Topic**: New `--filter-topic <string>` flag to filter displayed events by topic.

## Changes
- Created `src/inspector/events.rs`:Core logic for extracting and formatting events from the Host.
- Updated `src/runtime/executor.rs`: Added `get_events()` method to expose host events.
- Updated `src/cli/args.rs`: Added new CLI arguments.
- Updated `src/cli/commands.rs`: integrated event display into the execution flow.
- Added integration tests for event flags.

## Usage
```bash
# View all events
soroban-debug run --contract test.wasm --function test --show-events

# Filter events containing "mint"
soroban-debug run --contract test.wasm --function test --show-events --filter-topic "mint"
```

## Related Issues
Closes #40 