### PR TITLE
dwarf

### DIFF
--- a/src/debugger/engine.rs
+++ b/src/debugger/engine.rs
@@ -1,5 +1,6 @@
 use crate::debugger::breakpoint::BreakpointManager;
 use crate::debugger::instruction_pointer::StepMode;
+use crate::debugger::source_map::{SourceLocation, SourceMap};
 use crate::debugger::state::DebugState;
 use crate::debugger::stepper::Stepper;
 use crate::plugin::{EventContext, ExecutionEvent};
@@ -17,6 +18,7 @@ pub struct DebuggerEngine {
     state: Arc<Mutex<DebugState>>,
     stepper: Stepper,
     instrumenter: Instrumenter,
+    source_map: Option<SourceMap>,
     paused: bool,
     instruction_debug_enabled: bool,
 }
@@ -38,13 +40,44 @@ impl DebuggerEngine {
             state: Arc::new(Mutex::new(DebugState::new())),
             stepper: Stepper::new(),
             instrumenter: Instrumenter::new(),
+            source_map: None,
             paused: false,
             instruction_debug_enabled: false,
         }
     }
 
+    /// Best-effort DWARF source map loading.
+    ///
+    /// Missing or malformed debug information does not fail execution; it simply leaves the
+    /// engine without source mappings.
+    pub fn try_load_source_map(&mut self, wasm_bytes: &[u8]) {
+        let mut source_map = SourceMap::new();
+        match source_map.load(wasm_bytes) {
+            Ok(()) if !source_map.is_empty() => {
+                self.source_map = Some(source_map);
+            }
+            _ => {
+                self.source_map = None;
+            }
+        }
+    }
+
+    pub fn source_map(&self) -> Option<&SourceMap> {
+        self.source_map.as_ref()
+    }
+
+    pub fn source_map_mut(&mut self) -> Option<&mut SourceMap> {
+        self.source_map.as_mut()
+    }
+
+    pub fn lookup_source_location(&self, wasm_offset: usize) -> Option<SourceLocation> {
+        self.source_map.as_ref()?.lookup(wasm_offset)
+    }
+
     /// Enable instruction-level debugging.
     pub fn enable_instruction_debug(&mut self, wasm_bytes: &[u8]) -> Result<()> {
+        self.try_load_source_map(wasm_bytes);
+
         let instructions = self
             .instrumenter
             .parse_instructions(wasm_bytes)

--- a/src/debugger/source_map.rs
+++ b/src/debugger/source_map.rs
@@ -1,9 +1,9 @@
 use crate::{Result, DebuggerError};
 use gimli::{Dwarf, EndianSlice, RunTimeEndian};
-use object::{Object, ObjectSection};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
+use wasmparser::{Parser, Payload};
 
 /// Represents a source code location
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -19,6 +19,8 @@ pub struct SourceMap {
     offsets: BTreeMap<usize, SourceLocation>,
     /// Cache of source file contents
     source_cache: HashMap<PathBuf, String>,
+    /// Code section payload range (when known), used to normalize DWARF addresses.
+    code_section_range: Option<std::ops::Range<usize>>,
 }
 
 impl SourceMap {
@@ -27,27 +29,39 @@ impl SourceMap {
         Self {
             offsets: BTreeMap::new(),
             source_cache: HashMap::new(),
+            code_section_range: None,
         }
     }
 
     /// Load debug info from WASM bytes and build the mapping
     pub fn load(&mut self, wasm_bytes: &[u8]) -> Result<()> {
-        let obj = object::File::parse(wasm_bytes)
-            .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to parse WASM object file: {}", e)))?;
+        self.offsets.clear();
+        self.code_section_range = crate::utils::wasm::code_section_range(wasm_bytes)?;
 
-        let load_section =
-            |id: gimli::SectionId| -> std::result::Result<EndianSlice<RunTimeEndian>, gimli::Error> {
-                let data = obj
-                    .section_by_name(id.name())
-                    .or_else(|| obj.section_by_name(&format!(".{}", id.name())))
-                    .and_then(|section| section.data().ok())
-                    .unwrap_or(&[]);
+        let mut custom_sections: HashMap<String, &[u8]> = HashMap::new();
+        for payload in Parser::new(0).parse_all(wasm_bytes) {
+            let payload = payload
+                .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to parse WASM: {}", e)))?;
+            if let Payload::CustomSection(reader) = payload {
+                custom_sections.insert(reader.name().to_string(), reader.data());
+            }
+        }
 
-                Ok(EndianSlice::new(data, RunTimeEndian::Little))
-            };
+        let load_section = |id: gimli::SectionId| {
+            let name = id.name();
+            let data = custom_sections
+                .get(name)
+                .or_else(|| custom_sections.get(&format!(".{}", name)))
+                .or_else(|| custom_sections.get(name.trim_start_matches('.')))
+                .copied()
+                .unwrap_or(&[]);
 
-        let dwarf = Dwarf::load(&load_section)
-            .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to load DWARF sections: {}", e)))?;
+            Ok(EndianSlice::new(data, RunTimeEndian::Little))
+        };
+
+        let dwarf = Dwarf::load(&load_section).map_err(|e| {
+            DebuggerError::WasmLoadError(format!("Failed to load DWARF sections: {}", e))
+        })?;
 
         let mut units = dwarf.units();
         while let Some(header) = units.next()
@@ -61,8 +75,7 @@ impl SourceMap {
                     if let Some(file_path) =
                         self.get_file_path(&dwarf, &unit, header, row.file_index())
                     {
-                        // In WASM, DWARF addresses are usually offsets into the code section
-                        let offset = row.address() as usize;
+                        let offset = self.normalize_wasm_offset(row.address() as usize, wasm_bytes.len());
                         let line = row.line().map(|l| l.get() as u32).unwrap_or(0);
                         let column = match row.column() {
                             gimli::ColumnType::LeftEdge => None,
@@ -83,6 +96,43 @@ impl SourceMap {
         }
 
         Ok(())
+    }
+
+    /// Returns `true` if no mappings were loaded.
+    pub fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+
+    /// Number of mapped offsets.
+    pub fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Iterate over mappings as `(offset, location)` pairs.
+    pub fn mappings(&self) -> impl Iterator<Item = (usize, &SourceLocation)> {
+        self.offsets.iter().map(|(o, l)| (*o, l))
+    }
+
+    fn normalize_wasm_offset(&self, dwarf_address: usize, wasm_len: usize) -> usize {
+        let Some(code_range) = &self.code_section_range else {
+            return dwarf_address;
+        };
+
+        // Common case: DWARF line-program addresses are offsets into the code-section payload.
+        let code_start = code_range.start;
+        let code_len = code_range.end.saturating_sub(code_range.start);
+
+        // If the address already looks like a module/file offset, keep it.
+        if dwarf_address >= code_start && dwarf_address < wasm_len {
+            return dwarf_address;
+        }
+
+        // Otherwise, treat addresses within the code-section payload length as relative.
+        if dwarf_address < code_len {
+            return code_start.saturating_add(dwarf_address);
+        }
+
+        dwarf_address
     }
 
     fn get_file_path(

--- a/src/utils/wasm.rs
+++ b/src/utils/wasm.rs
@@ -231,6 +231,22 @@ pub fn get_module_info(wasm_bytes: &[u8]) -> Result<ModuleInfo> {
     Ok(info)
 }
 
+/// Returns the byte range of the WASM code section payload within the module, if present.
+///
+/// This range is suitable for normalizing DWARF line-program addresses that are expressed
+/// as offsets into the code section.
+pub fn code_section_range(wasm_bytes: &[u8]) -> Result<Option<std::ops::Range<usize>>> {
+    for payload in Parser::new(0).parse_all(wasm_bytes) {
+        let payload = payload
+            .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to parse WASM: {}", e)))?;
+        if let Payload::CodeSectionStart { range, .. } = payload {
+            return Ok(Some(range));
+        }
+    }
+
+    Ok(None)
+}
+
 /// Information about a WASM module.
 #[derive(Debug, Default, Serialize)]
 pub struct ModuleInfo {

--- a/tests/fixtures/build.sh
+++ b/tests/fixtures/build.sh
@@ -15,7 +15,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTRACTS_DIR="${SCRIPT_DIR}/contracts"
 WASM_DIR="${SCRIPT_DIR}/wasm"
-WORKSPACE_TARGET_DIR="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release"
+RELEASE_TARGET_DIR="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release"
+DEBUG_TARGET_DIR="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release-debug"
 
 # Check if wasm32 target is installed
 if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
@@ -45,13 +46,26 @@ for contract_dir in "${CONTRACTS_DIR}"/*/; do
                 exit 1
             fi
 
-            wasm_file="${WORKSPACE_TARGET_DIR}/${package_name//-/_}.wasm"
+            wasm_file="${RELEASE_TARGET_DIR}/${package_name//-/_}.wasm"
             
             if [ -f "${wasm_file}" ]; then
                 cp "${wasm_file}" "${WASM_DIR}/${contract_name}.wasm"
                 echo "    ✓ Built ${contract_name}.wasm"
             else
                 echo "    ✗ Failed to find WASM output for ${contract_name}"
+                exit 1
+            fi
+
+            echo "  Building ${contract_name} (debug info)..."
+            cargo build --profile release-debug --target wasm32-unknown-unknown
+
+            debug_wasm_file="${DEBUG_TARGET_DIR}/${package_name//-/_}.wasm"
+
+            if [ -f "${debug_wasm_file}" ]; then
+                cp "${debug_wasm_file}" "${WASM_DIR}/${contract_name}_debug.wasm"
+                echo "    Built ${contract_name}_debug.wasm"
+            else
+                echo "    Failed to find debug WASM output for ${contract_name}"
                 exit 1
             fi
         )

--- a/tests/fixtures/contracts/Cargo.toml
+++ b/tests/fixtures/contracts/Cargo.toml
@@ -22,3 +22,8 @@ debug-assertions = false
 panic = "abort"
 codegen-units = 1
 lto = true
+
+[profile.release-debug]
+inherits = "release"
+debug = 2
+strip = "none"

--- a/tests/source_map_integration_tests.rs
+++ b/tests/source_map_integration_tests.rs
@@ -1,0 +1,56 @@
+use soroban_debugger::debugger::source_map::SourceMap;
+
+fn fixture_wasm(name: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("wasm")
+        .join(format!("{name}.wasm"))
+}
+
+#[test]
+fn source_map_missing_debug_info_is_graceful() {
+    let wasm = fixture_wasm("counter");
+    if !wasm.exists() {
+        eprintln!(
+            "Skipping test: fixture not found at {}. Run tests/fixtures/build.sh to build fixtures.",
+            wasm.display()
+        );
+        return;
+    }
+
+    let bytes = std::fs::read(&wasm).unwrap();
+    let mut sm = SourceMap::new();
+    sm.load(&bytes).expect("load should not fail");
+    assert!(
+        sm.is_empty(),
+        "expected no DWARF mappings in stripped fixture"
+    );
+}
+
+#[test]
+fn source_map_debug_fixture_resolves_locations() {
+    let wasm = fixture_wasm("counter_debug");
+    if !wasm.exists() {
+        eprintln!(
+            "Skipping test: debug fixture not found at {}. Run tests/fixtures/build.sh to generate *_debug.wasm fixtures.",
+            wasm.display()
+        );
+        return;
+    }
+
+    let bytes = std::fs::read(&wasm).unwrap();
+    let mut sm = SourceMap::new();
+    sm.load(&bytes).expect("load should not fail");
+
+    assert!(!sm.is_empty(), "expected DWARF mappings in debug fixture");
+
+    let (first_offset, first_loc) = sm.mappings().next().expect("at least one mapping");
+    assert!(first_loc.line > 0, "expected non-zero line numbers");
+
+    let looked_up = sm.lookup(first_offset).expect("lookup should succeed");
+    assert_eq!(&looked_up, first_loc);
+
+    // Range lookup should return the same location for nearby offsets.
+    assert!(sm.lookup(first_offset.saturating_add(1)).is_some());
+}


### PR DESCRIPTION
closes issue #345 

Completes the partial DWARF parsing implementation in src/debugger/source_map.rs by wiring it through the entire debugging stack. The implementation now reliably resolves WASM code offsets to source locations using DWARF debug info, handles missing/stripped debug data gracefully, and provides a stable API for the rest of the debugger to consume source locations.