### PR TITLE
feat: implement debug console evaluate requests (#352)

### DIFF
--- a/extensions/vscode/src/cli/debuggerProcess.ts
+++ b/extensions/vscode/src/cli/debuggerProcess.ts
@@ -46,6 +46,7 @@ type DebugRequest =
   | { type: 'GetStorage' }
   | { type: 'SetBreakpoint'; function: string }
   | { type: 'ClearBreakpoint'; function: string }
+  | { type: 'Evaluate'; expression: string; frame_id?: number }
   | { type: 'Ping' }
   | { type: 'Disconnect' }
   | { type: 'LoadSnapshot'; snapshot_path: string };
@@ -61,6 +62,7 @@ type DebugResponse =
   | { type: 'SnapshotLoaded'; summary: string }
   | { type: 'BreakpointSet'; function: string }
   | { type: 'BreakpointCleared'; function: string }
+  | { type: 'EvaluateResult'; result: string; result_type?: string; variables_reference: number }
   | { type: 'Pong' }
   | { type: 'Disconnected' }
   | { type: 'Error'; message: string };
@@ -235,6 +237,20 @@ export class DebuggerProcess {
       function: functionName
     });
     this.expectResponse(response, 'BreakpointCleared');
+  }
+
+  async evaluate(expression: string, frameId?: number): Promise<{ result: string; type?: string; variablesReference: number }> {
+    const response = await this.sendRequest({
+      type: 'Evaluate',
+      expression,
+      frame_id: frameId
+    });
+    this.expectResponse(response, 'EvaluateResult');
+    return {
+      result: response.result,
+      type: response.result_type,
+      variablesReference: response.variables_reference
+    };
   }
 
   async getContractFunctions(): Promise<Set<string>> {

--- a/extensions/vscode/src/dap/adapter.ts
+++ b/extensions/vscode/src/dap/adapter.ts
@@ -299,6 +299,36 @@ export class SorobanDebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
+  protected async evaluateRequest(
+    response: DebugProtocol.EvaluateResponse,
+    args: DebugProtocol.EvaluateArguments
+  ): Promise<void> {
+    if (!this.debuggerProcess || !this.state.isPaused) {
+      this.sendErrorResponse(response, {
+        id: 1004,
+        format: 'Evaluation is only available when the debugger is paused',
+        showUser: true
+      });
+      return;
+    }
+
+    try {
+      const result = await this.debuggerProcess.evaluate(args.expression, args.frameId);
+      response.body = {
+        result: result.result,
+        type: result.type,
+        variablesReference: result.variablesReference
+      };
+      this.sendResponse(response);
+    } catch (error) {
+      this.sendErrorResponse(response, {
+        id: 1005,
+        format: `${error}`,
+        showUser: false
+      });
+    }
+  }
+
   protected async disconnectRequest(
     response: DebugProtocol.DisconnectResponse,
     args: DebugProtocol.DisconnectArguments

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -497,6 +497,74 @@ impl DebugServer {
                         },
                     }
                 }
+                DebugRequest::Evaluate { expression, .. } => match self.engine.as_ref() {
+                    Some(engine) => {
+                        // First try to look up the expression as a storage key
+                        match engine.executor().get_storage_snapshot() {
+                            Ok(snapshot) => {
+                                if let Some(value) = snapshot.get(&expression) {
+                                    let result = serde_json::to_string(value)
+                                        .unwrap_or_else(|_| format!("{:?}", value));
+                                    DebugResponse::EvaluateResult {
+                                        result,
+                                        result_type: Some("storage".to_string()),
+                                        variables_reference: 0,
+                                    }
+                                } else {
+                                    // Try matching built-in state fields
+                                    let state_result =
+                                        engine.state().lock().ok().and_then(|state| {
+                                            match expression.as_str() {
+                                                "function" | "current_function" => {
+                                                    state.current_function().map(|f| {
+                                                        (f.to_string(), "string".to_string())
+                                                    })
+                                                }
+                                                "args" | "arguments" => {
+                                                    state.current_args().map(|a| {
+                                                        (a.to_string(), "string".to_string())
+                                                    })
+                                                }
+                                                "step_count" | "steps" => Some((
+                                                    state.step_count().to_string(),
+                                                    "number".to_string(),
+                                                )),
+                                                _ => None,
+                                            }
+                                        });
+
+                                    match state_result {
+                                        Some((result, result_type)) => {
+                                            DebugResponse::EvaluateResult {
+                                                result,
+                                                result_type: Some(result_type),
+                                                variables_reference: 0,
+                                            }
+                                        }
+                                        None => DebugResponse::Error {
+                                            message: format!(
+                                                "Cannot evaluate '{}': only storage key lookup \
+                                                 and built-in fields (function, args, \
+                                                 step_count) are supported",
+                                                expression
+                                            ),
+                                        },
+                                    }
+                                }
+                            }
+                            Err(e) => DebugResponse::Error {
+                                message: format!(
+                                    "Failed to access storage for evaluation: {}",
+                                    e
+                                ),
+                            },
+                        }
+                    }
+                    None => DebugResponse::Error {
+                        message: "No contract loaded. Evaluation requires an active debug session."
+                            .to_string(),
+                    },
+                },
                 DebugRequest::Ping => DebugResponse::Pong,
                 DebugRequest::Disconnect => DebugResponse::Disconnected,
             };

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -88,6 +88,12 @@ pub enum DebugRequest {
     /// Load network snapshot
     LoadSnapshot { snapshot_path: String },
 
+    /// Evaluate an expression in the current debug context
+    Evaluate {
+        expression: String,
+        frame_id: Option<u64>,
+    },
+
     /// Ping to check connection
     Ping,
 
@@ -168,6 +174,13 @@ pub enum DebugResponse {
 
     /// Error response
     Error { message: String },
+
+    /// Evaluation result
+    EvaluateResult {
+        result: String,
+        result_type: Option<String>,
+        variables_reference: u64,
+    },
 
     /// Pong response
     Pong,


### PR DESCRIPTION
 ## Summary

  - Adds `Evaluate` request and `EvaluateResult` response to the Rust wire protocol (`src/server/protocol.rs`)
  - Implements evaluation handler in `src/server/debug_server.rs`: looks up expressions as storage keys first, then
  falls back to built-in fields (`function`, `args`, `step_count`); unsupported expressions return a descriptive error
  immediately instead of hanging
  - Adds `Evaluate`/`EvaluateResult` wire types and an `evaluate()` method to
  `extensions/vscode/src/cli/debuggerProcess.ts`
  - Implements `evaluateRequest` in `extensions/vscode/src/dap/adapter.ts`, gated on the paused state so evaluation is
  only attempted when the debugger is actually stopped

  ## Test plan

  - [ ] Launch a debug session and pause at a breakpoint
  - [ ] Open the debug console and type a known storage key — should return its value
  - [ ] Type `function`, `args`, or `step_count` — should return the current debugger state values
  - [ ] Type an unknown expression — should return a clean error message, not hang
  - [ ] Trigger evaluate while not paused — should return "only available when paused" error

  Closes #352