### PR TITLE
Feat: Network Nnapshot #359 and Instruction count #354

### DIFF
--- a/man/man1/soroban-debug-analyze.1
+++ b/man/man1/soroban-debug-analyze.1
@@ -4,7 +4,7 @@
 .SH NAME
 analyze \- Analyze contract for security vulnerabilities
 .SH SYNOPSIS
-\fBanalyze\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBanalyze\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-timeout\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Analyze contract for security vulnerabilities
 .SH OPTIONS
@@ -20,6 +20,9 @@ Function arguments as JSON array for dynamic analysis (optional)
 .TP
 \fB\-s\fR, \fB\-\-storage\fR \fI<STORAGE>\fR
 Initial storage state as JSON object (optional)
+.TP
+\fB\-\-timeout\fR \fI<TIMEOUT>\fR [default: 30]
+Execution timeout in seconds for dynamic analysis (default: 30)
 .TP
 \fB\-\-format\fR \fI<FORMAT>\fR [default: text]
 Output format (text, json)

--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,4 +17,16 @@ Shell to generate completion script for
 .br
 
 .br
-[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+bash
+.IP \(bu 2
+elvish
+.IP \(bu 2
+fish
+.IP \(bu 2
+powershell
+.IP \(bu 2
+zsh
+.RE

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -26,7 +26,13 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-[\fIpossible values: \fRdot, mermaid]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+dot
+.IP \(bu 2
+mermaid
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -56,7 +56,13 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/src/repl/executor.rs
+++ b/src/repl/executor.rs
@@ -35,6 +35,17 @@ impl ReplExecutor {
         let mut executor = ContractExecutor::new(wasm_bytes)?;
         executor.enable_mock_all_auths();
 
+        if let Some(snapshot_path) = &config.network_snapshot {
+            let loader = crate::simulator::SnapshotLoader::from_file(snapshot_path)
+                .map_err(|e| miette::miette!("Failed to load network snapshot {:?}: {}", snapshot_path, e))?;
+            let loaded = loader.apply_to_environment()?;
+            executor.apply_snapshot_ledger(&loaded)?;
+            crate::logging::log_display(
+                loaded.format_summary(),
+                crate::logging::LogLevel::Info,
+            );
+        }
+
         if let Some(storage_json) = &config.storage {
             executor.set_initial_storage(storage_json.clone())?;
         }

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -17,6 +17,7 @@ use crate::{DebuggerError, Result};
 
 use soroban_env_host::Host;
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::{Address, Env};
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -38,6 +39,8 @@ pub struct ContractExecutor {
     timeout_secs: u64,
     error_db: crate::debugger::error_db::ErrorDatabase,
     debug_env: DebugEnv,
+    /// Accumulated CPU instruction deltas keyed by function name.
+    per_function_cpu: HashMap<String, u64>,
 }
 
 impl ContractExecutor {
@@ -55,6 +58,7 @@ impl ContractExecutor {
             timeout_secs: 30,
             error_db: loaded.error_db,
             debug_env: DebugEnv::new(),
+            per_function_cpu: HashMap::new(),
         })
     }
 
@@ -141,6 +145,10 @@ impl ContractExecutor {
             None::<&str>,
         );
 
+        *self
+            .per_function_cpu
+            .entry(function.to_string())
+            .or_insert(0) += record.budget.cpu_instructions;
         self.last_execution = Some(record);
         Ok(display)
     }
@@ -367,6 +375,35 @@ impl ContractExecutor {
 
         Ok(())
     }
+    /// Apply ledger metadata (sequence, timestamp, network ID) from a network snapshot.
+    pub fn apply_snapshot_ledger(
+        &mut self,
+        snapshot: &crate::simulator::LoadedSnapshot,
+    ) -> Result<()> {
+        use sha2::{Digest, Sha256};
+
+        let seq = snapshot.ledger_sequence();
+        let ts = snapshot.snapshot().ledger.timestamp;
+        let passphrase = snapshot.network_passphrase();
+
+        let mut hasher = Sha256::new();
+        hasher.update(passphrase.as_bytes());
+        let network_id: [u8; 32] = hasher.finalize().into();
+
+        self.env.ledger().with_mut(|l| {
+            l.sequence_number = seq;
+            l.timestamp = ts;
+            l.network_id = network_id;
+        });
+
+        info!(
+            "Applied snapshot ledger state: sequence={}, timestamp={}",
+            seq, ts
+        );
+
+        Ok(())
+    }
+
     pub fn set_mock_specs(&mut self, specs: &[String]) -> Result<()> {
         let registry = MockRegistry::from_cli_specs(&self.env, specs)?;
         self.set_mock_registry(registry)
@@ -382,9 +419,16 @@ impl ContractExecutor {
             .unwrap_or_default()
     }
     pub fn get_instruction_counts(&self) -> Result<InstructionCounts> {
+        let mut function_counts: Vec<(String, u64)> = self
+            .per_function_cpu
+            .iter()
+            .map(|(name, &cpu)| (name.clone(), cpu))
+            .collect();
+        function_counts.sort_by(|a, b| b.1.cmp(&a.1));
+        let total = function_counts.iter().map(|(_, c)| c).sum();
         Ok(InstructionCounts {
-            function_counts: Vec::new(),
-            total: 0,
+            function_counts,
+            total,
         })
     }
     pub fn host(&self) -> &Host {


### PR DESCRIPTION
##Description 

Network-snapshot actually load the snapshot into the session and Implement ContractExecutor::get_instruction_counts instead of returning zeroed data Repo Avatar

closes #354
closes #359