### PR TITLE
feat: add memory allocation tracker

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -295,6 +295,7 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
         };
         let _ = manager.append_record(record);
     }
+    let json_memory_summary = engine.executor().last_memory_summary().cloned();
 
     // Export storage if specified
     if let Some(export_path) = &args.export_storage {
@@ -465,6 +466,11 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
         }
         if let Some(ref ledger) = json_ledger {
             output["ledger_entries"] = ledger.to_json();
+        }
+        if let Some(memory_summary) = json_memory_summary {
+            output["memory_summary"] = serde_json::to_value(memory_summary).map_err(|e| {
+                DebuggerError::FileError(format!("Failed to serialize memory summary: {}", e))
+            })?;
         }
 
         logging::log_display(


### PR DESCRIPTION
## Summary

Adds memory allocation tracking and reporting for contract execution to help developers understand memory footprint and optimize usage.

### What changed

- Hooked memory tracking into contract execution in `ContractExecutor::execute`
- Captures memory growth snapshots at key execution stages
- Tracks:
  - total allocation count
  - total bytes allocated
  - peak memory usage
  - top 5 largest tracked allocations
- Displays a memory allocation summary section after execution
- Includes `memory_summary` in JSON output for `run --json`
- Added unit tests for memory tracking totals/peak/top-allocation ordering

## Acceptance Criteria

- [x] Allocation count tracked correctly
- [x] Peak memory usage displayed
- [x] Top 5 allocations listed
- [x] Memory summary shown in output
- [x] Included in JSON output

## Validation

- `cargo test inspector::budget:: --lib`
- Manual verification with:
  - `soroban-debug run --contract tests/fixtures/wasm/counter.wasm --function increment`
  - `soroban-debug run --contract tests/fixtures/wasm/counter.wasm --function increment --json`

## Notes

- "Top 5 allocations" reports up to 5 tracked allocation events (checkpoint-based memory growth deltas). Small contracts may show fewer than 5 entries.

Closes #203

Issue: https://github.com/Timi16/soroban-debugger/issues/203
