### PR TITLE
[#382] Build break: wasmparser import reader no longer supports flatten() directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ rustyline = "13.0"
 
 # Snapshot loading
 soroban-ledger-snapshot = "22.0.2"
+gimli = "0.33.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/analyzer/security.rs
+++ b/src/analyzer/security.rs
@@ -422,7 +422,7 @@ fn analyze_unbounded_iteration_static(wasm_bytes: &[u8]) -> UnboundedStaticSigna
 
         match payload {
             Payload::ImportSection(reader) => {
-                for import in reader.flatten() {
+                for import in reader.into_iter().flatten() {
                     if let wasmparser::TypeRef::Func(_) = import.ty {
                         if is_storage_read_import(import.module, import.name) {
                             storage_import_indices.insert(imported_func_count);

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -2,6 +2,7 @@ pub mod breakpoint;
 pub mod engine;
 pub mod error_db;
 pub mod instruction_pointer;
+pub mod source_map;
 pub mod state;
 pub mod stepper;
 
@@ -9,5 +10,6 @@ pub use breakpoint::BreakpointManager;
 pub use engine::DebuggerEngine;
 pub use error_db::{ErrorDatabase, ErrorExplanation};
 pub use instruction_pointer::{InstructionPointer, StepMode};
+pub use source_map::{SourceLocation, SourceMap};
 pub use state::DebugState;
 pub use stepper::Stepper;

--- a/src/debugger/source_map.rs
+++ b/src/debugger/source_map.rs
@@ -47,7 +47,10 @@ impl SourceMap {
             }
         }
 
-        let load_section = |id: gimli::SectionId| {
+        let load_section = |id: gimli::SectionId| -> std::result::Result<
+            EndianSlice<RunTimeEndian>,
+            gimli::Error,
+        > {
             let name = id.name();
             let data = custom_sections
                 .get(name)


### PR DESCRIPTION
Closes #382

## Summary
- Replace direct `flatten()` usage on wasmparser import readers with iterator flattening that is compatible with current wasmparser APIs.
- Ensure debugger source-map module is wired and compiles by adding the missing `gimli` dependency and explicit DWARF section loader type.
- Verified fix by running full `cargo test` successfully.