### PR TITLE
test: add cargo-fuzz targets

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -69,6 +69,30 @@ cargo test test_name
 cargo test --test integration/basic-tests
 ```
 
+### Fuzzing
+
+Fuzzing helps discover crashes and panics in critical code paths like WASM parsing and argument parsing.
+
+**Prerequisites:**
+Install `cargo-fuzz`:
+```sh
+cargo install cargo-fuzz
+```
+
+**Running a fuzz target:**
+```sh
+# Run WASM loading fuzzer
+cargo +nightly fuzz run wasm_loading
+
+# Run argument parser fuzzer
+cargo +nightly fuzz run arg_parser
+
+# Run storage key parsing fuzzer
+cargo +nightly fuzz run storage_keys
+```
+
+By default, fuzzers run indefinitely. You can limit the execution time with `-- -max_total_time=<seconds>`.
+
 Tests should be:
 - Isolated and repeatable
 - Well-named and descriptive

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "soroban-debugger-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[dependencies.soroban-debugger]
+path = ".."
+
+[[bin]]
+name = "wasm_loading"
+path = "fuzz_targets/wasm_loading.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "arg_parser"
+path = "fuzz_targets/arg_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "storage_keys"
+path = "fuzz_targets/storage_keys.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/arg_parser.rs
+++ b/fuzz/fuzz_targets/arg_parser.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_debugger::utils::arguments::ArgumentParser;
+use soroban_sdk::Env;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(json_str) = std::str::from_utf8(data) {
+        let env = Env::default();
+        let parser = ArgumentParser::new(env);
+        let _ = parser.parse_args_string(json_str);
+    }
+});

--- a/fuzz/fuzz_targets/storage_keys.rs
+++ b/fuzz/fuzz_targets/storage_keys.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_debugger::inspector::storage::{StorageFilter, FilterPattern};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = FilterPattern::parse(s);
+        let _ = StorageFilter::new(&[s.to_string()]);
+    }
+});

--- a/fuzz/fuzz_targets/wasm_loading.rs
+++ b/fuzz/fuzz_targets/wasm_loading.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_debugger::utils::wasm;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = wasm::parse_functions(data);
+    let _ = wasm::get_module_info(data);
+    let _ = wasm::extract_contract_metadata(data);
+});


### PR DESCRIPTION
# Summary

I have added fuzz targets to the `soroban-debugger` to help identify potential crashes and panics in critical code paths.

## Changes Made

### 1. Fuzz Targets
I created three new fuzz targets in the `fuzz/fuzz_targets/` directory:
- **`wasm_loading`**: Fuzzes WASM parsing, module info extraction, and contract metadata extraction.
- **`arg_parser`**: Fuzzes the argument parsing logic with arbitrary JSON-like strings.
- **`storage_keys`**: Fuzzes storage key filter patterns and parsing.

### 2. Configuration
- Updated `fuzz/Cargo.toml` to include necessary dependencies (`libfuzzer-sys`, `soroban-sdk`) and define the new binaries.

### 3. Documentation
- Updated `CONTRIBUTION.md` with a new "Fuzzing" section, explaining prerequisites and how to run each fuzzer.

## Verification

### Fuzz Targets Created
The following files were created:
- `fuzz/fuzz_targets/wasm_loading.rs` (soroban-debugger/fuzz/fuzz_targets/wasm_loading.rs)
- `fuzz/fuzz_targets/arg_parser.rs` (soroban-debugger/fuzz/fuzz_targets/arg_parser.rs)
- `fuzz/fuzz_targets/storage_keys.rs` (soroban-debugger/fuzz/fuzz_targets/storage_keys.rs)

## How to Run
My disk space is low, you can run the fuzzers using:
```ps1
cargo install cargo-fuzz
cargo +nightly fuzz run wasm_loading
```
---
Closes #34 