### PR TITLE
Implement basic argument parsing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -185,6 +185,64 @@ soroban-debug run --contract complex.wasm --function expensive_operation
 > Warning: High CPU usage detected
 ```
 
+## Supported Argument Types
+
+The debugger supports passing typed arguments to contract functions via the `--args` flag. You can use **bare values** for quick usage or **type annotations** for precise control.
+
+### Bare Values (Default Types)
+
+| JSON Value     | Soroban Type | Example               |
+|----------------|-------------|------------------------|
+| Number         | `i128`      | `10`, `-5`, `999`      |
+| String         | `Symbol`    | `"hello"`              |
+| Boolean        | `Bool`      | `true`, `false`        |
+| Array          | `Vec<Val>`  | `[1, 2, 3]`           |
+| Object         | `Map`       | `{"key": "value"}`     |
+
+```bash
+# Bare values (numbers default to i128, strings to Symbol)
+soroban-debug run --contract counter.wasm --function add --args '[10]'
+soroban-debug run --contract token.wasm --function transfer --args '["Alice", "Bob", 100]'
+```
+
+### Type Annotations
+
+For precise type control, use `{"type": "<type>", "value": <value>}`:
+
+| Type     | Description               | Example                                    |
+|----------|---------------------------|--------------------------------------------|
+| `u32`    | Unsigned 32-bit integer   | `{"type": "u32", "value": 42}`             |
+| `i32`    | Signed 32-bit integer     | `{"type": "i32", "value": -5}`             |
+| `u64`    | Unsigned 64-bit integer   | `{"type": "u64", "value": 1000000}`        |
+| `i64`    | Signed 64-bit integer     | `{"type": "i64", "value": -999}`           |
+| `u128`   | Unsigned 128-bit integer  | `{"type": "u128", "value": 100}`           |
+| `i128`   | Signed 128-bit integer    | `{"type": "i128", "value": -100}`          |
+| `bool`   | Boolean value             | `{"type": "bool", "value": true}`          |
+| `symbol` | Soroban Symbol (≤32 chars)| `{"type": "symbol", "value": "hello"}`     |
+| `string` | Soroban String (any len)  | `{"type": "string", "value": "long text"}` |
+
+```bash
+# Typed arguments for precise control
+soroban-debug run --contract counter.wasm --function add --args '[{"type": "u32", "value": 10}]'
+
+# Mixed typed and bare values
+soroban-debug run --contract token.wasm --function transfer \
+  --args '[{"type": "symbol", "value": "Alice"}, {"type": "symbol", "value": "Bob"}, {"type": "u64", "value": 100}]'
+
+# Soroban String for longer text
+soroban-debug run --contract dao.wasm --function create_proposal \
+  --args '[{"type": "string", "value": "My proposal title"}]'
+```
+
+### Error Handling
+
+The parser provides clear error messages for common issues:
+
+- **Unsupported type**: `Unsupported type: bytes. Supported types: u32, i32, u64, i64, u128, i128, bool, string, symbol`
+- **Out of range**: `Value out of range for type u32: 5000000000 (valid range: 0..=4294967295)`
+- **Type mismatch**: `Type/value mismatch: expected u32 (non-negative integer) but got "hello"`
+- **Invalid JSON**: `JSON parsing error: ...`
+
 ## Interactive Commands Reference
 
 During an interactive debugging session, you can use:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,2 @@
+#[path = "integration/arg_parsing_tests.rs"]
+mod arg_parsing_tests;

--- a/tests/integration/arg_parsing_tests.rs
+++ b/tests/integration/arg_parsing_tests.rs
@@ -1,0 +1,247 @@
+//! Integration tests for argument parsing
+//!
+//! These tests validate the full argument parsing pipeline from JSON string
+//! to Soroban Val values, testing the public API of ArgumentParser.
+
+use soroban_debugger::utils::ArgumentParser;
+use soroban_sdk::Env;
+
+fn create_parser() -> ArgumentParser {
+    ArgumentParser::new(Env::default())
+}
+
+// ── Typed numeric parsing ────────────────────────────────────────────
+
+#[test]
+fn test_parse_u32_typed_argument() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": 10}]"#);
+    assert!(result.is_ok(), "Failed to parse u32: {:?}", result.err());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_i32_typed_argument() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "i32", "value": -5}]"#);
+    assert!(result.is_ok(), "Failed to parse i32: {:?}", result.err());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_u64_typed_argument() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u64", "value": 1000000}]"#);
+    assert!(result.is_ok(), "Failed to parse u64: {:?}", result.err());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_i64_typed_argument() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "i64", "value": -999}]"#);
+    assert!(result.is_ok(), "Failed to parse i64: {:?}", result.err());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+// ── Boolean parsing ──────────────────────────────────────────────────
+
+#[test]
+fn test_parse_bool_true_bare() {
+    let parser = create_parser();
+    let result = parser.parse_args_string("[true]");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_bool_false_bare() {
+    let parser = create_parser();
+    let result = parser.parse_args_string("[false]");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_bool_typed() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "bool", "value": true}]"#);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+// ── String and Symbol parsing ────────────────────────────────────────
+
+#[test]
+fn test_parse_symbol_bare() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"["hello"]"#);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_symbol_typed() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "symbol", "value": "hello"}]"#);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_string_typed() {
+    let parser = create_parser();
+    let result =
+        parser.parse_args_string(r#"[{"type": "string", "value": "a longer string value"}]"#);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+// ── Mixed arguments (simulating real contract calls) ─────────────────
+
+#[test]
+fn test_parse_counter_add_args() {
+    // Simulate: soroban-debug run --contract counter.wasm --function add --args '[10]'
+    let parser = create_parser();
+    let result = parser.parse_args_string("[10]");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_counter_add_typed_args() {
+    // Simulate: counter add with explicit u32 type
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": 10}]"#);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_parse_transfer_args() {
+    // Simulate: token transfer with mixed types
+    let parser = create_parser();
+    let result = parser.parse_args_string(
+        r#"[{"type": "symbol", "value": "Alice"}, {"type": "symbol", "value": "Bob"}, {"type": "u64", "value": 100}]"#,
+    );
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 3);
+}
+
+#[test]
+fn test_parse_mixed_typed_and_bare() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": 42}, "hello", true, 100]"#);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 4);
+}
+
+// ── Error handling ───────────────────────────────────────────────────
+
+#[test]
+fn test_error_unsupported_type() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "bytes", "value": "abc"}]"#);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Unsupported type") || err_msg.contains("bytes"),
+        "Expected unsupported type error, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn test_error_u32_out_of_range() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": 5000000000}]"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_error_i32_out_of_range() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "i32", "value": 3000000000}]"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_error_type_value_mismatch() {
+    let parser = create_parser();
+    // u32 expects a number, not a string
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": "hello"}]"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_error_bool_type_mismatch() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "bool", "value": "yes"}]"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_error_invalid_json() {
+    let parser = create_parser();
+    let result = parser.parse_args_string("not valid json");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_error_empty_args() {
+    let parser = create_parser();
+    let result = parser.parse_args_string("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_error_float_not_supported() {
+    let parser = create_parser();
+    let result = parser.parse_args_string("[3.14]");
+    assert!(result.is_err());
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────
+
+#[test]
+fn test_boundary_u32_max() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": 4294967295}]"#);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_boundary_u32_zero() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "u32", "value": 0}]"#);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_boundary_i32_min() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "i32", "value": -2147483648}]"#);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_boundary_i32_max() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "i32", "value": 2147483647}]"#);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_empty_array_returns_no_args() {
+    let parser = create_parser();
+    let result = parser.parse_args_string("[]");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 0);
+}
+
+#[test]
+fn test_empty_string_typed() {
+    let parser = create_parser();
+    let result = parser.parse_args_string(r#"[{"type": "string", "value": ""}]"#);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
### Description
Implements JSON to Soroban Val conversion for basic types, enabling passing typed arguments to contract functions via the `--args` CLI flag.

### Changes
- Added type annotation support (`{"type": "u32", "value": 10}`)
- Supported types: u32, i32, u64, u128,i128, bool, string, symbol 
- Added Soroban String support for longer text (bare strings default to Symbol)
- Improved error handling with descriptive error messages for unsupported types, out-of-range values, and type/value mismatches
- Full backward compatibility with bare JSON values
- Added 28 integration tests covering all types, errors, and boundary values
- Updated README with supported types documentation and examples

### Testing
All 120 tests pass (77 unit + 5 CLI + 28 integration + 10 property).

### Usage
```bash
# Bare values (backward compatible)
soroban-debug run --contract counter.wasm --function add --args '[10]'

# Typed arguments
soroban-debug run --contract counter.wasm --function add --args '[{"type": "u32", "value": 10}]'

# Mixed types
soroban-debug run --contract token.wasm --function transfer \
  --args '[{"type": "symbol", "value": "Alice"}, {"type": "symbol", "value": "Bob"}, {"type": "u64", "value": 100}]'
```

### Related issue
Closes #11 