### PR TITLE
feat: add list-functions shorthand alias for inspect --functions

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -79,6 +79,9 @@ pub enum Commands {
 
     /// Compare two execution trace JSON files side-by-side
     Compare(CompareArgs),
+
+    /// List exported functions of a contract (shorthand for `inspect --functions`)
+    ListFunctions(ListFunctionsArgs),
 }
 
 #[derive(Parser)]
@@ -222,6 +225,15 @@ pub struct InspectArgs {
     /// Show contract metadata
     #[arg(long)]
     pub metadata: bool,
+}
+
+/// Args for the `list-functions` shorthand command.
+/// Delegates to `inspect --functions` under the hood.
+#[derive(Parser)]
+pub struct ListFunctionsArgs {
+    /// Path to the contract WASM file
+    #[arg(short, long)]
+    pub contract: PathBuf,
 }
 
 #[derive(Parser)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,6 @@
 use crate::cli::args::{
-    CompareArgs, InspectArgs, InteractiveArgs, OptimizeArgs, ProfileArgs, RunArgs,
-    UpgradeCheckArgs, Verbosity,
+    CompareArgs, InspectArgs, InteractiveArgs, ListFunctionsArgs, OptimizeArgs, ProfileArgs,
+    RunArgs, UpgradeCheckArgs, Verbosity,
 };
 use crate::debugger::engine::DebuggerEngine;
 use crate::debugger::instruction_pointer::StepMode;
@@ -453,6 +453,19 @@ pub fn inspect(args: InspectArgs, _verbosity: Verbosity) -> Result<()> {
 
     println!("\n{}", "=".repeat(54));
     Ok(())
+}
+
+/// Execute the list-functions command (shorthand for `inspect --functions`).
+///
+/// Constructs an [`InspectArgs`] with `functions: true` and delegates
+/// entirely to [`inspect`], guaranteeing identical output.
+pub fn list_functions(args: ListFunctionsArgs, verbosity: Verbosity) -> Result<()> {
+    let inspect_args = InspectArgs {
+        contract: args.contract,
+        functions: true,
+        metadata: false,
+    };
+    inspect(inspect_args, verbosity)
 }
 
 /// Parse JSON arguments with validation.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,6 @@ pub mod args;
 pub mod commands;
 
 pub use args::{
-    Cli, Commands, CompareArgs, CompletionsArgs, InspectArgs, InteractiveArgs, OptimizeArgs,
-    RunArgs, UpgradeCheckArgs, Verbosity,
+    Cli, Commands, CompareArgs, CompletionsArgs, InspectArgs, InteractiveArgs, ListFunctionsArgs,
+    OptimizeArgs, RunArgs, UpgradeCheckArgs, Verbosity,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,9 @@ fn main() -> Result<()> {
             soroban_debugger::cli::commands::profile(args)?;
             Ok(())
         }
+        Some(Commands::ListFunctions(args)) => {
+            soroban_debugger::cli::commands::list_functions(args, verbosity)
+        }
         None => {
             let mut cmd = Cli::command();
             cmd.print_help()?;


### PR DESCRIPTION
**Title:** `feat: add list-functions shorthand alias for inspect --functions (#94)`

**Body:**
```
## Summary
Adds `list-functions` as a top-level subcommand shorthand for `inspect --functions`, 
making the most common inspect operation faster to type.

## Changes
- `src/cli/args.rs`: Added `ListFunctions(ListFunctionsArgs)` variant to `Commands` enum and `ListFunctionsArgs` struct
- `src/cli/mod.rs`: Exported `ListFunctionsArgs` via `pub use`
- `src/cli/commands.rs`: Added `list_functions()` handler that delegates directly to `inspect()`
- `src/main.rs`: Wired `Commands::ListFunctions` arm into the dispatcher
- `Readme.md`: Documented the shorthand with usage example

## Usage
```bash
# New shorthand
soroban-debug list-functions --contract contract.wasm

# Equivalent to
soroban-debug inspect --contract contract.wasm --functions
```

## Verification
Tested against `budget_heavy_fixture.wasm` — output of both commands is identical.

## Proof

<img width="1136" height="880" alt="Screenshot 2026-02-21 at 00 55 32" src="https://github.com/user-attachments/assets/0ca8649a-41a9-4e1f-b2b8-2c955ab7191f" />

<img width="1136" height="880" alt="Screenshot 2026-02-21 at 00 55 44" src="https://github.com/user-attachments/assets/7f2f2e78-b569-4b99-a682-d0102905d57b" />


Closes #94