### PR TITLE
feat: implement plugin system for custom inspector modules

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -162,6 +162,10 @@ pub enum Commands {
 
     /// Run a multi-step scenario from a TOML file
     Scenario(ScenarioArgs),
+
+    /// Plugin-provided subcommand (loaded at runtime)
+    #[command(external_subcommand)]
+    External(Vec<String>),
 }
 
 #[derive(Parser)]

--- a/src/debugger/engine.rs
+++ b/src/debugger/engine.rs
@@ -2,6 +2,7 @@ use crate::debugger::breakpoint::BreakpointManager;
 use crate::debugger::instruction_pointer::StepMode;
 use crate::debugger::state::DebugState;
 use crate::debugger::stepper::Stepper;
+use crate::plugin::{EventContext, ExecutionEvent};
 use crate::runtime::executor::ContractExecutor;
 use crate::runtime::instruction::Instruction;
 use crate::runtime::instrumentation::Instrumenter;
@@ -104,6 +105,21 @@ impl DebuggerEngine {
             state.call_stack_mut().push(function.to_string(), None);
         }
 
+        let mut plugin_ctx = EventContext::new();
+        plugin_ctx.stack_depth = self
+            .state
+            .lock()
+            .map(|s| s.call_stack().get_stack().len())
+            .unwrap_or(0);
+        plugin_ctx.is_paused = self.paused;
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::BeforeFunctionCall {
+                function: function.to_string(),
+                args: args.map(str::to_string),
+            },
+            &mut plugin_ctx,
+        );
+
         if check_breakpoints && self.breakpoints.should_break(function) {
             self.pause_at_function(function);
         }
@@ -113,6 +129,19 @@ impl DebuggerEngine {
         let duration = start_time.elapsed();
 
         self.update_call_stack(duration)?;
+
+        let event_result = match &result {
+            Ok(output) => Ok(output.clone()),
+            Err(e) => Err(e.to_string()),
+        };
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::AfterFunctionCall {
+                function: function.to_string(),
+                result: event_result,
+                duration,
+            },
+            &mut plugin_ctx,
+        );
 
         if let Err(ref e) = result {
             tracing::error!("Execution failed: {}", e);
@@ -137,6 +166,23 @@ impl DebuggerEngine {
 
         crate::logging::log_breakpoint(function);
         self.paused = true;
+
+        let mut plugin_ctx = EventContext::new();
+        plugin_ctx.stack_depth = 1;
+        plugin_ctx.is_paused = true;
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::BreakpointHit {
+                function: function.to_string(),
+                condition: None,
+            },
+            &mut plugin_ctx,
+        );
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::ExecutionPaused {
+                reason: "breakpoint".to_string(),
+            },
+            &mut plugin_ctx,
+        );
     }
 
     /// Stage an execution so the debugger starts in a paused state without
@@ -283,6 +329,13 @@ impl DebuggerEngine {
         if let Ok(mut state) = self.state.lock() {
             self.stepper.continue_execution(&mut state);
         }
+
+        let mut plugin_ctx = EventContext::new();
+        plugin_ctx.is_paused = false;
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::ExecutionResumed,
+            &mut plugin_ctx,
+        );
         Ok(())
     }
 
@@ -294,6 +347,22 @@ impl DebuggerEngine {
             state.set_current_function(function.to_string(), None);
             state.call_stack().display();
         }
+
+        let mut plugin_ctx = EventContext::new();
+        plugin_ctx.is_paused = true;
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::BreakpointHit {
+                function: function.to_string(),
+                condition: None,
+            },
+            &mut plugin_ctx,
+        );
+        crate::plugin::registry::dispatch_global_event(
+            &ExecutionEvent::ExecutionPaused {
+                reason: "breakpoint".to_string(),
+            },
+            &mut plugin_ctx,
+        );
     }
 
     pub fn is_paused(&self) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,9 @@ fn main() -> miette::Result<()> {
     Formatter::set_verbosity(verbosity_to_level(verbosity));
     initialize_tracing(verbosity);
 
+    // Load community plugins at startup unless disabled via env var.
+    let _ = soroban_debugger::plugin::registry::init_global_plugin_registry();
+
     let config = soroban_debugger::config::Config::load_or_default();
 
     let result = match cli.command {
@@ -195,6 +198,53 @@ fn main() -> miette::Result<()> {
             tokio::runtime::Runtime::new()
                 .map_err(|e: std::io::Error| miette::miette!(e))
                 .and_then(|rt| rt.block_on(soroban_debugger::cli::commands::repl(args)))
+        }
+        Some(Commands::External(argv)) => {
+            if argv.is_empty() {
+                return Err(miette::miette!("Missing plugin subcommand"));
+            }
+
+            let command = &argv[0];
+            let args = argv[1..].to_vec();
+
+            match soroban_debugger::plugin::registry::execute_global_command(command, &args) {
+                Ok(Some(output)) => {
+                    println!("{}", output);
+                    Ok(())
+                }
+                Ok(None) => {
+                    // If no plugin registered a command, try treating this as a formatter invocation.
+                    if let Ok(Some(formatted)) =
+                        soroban_debugger::plugin::registry::format_global_output(
+                            command,
+                            &args.join(" "),
+                        )
+                    {
+                        println!("{}", formatted);
+                        return Ok(());
+                    }
+
+                    let available = soroban_debugger::plugin::registry::global_commands();
+                    let formatters = soroban_debugger::plugin::registry::global_formatters();
+                    let mut message = format!("Unknown command: '{command}'");
+                    if !available.is_empty() {
+                        message.push_str("\n\nAvailable plugin commands:\n");
+                        for cmd in available {
+                            message.push_str(&format!("  - {}: {}\n", cmd.name, cmd.description));
+                        }
+                    }
+                    if !formatters.is_empty() {
+                        message.push_str("\nAvailable plugin formatters:\n");
+                        for fmt in formatters {
+                            message.push_str(&format!("  - {}\n", fmt.name));
+                        }
+                    }
+                    Err(soroban_debugger::DebuggerError::ExecutionError(message).into())
+                }
+                Err(e) => {
+                    Err(soroban_debugger::DebuggerError::ExecutionError(e.to_string()).into())
+                }
+            }
         }
         None => {
             if let Some(path) = cli.list_functions {

--- a/src/plugin/README.md
+++ b/src/plugin/README.md
@@ -131,6 +131,23 @@ The plugin system uses dynamic library loading (`libloading` crate) to load plug
 
 The `PluginRegistry` manages all loaded plugins and dispatches events to them.
 
+## Plugin Commands and Formatters
+
+Plugins can provide custom CLI commands via [`InspectorPlugin::commands`]. These are routed at runtime
+using clap's external subcommand support, so a plugin command named `my-command` can be invoked as:
+
+```bash
+soroban-debug my-command arg1 arg2
+```
+
+Plugins can also provide output formatters via [`InspectorPlugin::formatters`]. If no plugin command matches
+an external subcommand, the debugger will attempt to treat it as a formatter name and pass the remaining
+arguments as the input payload:
+
+```bash
+soroban-debug my-formatter '{\"some\":\"json\"}'
+```
+
 ## Security Considerations
 
 ⚠️ **Warning**: Plugins run in the same process as the debugger with full access to your system. Only install plugins from trusted sources.

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -81,7 +81,12 @@ impl PluginLoader {
             .parent()
             .ok_or_else(|| PluginError::Invalid("Invalid manifest path".to_string()))?;
 
-        let library_path = manifest_dir.join(&manifest.library);
+        let mut library_path = manifest_dir.join(&manifest.library);
+        if !library_path.exists() {
+            if let Some(fallback) = resolve_platform_library_path(manifest_dir, &manifest.library) {
+                library_path = fallback;
+            }
+        }
 
         if !library_path.exists() {
             return Err(PluginError::NotFound(format!(
@@ -191,6 +196,39 @@ impl PluginLoader {
             .map(|manifest_path| self.load_from_manifest(manifest_path))
             .collect()
     }
+}
+
+fn resolve_platform_library_path(manifest_dir: &Path, library: &str) -> Option<PathBuf> {
+    let wanted_ext = match std::env::consts::OS {
+        "windows" => "dll",
+        "macos" => "dylib",
+        _ => "so",
+    };
+
+    let base = Path::new(library);
+    let stem = base.file_stem()?.to_string_lossy();
+    let file_name = base.file_name()?.to_string_lossy();
+
+    let mut candidates = Vec::new();
+
+    // 1) Same stem, correct extension.
+    candidates.push(format!("{stem}.{wanted_ext}"));
+
+    // 2) Try toggling the `lib` prefix for cross-platform portability.
+    if wanted_ext == "dll" && file_name.starts_with("lib") {
+        candidates.push(format!("{}.dll", stem.trim_start_matches("lib")));
+    } else if wanted_ext != "dll" && !file_name.starts_with("lib") {
+        candidates.push(format!("lib{stem}.{wanted_ext}"));
+    }
+
+    for candidate in candidates {
+        let p = manifest_dir.join(candidate);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    None
 }
 
 impl Drop for LoadedPlugin {

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -1,10 +1,90 @@
-use super::api::{PluginError, PluginResult};
+use super::api::{OutputFormatter, PluginCommand, PluginError, PluginResult};
 use super::events::{EventContext, ExecutionEvent};
 use super::loader::{LoadedPlugin, PluginLoader};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::sync::{Arc, RwLock};
 use tracing::{debug, error, info, warn};
+
+static GLOBAL_PLUGIN_REGISTRY: OnceLock<Arc<RwLock<PluginRegistry>>> = OnceLock::new();
+
+fn env_var_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .is_some_and(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
+/// Initialize the global plugin registry and load plugins from disk.
+///
+/// This is intended to be called once at startup.
+pub fn init_global_plugin_registry() -> Arc<RwLock<PluginRegistry>> {
+    GLOBAL_PLUGIN_REGISTRY
+        .get_or_init(|| {
+            let mut registry = PluginRegistry::new().unwrap_or_default();
+            if env_var_truthy("SOROBAN_DEBUG_NO_PLUGINS") {
+                info!("Plugins disabled via SOROBAN_DEBUG_NO_PLUGINS");
+            } else {
+                let _ = registry.load_all_plugins();
+            }
+            Arc::new(RwLock::new(registry))
+        })
+        .clone()
+}
+
+pub fn dispatch_global_event(event: &ExecutionEvent, context: &mut EventContext) {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return;
+    };
+
+    if let Ok(registry) = registry.read() {
+        registry.dispatch_event(event, context);
+    }
+}
+
+pub fn execute_global_command(command: &str, args: &[String]) -> PluginResult<Option<String>> {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return Ok(None);
+    };
+
+    let registry = registry
+        .read()
+        .map_err(|_| PluginError::ExecutionFailed("Failed to acquire registry lock".to_string()))?;
+    registry.execute_command(command, args)
+}
+
+pub fn global_commands() -> Vec<PluginCommand> {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return Vec::new();
+    };
+
+    registry
+        .read()
+        .map(|r| r.all_commands())
+        .unwrap_or_default()
+}
+
+pub fn global_formatters() -> Vec<OutputFormatter> {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return Vec::new();
+    };
+
+    registry
+        .read()
+        .map(|r| r.all_formatters())
+        .unwrap_or_default()
+}
+
+pub fn format_global_output(formatter: &str, data: &str) -> PluginResult<Option<String>> {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return Ok(None);
+    };
+
+    let registry = registry
+        .read()
+        .map_err(|_| PluginError::ExecutionFailed("Failed to acquire registry lock".to_string()))?;
+    registry.format_output(formatter, data)
+}
 
 /// Registry that manages all loaded plugins
 pub struct PluginRegistry {
@@ -243,6 +323,89 @@ impl PluginRegistry {
 
         stats.total = self.plugins.len();
         stats
+    }
+
+    pub fn all_commands(&self) -> Vec<PluginCommand> {
+        let mut out = Vec::new();
+        for plugin_arc in self.plugins.values() {
+            if let Ok(plugin) = plugin_arc.read() {
+                let caps = &plugin.manifest().capabilities;
+                if !caps.provides_commands {
+                    continue;
+                }
+                out.extend(plugin.plugin().commands());
+            }
+        }
+        out
+    }
+
+    pub fn all_formatters(&self) -> Vec<OutputFormatter> {
+        let mut out = Vec::new();
+        for plugin_arc in self.plugins.values() {
+            if let Ok(plugin) = plugin_arc.read() {
+                let caps = &plugin.manifest().capabilities;
+                if !caps.provides_formatters {
+                    continue;
+                }
+                out.extend(plugin.plugin().formatters());
+            }
+        }
+        out
+    }
+
+    /// Execute a plugin-provided command, if any plugin declares it.
+    pub fn execute_command(&self, command: &str, args: &[String]) -> PluginResult<Option<String>> {
+        for (name, plugin_arc) in &self.plugins {
+            let mut plugin = plugin_arc.write().map_err(|_| {
+                PluginError::ExecutionFailed(format!("Failed to acquire plugin lock: {}", name))
+            })?;
+
+            if !plugin.manifest().capabilities.provides_commands {
+                continue;
+            }
+
+            if !plugin
+                .plugin()
+                .commands()
+                .iter()
+                .any(|cmd| cmd.name == command)
+            {
+                continue;
+            }
+
+            return plugin.plugin_mut().execute_command(command, args).map(Some);
+        }
+
+        Ok(None)
+    }
+
+    pub fn format_output(&self, formatter: &str, data: &str) -> PluginResult<Option<String>> {
+        for (name, plugin_arc) in &self.plugins {
+            let plugin = plugin_arc.read().map_err(|_| {
+                PluginError::ExecutionFailed(format!("Failed to acquire plugin lock: {}", name))
+            })?;
+
+            if !plugin.manifest().capabilities.provides_formatters {
+                continue;
+            }
+
+            if !plugin
+                .plugin()
+                .formatters()
+                .iter()
+                .any(|fmt| fmt.name == formatter)
+            {
+                continue;
+            }
+
+            drop(plugin);
+            let mut plugin = plugin_arc.write().map_err(|_| {
+                PluginError::ExecutionFailed(format!("Failed to acquire plugin lock: {}", name))
+            })?;
+            return plugin.plugin().format_output(formatter, data).map(Some);
+        }
+
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
Closes issue #218 

Implements a complete plugin architecture allowing community members to write custom inspector plugins as shared libraries (.so/.dylib/.dll) and load them into the debugger at runtime. This transforms the existing plugin scaffold into a fully functional extension system that supports execution hooks, custom CLI subcommands, and output formatters.
Key Changes:
src/plugin/api.rs (Existing foundation)
InspectorPlugin trait serves as the stable plugin API
Supports event hooks, custom commands, and output formatters
src/plugin/registry.rs
Implemented global plugin registry with OnceLock singleton pattern
Added init_global_plugin_registry() for startup initialization
Event dispatch system: dispatch_global_event() broadcasts execution lifecycle events to all loaded plugins
Command routing: execute_global_command() and global_commands() for CLI integration
Formatter resolution: format_global_output() and global_formatters() for output processing
Auto-loads from ~/.soroban-debug/plugins/ unless SOROBAN_DEBUG_NO_PLUGINS=1 is set
src/plugin/loader.rs
Enhanced platform-specific library resolution (handles lib prefix toggling for cross-platform portability: .so/.dylib/.dll)
Added fallback logic to resolve library paths when manifest names don't match platform conventions
src/main.rs
Integrated plugin initialization at startup
Implemented external subcommand routing using clap's External command variant
Added fallback mechanism: unknown commands are first tried as plugin commands, then as formatters
Provides helpful error messages listing available plugin commands and formatters when routing fails
src/cli/args.rs
Added External(Vec<String>) variant to Commands enum with #[command(external_subcommand)]
Enables dynamic routing of unknown subcommands to plugins
src/debugger/engine.rs
Integrated plugin event dispatching into execution lifecycle:
BeforeFunctionCall: Dispatched before contract execution begins
AfterFunctionCall: Dispatched after execution completes (with results and duration)
BreakpointHit & ExecutionPaused: Dispatched when execution pauses at breakpoints
ExecutionResumed: Dispatched when execution continues
src/plugin/README.md
Updated documentation covering plugin capabilities, execution events, and architecture
Documented command and formatter usage patterns
Features:
Dynamic Loading: Plugins auto-load from ~/.soroban-debug/plugins/ at startup via libloading
Execution Hooks: Plugins receive events for function calls, breakpoints, and state changes
CLI Extensions: Plugins can register custom subcommands accessible as soroban-debug <plugin-cmd> [args]
Output Formatters: Plugins can provide custom formatters for structured output (JSON, custom reports, etc.)
Cross-Platform: Handles library naming conventions across Linux, macOS, and Windows
Manifest-Driven: Each plugin includes a plugin.toml with metadata (name, version, author, capabilities)
Graceful Degradation: Plugins can be disabled via SOROBAN_DEBUG_NO_PLUGINS=1 environment variable