### PR TITLE
refactor: migrate error types to thiserror

### DIFF
--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -118,6 +118,7 @@ impl RemoteClient {
                 paused,
                 current_function,
                 step_count,
+                ..
             } => Ok((paused, current_function, step_count)),
             DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
             _ => {
@@ -135,6 +136,7 @@ impl RemoteClient {
                 paused,
                 current_function,
                 step_count,
+                ..
             } => Ok((paused, current_function, step_count)),
             DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
             _ => {
@@ -152,6 +154,7 @@ impl RemoteClient {
                 paused,
                 current_function,
                 step_count,
+                ..
             } => Ok((paused, current_function, step_count)),
             DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
             _ => {

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -6,49 +6,32 @@ use std::any::Any;
 pub type PluginResult<T> = Result<T, PluginError>;
 
 /// Errors that can occur during plugin operations
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum PluginError {
     /// Plugin initialization failed
+    #[error("Plugin initialization failed: {0}")]
     InitializationFailed(String),
 
     /// Plugin execution failed
+    #[error("Plugin execution failed: {0}")]
     ExecutionFailed(String),
 
     /// Plugin not found
+    #[error("Plugin not found: {0}")]
     NotFound(String),
 
     /// Invalid plugin
+    #[error("Invalid plugin: {0}")]
     Invalid(String),
 
     /// Version mismatch
+    #[error("Version mismatch: required {required}, found {found}")]
     VersionMismatch { required: String, found: String },
 
     /// Dependency error
+    #[error("Dependency error: {0}")]
     DependencyError(String),
 }
-
-impl std::fmt::Display for PluginError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PluginError::InitializationFailed(msg) => {
-                write!(f, "Plugin initialization failed: {}", msg)
-            }
-            PluginError::ExecutionFailed(msg) => write!(f, "Plugin execution failed: {}", msg),
-            PluginError::NotFound(msg) => write!(f, "Plugin not found: {}", msg),
-            PluginError::Invalid(msg) => write!(f, "Invalid plugin: {}", msg),
-            PluginError::VersionMismatch { required, found } => {
-                write!(
-                    f,
-                    "Version mismatch: required {}, found {}",
-                    required, found
-                )
-            }
-            PluginError::DependencyError(msg) => write!(f, "Dependency error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for PluginError {}
 
 /// Custom CLI command that a plugin can provide
 #[derive(Debug, Clone)]

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -184,6 +184,7 @@ impl DebugServer {
                             error: None,
                             paused: true,
                             completed: false,
+                            source_location: None,
                         }
                     }
                     Some(engine) => {
@@ -196,6 +197,7 @@ impl DebugServer {
                                     error: None,
                                     paused: engine.is_paused(),
                                     completed: true,
+                                    source_location: None,
                                 }
                             }
                             Err(e) => {
@@ -206,6 +208,7 @@ impl DebugServer {
                                     error: Some(e.to_string()),
                                     paused: false,
                                     completed: true,
+                                    source_location: None,
                                 }
                             }
                         }
@@ -231,6 +234,7 @@ impl DebugServer {
                                 paused: engine.is_paused(),
                                 current_function,
                                 step_count,
+                                source_location: None,
                             }
                         }
                         Err(e) => DebugResponse::Error {
@@ -258,6 +262,7 @@ impl DebugServer {
                                 paused: engine.is_paused(),
                                 current_function,
                                 step_count,
+                                source_location: None,
                             }
                         }
                         Err(e) => DebugResponse::Error {
@@ -285,6 +290,7 @@ impl DebugServer {
                                 paused: engine.is_paused(),
                                 current_function,
                                 step_count,
+                                source_location: None,
                             }
                         }
                         Err(e) => DebugResponse::Error {
@@ -307,12 +313,14 @@ impl DebugServer {
                                     output: Some(output),
                                     error: None,
                                     paused: false,
+                                    source_location: None,
                                 },
                                 Err(e) => DebugResponse::ContinueResult {
                                     completed: false,
                                     output: None,
                                     error: Some(e.to_string()),
                                     paused: false,
+                                    source_location: None,
                                 },
                             }
                         } else {
@@ -322,12 +330,14 @@ impl DebugServer {
                                     output: None,
                                     error: None,
                                     paused: engine.is_paused(),
+                                    source_location: None,
                                 },
                                 Err(e) => DebugResponse::ContinueResult {
                                     completed: false,
                                     output: None,
                                     error: Some(e.to_string()),
                                     paused: engine.is_paused(),
+                                    source_location: None,
                                 },
                             }
                         }
@@ -358,6 +368,7 @@ impl DebugServer {
                                 step_count: state.step_count() as u64,
                                 paused: engine.is_paused(),
                                 call_stack,
+                                source_location: None,
                             }
                         }
                         Err(e) => DebugResponse::Error {

--- a/src/utils/arguments.rs
+++ b/src/utils/arguments.rs
@@ -49,7 +49,7 @@ pub enum ArgumentParseError {
     ConversionError(String),
 
     #[error("JSON parsing error: {0}")]
-    JsonError(String),
+    JsonError(#[from] serde_json::Error),
 
     #[error("Empty arguments")]
     EmptyArguments,
@@ -66,11 +66,6 @@ pub enum ArgumentParseError {
     },
 }
 
-impl From<serde_json::Error> for ArgumentParseError {
-    fn from(err: serde_json::Error) -> Self {
-        ArgumentParseError::JsonError(err.to_string())
-    }
-}
 
 /// Argument parser for converting JSON to Soroban values
 pub struct ArgumentParser {


### PR DESCRIPTION
Migrate PluginError in src/plugin/api.rs from manual Display and std::error::Error impls to #[derive(thiserror::Error)] with #[error("...")] attributes on each variant. Error messages are unchanged.

Replace the manual From<serde_json::Error> impl in ArgumentParseError with #[from] on the JsonError variant, aligning it with the pattern already used by SimulatorError.

Also fix pre-existing compile errors in the debug server and remote client where DebugResponse struct variants were missing the source_location field introduced in the source-location-protocol PR.

Closes #290