### PR TITLE
fix: replace unwrap() calls with proper error handling

### DIFF
--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -248,7 +248,13 @@ impl PluginRegistry {
 
 impl Default for PluginRegistry {
     fn default() -> Self {
-        Self::new().expect("Failed to create default plugin registry")
+        // Use a fallback temporary directory if default creation fails
+        Self::new().unwrap_or_else(|e| {
+            warn!("Failed to create default plugin registry: {}. Using temporary directory.", e);
+            let temp_dir = std::env::temp_dir().join("soroban-debugger-plugins");
+            Self::with_plugin_dir(temp_dir)
+                .expect("Failed to create plugin registry even with temp directory")
+        })
     }
 }
 

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -82,9 +82,9 @@ impl ContractExecutor {
         let _guard = ProgressGuard(pb);
 
         let env = Env::default();
-        env.host()
-            .set_diagnostic_level(DiagnosticLevel::Debug)
-            .expect("Failed to set diagnostic level");
+        if let Err(e) = env.host().set_diagnostic_level(DiagnosticLevel::Debug) {
+            return Err(miette::miette!("Failed to set diagnostic level: {}", e));
+        }
 
         // Simulate progress during WASM registration
         _guard.0.set_position(50);

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -140,8 +140,10 @@ impl DebugServer {
                     DebugResponse::Ok
                 }
                 DebugRequest::GetState => {
-                    let state = self.engine.state().lock().unwrap().clone();
-                    DebugResponse::State(state)
+                    match self.engine.state().lock() {
+                        Ok(state) => DebugResponse::State(state.clone()),
+                        Err(e) => DebugResponse::Error(format!("Failed to acquire state lock: {}", e)),
+                    }
                 }
                 DebugRequest::Execute { function, args } => {
                     match self.engine.execute(&function, args.as_deref()) {

--- a/src/simulator/snapshot.rs
+++ b/src/simulator/snapshot.rs
@@ -144,8 +144,12 @@ impl SnapshotDiff {
         }
 
         for addr in before_addresses.intersection(&after_addresses) {
-            let before_acc = before.get_account(addr).unwrap();
-            let after_acc = after.get_account(addr).unwrap();
+            let Some(before_acc) = before.get_account(addr) else {
+                continue; // Skip if account not found (shouldn't happen)
+            };
+            let Some(after_acc) = after.get_account(addr) else {
+                continue; // Skip if account not found (shouldn't happen)
+            };
 
             let account_diff = AccountDiff {
                 address: addr.clone(),
@@ -187,8 +191,12 @@ impl SnapshotDiff {
         }
 
         for id in before_contracts.intersection(&after_contracts) {
-            let before_contract = before.get_contract(id).unwrap();
-            let after_contract = after.get_contract(id).unwrap();
+            let Some(before_contract) = before.get_contract(id) else {
+                continue; // Skip if contract not found (shouldn't happen)
+            };
+            let Some(after_contract) = after.get_contract(id) else {
+                continue; // Skip if contract not found (shouldn't happen)
+            };
 
             let storage_changed = before_contract.storage != after_contract.storage;
 


### PR DESCRIPTION
Closes #291

---

Closes #287

---

- Replaced unwrap() on Mutex lock in debug_server.rs with proper error handling
- Replaced expect() in executor.rs with Result propagation using ?
- Improved Default impl for PluginRegistry with fallback error handling
- Replaced unwrap() calls in snapshot.rs with defensive Option handling
- All changes maintain backward compatibility and improve error resilience
- Test code unwrap()/expect() calls intentionally left unchanged