### PR TITLE
Fix #340: Make REPL storage seeding real

### DIFF
--- a/man/man1/soroban-debug-interactive.1
+++ b/man/man1/soroban-debug-interactive.1
@@ -4,7 +4,7 @@
 .SH NAME
 interactive \- Start an interactive debugging session
 .SH SYNOPSIS
-\fBinteractive\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-\-network\-snapshot\fR] [\fB\-\-expected\-hash\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBinteractive\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-\-network\-snapshot\fR] <\fB\-f\fR|\fB\-\-function\fR> [\fB\-a\fR|\fB\-\-args\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-import\-storage\fR] [\fB\-b\fR|\fB\-\-breakpoint\fR] [\fB\-\-mock\fR] [\fB\-\-timeout\fR] [\fB\-\-instruction\-debug\fR] [\fB\-\-step\-instructions\fR] [\fB\-\-step\-mode\fR] [\fB\-\-expected\-hash\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Start an interactive debugging session
 .SH OPTIONS
@@ -14,6 +14,36 @@ Path to the contract WASM file
 .TP
 \fB\-\-network\-snapshot\fR \fI<NETWORK_SNAPSHOT>\fR
 Network snapshot file to load before starting interactive session
+.TP
+\fB\-f\fR, \fB\-\-function\fR \fI<FUNCTION>\fR
+Function name to execute (staged; use \*(Aqcontinue\*(Aq inside the session)
+.TP
+\fB\-a\fR, \fB\-\-args\fR \fI<ARGS>\fR
+Function arguments as JSON array (e.g., \*(Aq["arg1", "arg2"]\*(Aq)
+.TP
+\fB\-s\fR, \fB\-\-storage\fR \fI<STORAGE>\fR
+Initial storage state as JSON object
+.TP
+\fB\-\-import\-storage\fR \fI<IMPORT_STORAGE>\fR
+Import storage state from JSON file before starting the session
+.TP
+\fB\-b\fR, \fB\-\-breakpoint\fR \fI<BREAKPOINT>\fR
+Set breakpoint at function name
+.TP
+\fB\-\-mock\fR \fI<CONTRACT_ID.function=return_value>\fR
+Mock cross\-contract return: CONTRACT_ID.function=return_value (repeatable)
+.TP
+\fB\-\-timeout\fR \fI<TIMEOUT>\fR [default: 30]
+Execution timeout in seconds (default: 30)
+.TP
+\fB\-\-instruction\-debug\fR
+Enable instruction\-level debugging
+.TP
+\fB\-\-step\-instructions\fR
+Start with instruction stepping enabled
+.TP
+\fB\-\-step\-mode\fR \fI<STEP_MODE>\fR [default: into]
+Step mode for instruction debugging (into, over, out, block)
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match

--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -149,6 +149,7 @@ impl RemoteClient {
                 step_count,
                 paused,
                 call_stack,
+                ..
             } => Ok((function, step_count, paused, call_stack)),
             DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
             _ => Err(

--- a/src/repl/executor.rs
+++ b/src/repl/executor.rs
@@ -36,8 +36,6 @@ impl ReplExecutor {
         executor.enable_mock_all_auths();
 
         if let Some(storage_json) = &config.storage {
-            // Best-effort for parity with the rest of the CLI. The underlying
-            // executor currently treats this as a no-op placeholder.
             executor.set_initial_storage(storage_json.clone())?;
         }
 

--- a/tests/command_feature_tests.rs
+++ b/tests/command_feature_tests.rs
@@ -283,3 +283,32 @@ fn repl_accepts_commands_and_exits() {
 
     assert!(combined.contains("soroban-debug repl ["));
 }
+
+#[test]
+fn repl_seeds_initial_storage() {
+    let wasm = fixture_wasm("counter");
+    let output = Command::new(env!("CARGO_BIN_EXE_soroban-debug"))
+        .env("NO_COLOR", "1")
+        .args([
+            "repl",
+            "--contract",
+            wasm.to_str().unwrap(),
+            "--storage",
+            r#"{"c": 42}"#,
+        ])
+        .write_stdin("call get\nexit\n")
+        .output()
+        .unwrap();
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        combined.contains("Result: I64(42)"),
+        "Storage was not seeded correctly in REPL\n{}",
+        combined
+    );
+}


### PR DESCRIPTION
## Description

Fixes #340

The runtime executor natively supports initial storage seeding, and the REPL correctly passes the \`--storage\` JSON payload down to it. However, the \`src/repl/executor.rs\` had an outdated comment marking it as a "best-effort no-op placeholder". 

This PR removes the incorrect documentation and adds a smoke test (\`repl_seeds_initial_storage\`) to properly safeguard and prove that REPL successfully initializes with the exact seeded context state.

## Changes Made
- **Removed Outdated Documentation**: Stripped the incorrect comment from \`src/repl/executor.rs\` regarding storage being a no-op placeholder.
- **Created a Smoke Test**: Added \`repl_seeds_initial_storage\` into \`tests/command_feature_tests.rs\`. This explicitly launches the debug CLI via the REPL passing \`--storage '{"c": 42}'\`, triggering a \`call get\`, and confirming that \`Result: I64(42)\` is successfully rendered.
- **Formatting Updates**: Ran \`cargo fmt\`.
- **Compiler Fix**: Addressed a lingering \`E0027\` missing \`args\` field error within \`remote_client.rs\`.

## What Was Tested
- **Compilation**: Verified using \`cargo test\` across all targets without any compile warnings or errors.
- **Integration tests**: The newly written \`repl_seeds_initial_storage\` and overarching \`command_feature_tests\` suite pass with exit code 0.