### PR TITLE
feat: add Address type argument parsing #14

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -362,7 +362,8 @@ For precise type control, use `{"type": "<type>", "value": <value>}`:
 | `i128`   | Signed 128-bit integer     | `{"type": "i128", "value": -100}`          |
 | `bool`   | Boolean value              | `{"type": "bool", "value": true}`          |
 | `symbol` | Soroban Symbol (≤32 chars) | `{"type": "symbol", "value": "hello"}`     |
-| `string` | Soroban String (any len)   | `{"type": "string", "value": "long text"}` |
+| `string`  | Soroban String (any len)   | `{"type": "string", "value": "long text"}` |
+| `address` | Soroban Address (Contract/Acc) | `{"type": "address", "value": "C..."}`     |
 
 ```bash
 # Typed arguments for precise control
@@ -375,13 +376,21 @@ soroban-debug run --contract token.wasm --function transfer \
 # Soroban String for longer text
 soroban-debug run --contract dao.wasm --function create_proposal \
   --args '[{"type": "string", "value": "My proposal title"}]'
+
+# Address type (contract or account addresses)
+soroban-debug run --contract token.wasm --function balance_of \
+  --args '[{"type": "address", "value": "GD3IYSAL6Z2A3A4A3A4A3A4A3A4A3A4A3A4A3A4A3A4A3A4A3A4A3A4A"}]'
+
+# Bare address (auto-detected if starts with C or G and is 56 chars)
+soroban-debug run --contract token.wasm --function transfer \
+  --args '["CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADUI", "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", 100]'
 ```
 
 ### Error Handling
 
 The parser provides clear error messages for common issues:
 
-- **Unsupported type**: `Unsupported type: bytes. Supported types: u32, i32, u64, i64, u128, i128, bool, string, symbol`
+- **Unsupported type**: `Unsupported type: bytes. Supported types: u32, i32, u64, i64, u128, i128, bool, string, symbol, address`
 - **Out of range**: `Value out of range for type u32: 5000000000 (valid range: 0..=4294967295)`
 - **Type mismatch**: `Type/value mismatch: expected u32 (non-negative integer) but got "hello"`
 - **Invalid JSON**: `JSON parsing error: ...`


### PR DESCRIPTION
closes #14 
- Parses contract addresses (C...)
- Parses account addresses (G...)
- Validates address format
- Error messages for invalid addresses
- Tests and docs included