### PR TITLE
feat: add --no-banner option to suppress startup banner output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ base64 = "0.21.7"
 sha2 = "0.10.9"
 libloading = "0.8"
 dirs = "5.0"
+atty = "0.2"
 
 is-terminal = "0.4"
 

--- a/man/man1/soroban-debug.1
+++ b/man/man1/soroban-debug.1
@@ -4,7 +4,7 @@
 .SH NAME
 soroban\-debug \- A debugger for Soroban smart contracts
 .SH SYNOPSIS
-\fBsoroban\-debug\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-budget\-trend\fR] [\fB\-\-trend\-contract\fR] [\fB\-\-trend\-function\fR] [\fB\-\-version\-verbose\fR] [\fB\-\-list\-functions\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBsoroban\-debug\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-banner\fR] [\fB\-\-budget\-trend\fR] [\fB\-\-trend\-contract\fR] [\fB\-\-trend\-function\fR] [\fB\-\-version\-verbose\fR] [\fB\-\-list\-functions\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 A debugger for Soroban smart contracts
 .SH OPTIONS
@@ -14,6 +14,9 @@ Suppress non\-essential output (errors and return value only)
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Show verbose output including internal details
+.TP
+\fB\-\-no\-banner\fR
+Suppress startup banner output
 .TP
 \fB\-\-budget\-trend\fR
 Show historical budget trend visualization

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -35,6 +35,10 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
+    /// Suppress startup banner output
+    #[arg(long, global = true)]
+    pub no_banner: bool,
+
     /// Show historical budget trend visualization
     #[arg(long)]
     pub budget_trend: bool,


### PR DESCRIPTION
This pull request introduces a new feature that allows users to suppress the startup banner in the `soroban-debug` CLI tool, along with related documentation updates and tests. The main change is the addition of a `--no-banner` flag and corresponding logic to control banner display, including honoring the `NO_BANNER` environment variable and whether output is interactive. Documentation and tests have been updated to reflect and validate this new functionality.

**CLI and Banner Display Enhancements:**

* Added a `--no-banner` global CLI flag to suppress the startup banner output in `src/cli/args.rs` and documented it in the man page. [[1]](diffhunk://#diff-fa7a2e409b60cd321e69d7bbc327e6192a1dc34ab81f702a04bc9dda4a9c15aeR38-R41) [[2]](diffhunk://#diff-54afd2e8793bfa734e7cdf1804047a1407cf8455ade6cd80e6948dcfb2bea081L7-R7) [[3]](diffhunk://#diff-54afd2e8793bfa734e7cdf1804047a1407cf8455ade6cd80e6948dcfb2bea081R18-R20)
* Implemented logic in `src/main.rs` to control banner display based on the `--no-banner` flag, `NO_BANNER` environment variable, and whether output is interactive.
* Added the `atty` crate to `Cargo.toml` to detect interactive output for banner display.

**Documentation Updates:**

* Updated the man page (`man/man1/soroban-debug.1`) to include the new `--no-banner` option in the synopsis and options sections. [[1]](diffhunk://#diff-54afd2e8793bfa734e7cdf1804047a1407cf8455ade6cd80e6948dcfb2bea081L7-R7) [[2]](diffhunk://#diff-54afd2e8793bfa734e7cdf1804047a1407cf8455ade6cd80e6948dcfb2bea081R18-R20)

**Testing Improvements:**

* Added unit tests in `src/main.rs` to verify banner content, suppression logic, and environment variable handling.

Closes #185 