### PR TITLE
Fix #341: Replace placeholder storage-filter output with real filtere…

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -544,9 +544,8 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
             .map_err(|e| DebuggerError::StorageError(format!("Invalid storage filter: {}", e)))?;
 
         print_info("\n--- Storage ---");
-        let inspector = crate::inspector::StorageInspector::new();
+        let inspector = crate::inspector::storage::StorageInspector::with_state(storage_after.clone());
         inspector.display_filtered(&storage_filter);
-        print_info("(Storage view is currently placeholder data)");
     }
 
     let mut json_auth = None;

--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -149,6 +149,7 @@ impl RemoteClient {
                 step_count,
                 paused,
                 call_stack,
+                ..
             } => Ok((function, step_count, paused, call_stack)),
             DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
             _ => Err(

--- a/src/inspector/storage.rs
+++ b/src/inspector/storage.rs
@@ -153,6 +153,15 @@ impl StorageInspector {
         }
     }
 
+    /// Create a StorageInspector from an existing storage snapshot
+    pub fn with_state(storage: HashMap<String, String>) -> Self {
+        Self {
+            storage,
+            reads: HashMap::new(),
+            writes: HashMap::new(),
+        }
+    }
+
     /// Get all storage entries
     pub fn get_all(&self) -> &HashMap<String, String> {
         &self.storage


### PR DESCRIPTION
### Resolves
Fixes #341 

### Description
When running a contract execution with storage filtering enabled (`--storage-filter`), the debug CLI previously printed a generic [(Storage view is currently placeholder data)](cci:1://file:///Users/macbookpro/soroban-debugger/src/cli/commands.rs:262:0-704:1) message and instantiated a blank inspector. 

This PR properly wires up the post-execution storage snapshot so that actual contract keys and values are displayed. 

### Changes Made
- **Created [with_state](cci:1://file:///Users/macbookpro/soroban-debugger/src/inspector/storage.rs:155:4-162:5) Constructor**: Added a new initialization method in [src/inspector/storage.rs](cci:7://file:///Users/macbookpro/soroban-debugger/src/inspector/storage.rs:0:0-0:0) to allow [StorageInspector](cci:2://file:///Users/macbookpro/soroban-debugger/src/inspector/storage.rs:137:0-144:1) to be instantiated with an existing, populated storage snapshot (`HashMap<String, String>`).
- **Wired up Real Storage**: In [src/cli/commands.rs](cci:7://file:///Users/macbookpro/soroban-debugger/src/cli/commands.rs:0:0-0:0), removed the empty temporary inspector and the placeholder print statement. The engine's captured `storage_after` footprint is now correctly passed to the [StorageInspector](cci:2://file:///Users/macbookpro/soroban-debugger/src/inspector/storage.rs:137:0-144:1), presenting real filtered storage data to the user.
- **Compiler Fix**: Fixed a lingering `E0027` rustc compiler error in [src/client/remote_client.rs](cci:7://file:///Users/macbookpro/soroban-debugger/src/client/remote_client.rs:0:0-0:0) by correctly ignoring unused missing fields (`..`) in the `DebugResponse::InspectionResult` pattern match.

### What Was Tested
- **Compilation**: Cleanly passes without any compile errors.
- **Unit & Integration tests**: Ran `cargo test -p soroban-debugger storage_filter` successfully. The code remains fully compatible with existing CLI testing frameworks (e.g., [tests/cli/output_tests.rs](cci:7://file:///Users/macbookpro/soroban-debugger/tests/cli/output_tests.rs:0:0-0:0)) covering the `--storage-filter` flags.

### Validation Results
- The "placeholder data" printout has been successfully stripped from the happy path.
- The storage view now correctly renders filtered keys and values from the active contract execution environment.