### PR TITLE
feat: tab_completion_repl

### DIFF
--- a/src/repl/commands.rs
+++ b/src/repl/commands.rs
@@ -21,6 +21,11 @@ pub enum ReplCommand {
 }
 
 impl ReplCommand {
+    /// Built-in REPL commands for completion
+    pub fn builtins() -> &'static [&'static str] {
+        &["call", "storage", "history", "clear", "help", "exit", "quit"]
+    }
+
     /// Parse a command string into a ReplCommand
     pub fn parse(input: &str) -> Result<Self> {
         let trimmed = input.trim();

--- a/src/repl/executor.rs
+++ b/src/repl/executor.rs
@@ -74,6 +74,13 @@ impl ReplExecutor {
         Ok(())
     }
 
+    /// Return known exported function names for REPL completion.
+    pub fn function_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.signatures.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
     fn args_to_json_array_for(&mut self, function: &str, args: &[String]) -> Result<String> {
         let values = if let Some(sig) = self.signatures.get(function).cloned() {
             self.typed_repl_args(&sig, args)?

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -7,17 +7,113 @@ use super::executor::ReplExecutor;
 use super::ReplConfig;
 use crate::ui::formatter::Formatter;
 use crate::Result;
+use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
-use rustyline::{DefaultEditor, Editor};
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Context, Editor, Helper};
 use std::path::PathBuf;
 
 /// REPL session state and editor
 pub struct ReplSession {
-    editor: Editor<(), FileHistory>,
+    editor: Editor<ReplHelper, FileHistory>,
     config: ReplConfig,
     executor: ReplExecutor,
     history_path: PathBuf,
+}
+
+#[derive(Clone)]
+struct ReplHelper {
+    commands: Vec<String>,
+    functions: Vec<String>,
+}
+
+impl ReplHelper {
+    fn new(commands: Vec<String>, functions: Vec<String>) -> Self {
+        Self {
+            commands,
+            functions,
+        }
+    }
+
+    fn complete_from(candidates: &[String], prefix: &str) -> Vec<Pair> {
+        candidates
+            .iter()
+            .filter(|candidate| candidate.starts_with(prefix))
+            .map(|candidate| Pair {
+                display: candidate.clone(),
+                replacement: candidate.clone(),
+            })
+            .collect()
+    }
+
+    fn complete_for_input(&self, line: &str, pos: usize) -> (usize, Vec<Pair>) {
+        let input = &line[..pos];
+        let tokens: Vec<&str> = input.split_whitespace().collect();
+
+        // Complete top-level command name.
+        if tokens.is_empty() || (tokens.len() == 1 && !input.ends_with(' ')) {
+            let (start, prefix) = match tokens.first() {
+                Some(prefix) => (pos.saturating_sub(prefix.len()), *prefix),
+                None => (pos, ""),
+            };
+            let matches = Self::complete_from(&self.commands, prefix);
+            return (start, matches);
+        }
+
+        // Complete function name after `call`.
+        if tokens.first() == Some(&"call") {
+            if input.ends_with(' ') {
+                if tokens.len() == 1 {
+                    let start = pos;
+                    let matches = Self::complete_from(&self.functions, "");
+                    return (start, matches);
+                }
+                return (pos, Vec::new());
+            }
+
+            if tokens.len() == 2 {
+                let prefix = tokens[1];
+                let start = pos.saturating_sub(prefix.len());
+                let matches = Self::complete_from(&self.functions, prefix);
+                return (start, matches);
+            }
+        }
+
+        (pos, Vec::new())
+    }
+}
+
+impl Helper for ReplHelper {}
+
+impl Hinter for ReplHelper {
+    type Hint = String;
+}
+
+impl Highlighter for ReplHelper {}
+
+impl Validator for ReplHelper {
+    fn validate(
+        &self,
+        _ctx: &mut ValidationContext<'_>,
+    ) -> rustyline::Result<ValidationResult> {
+        Ok(ValidationResult::Valid(None))
+    }
+}
+
+impl Completer for ReplHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        Ok(self.complete_for_input(line, pos))
+    }
 }
 
 impl ReplSession {
@@ -27,13 +123,21 @@ impl ReplSession {
             .unwrap_or_else(std::env::temp_dir)
             .join(".soroban_repl_history");
 
-        let mut editor = DefaultEditor::new()
+        let executor = ReplExecutor::new(&config)?;
+        let helper = ReplHelper::new(
+            ReplCommand::builtins()
+                .iter()
+                .map(|cmd| (*cmd).to_string())
+                .collect(),
+            executor.function_names(),
+        );
+
+        let mut editor = Editor::<ReplHelper, FileHistory>::new()
             .map_err(|e| miette::miette!("Failed to initialize REPL editor: {}", e))?;
+        editor.set_helper(Some(helper));
 
         // Load history if it exists
         let _ = editor.load_history(&history_path);
-
-        let executor = ReplExecutor::new(&config)?;
 
         Ok(ReplSession {
             editor,


### PR DESCRIPTION
Closes #361 

---

**Problem**
The REPL loop works, but it does not yet provide completion support for commands or exported functions.

**Files likely to touch**

`src/repl/session.rs`
`src/repl/commands.rs`
`src/repl/executor.rs`

**What to fix**

Configure rustyline completion for built-in commands and known function names.

**Acceptance criteria**

Tab completion works for at least REPL commands and exported functions.
Non-interactive tests are not broken by the completion setup.