### PR TITLE
feat: implement source-level step-out support (#350)

### DIFF
--- a/src/debugger/stepper.rs
+++ b/src/debugger/stepper.rs
@@ -131,9 +131,8 @@ impl Stepper {
                 debug_state.instruction_pointer().call_stack_depth() <= target_depth
             }
             StepMode::StepOut => {
-                // Pause if we've stepped out of the function
-                let target_depth = debug_state.instruction_pointer().call_stack_depth();
-                debug_state.instruction_pointer().call_stack_depth() < target_depth
+                // Delegate to the instruction pointer which holds the stored target depth
+                debug_state.instruction_pointer().should_pause_at(instruction)
             }
             StepMode::StepBlock => {
                 // Pause at control flow instructions
@@ -166,14 +165,20 @@ impl Stepper {
 
     /// Find next instruction at lower call depth (step out)
     fn find_next_instruction_at_lower_depth(&self, debug_state: &mut DebugState) -> bool {
-        let target_depth = debug_state.instruction_pointer().call_stack_depth();
+        let current_depth = debug_state.instruction_pointer().call_stack_depth();
 
-        for _ in 0..1000 {
-            // Prevent infinite loop
+        // Already at root — cannot step out at the instruction level
+        if current_depth == 0 {
+            return false;
+        }
+
+        let target_depth = current_depth - 1;
+
+        for _ in 0..10_000 {
             if debug_state.next_instruction().is_none() {
                 break;
             }
-            if debug_state.instruction_pointer().call_stack_depth() < target_depth {
+            if debug_state.instruction_pointer().call_stack_depth() <= target_depth {
                 return true;
             }
         }

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -276,8 +276,10 @@ impl DebugServer {
                     },
                 },
                 DebugRequest::StepOut => match self.engine.as_mut() {
-                    Some(engine) => match engine.step_out() {
-                        Ok(_) => {
+                    Some(engine) => {
+                        // When paused at a function-level breakpoint (pending execution),
+                        // step-out means executing the function to completion.
+                        if let Some(pending) = self.pending_execution.take() {
                             let (current_function, step_count) = engine
                                 .state()
                                 .lock()
@@ -288,17 +290,46 @@ impl DebugServer {
                                     )
                                 })
                                 .unwrap_or((None, 0));
-                            DebugResponse::StepResult {
-                                paused: engine.is_paused(),
-                                current_function,
-                                step_count,
-                                source_location: None,
+                            match engine.execute_without_breakpoints(
+                                &pending.function,
+                                pending.args.as_deref(),
+                            ) {
+                                Ok(_) => DebugResponse::StepResult {
+                                    paused: false,
+                                    current_function,
+                                    step_count,
+                                    source_location: None,
+                                },
+                                Err(e) => DebugResponse::Error {
+                                    message: e.to_string(),
+                                },
+                            }
+                        } else {
+                            match engine.step_out() {
+                                Ok(_) => {
+                                    let (current_function, step_count) = engine
+                                        .state()
+                                        .lock()
+                                        .map(|state| {
+                                            (
+                                                state.current_function().map(|s| s.to_string()),
+                                                state.step_count() as u64,
+                                            )
+                                        })
+                                        .unwrap_or((None, 0));
+                                    DebugResponse::StepResult {
+                                        paused: engine.is_paused(),
+                                        current_function,
+                                        step_count,
+                                        source_location: None,
+                                    }
+                                }
+                                Err(e) => DebugResponse::Error {
+                                    message: e.to_string(),
+                                },
                             }
                         }
-                        Err(e) => DebugResponse::Error {
-                            message: e.to_string(),
-                        },
-                    },
+                    }
                     None => DebugResponse::Error {
                         message: "No contract loaded".to_string(),
                     },


### PR DESCRIPTION
## Summary

- `src/debugger/stepper.rs`: Fixed `find_next_instruction_at_lower_depth` which was using the current depth as its own target, making it impossible to ever satisfy. Now correctly uses `current_depth - 1` and returns early when already at root depth (no caller to return to).
- `src/debugger/stepper.rs`: Fixed `should_pause` for `StepOut` which was comparing `call_stack_depth()` against itself (always false). Now delegates to `instruction_pointer.should_pause_at()` which uses the target depth captured when stepping began.
- `src/server/debug_server.rs`: Fixed `StepOut` handler to recognise when the debugger is paused at a function-level breakpoint (`pending_execution`). Previously it fell through to the instruction stepper at depth 0 and made no progress. Now executes the pending function to completion and returns `paused: false`, causing the adapter to correctly close the frame.

## How frame depth updates reach the UI

`refreshState` in the VS Code adapter calls `inspect()` after each step. The `Inspect` handler reads `state.call_stack()` (the `CallStackInspector`), which is kept in sync by `next_instruction()` as it pushes on `Call` and pops on `Return`/`End` instructions. So once step-out advances past the return point, the next `refreshState` shows one fewer frame.

Closes #350