### PR TITLE
feat: add --save-output flag to persist results

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -294,6 +294,14 @@ pub struct RunArgs {
     /// TTL warning threshold in ledger sequence numbers (default: 1000)
     #[arg(long, default_value = "1000")]
     pub ttl_warning_threshold: u32,
+
+    /// Path to file where execution results should be saved
+    #[arg(long, value_name = "FILE")]
+    pub save_output: Option<PathBuf>,
+
+    /// Append to output file instead of overwriting (used with --save-output)
+    #[arg(long)]
+    pub append: bool,
 }
 
 impl RunArgs {


### PR DESCRIPTION
### Summary
This implementation adds:

- --save-output FILE: Write execution results to a file in addition to stdout
- --append: Append to the output file instead of overwriting it
- Automatic detection: Works with both text and JSON output formats
- Confirmation message: Shows the file path where output was written
- Helper struct OutputWriter: Handles simultaneous writing to stdout and file

Usage examples:
```bash
# Save output to file (overwrite if exists)
soroban-debug run --contract contract.wasm --function test --save-output results.txt

# Append to existing file
soroban-debug run --contract contract.wasm --function test --save-output results.txt --append

# Save JSON output to file
soroban-debug run --contract contract.wasm --function test --output json --save-output results.json
```

Closes #189 