### PR TITLE
Add expected-error / expected-panic assertions to scenario execution #362

### DIFF
--- a/examples/contracts/simple-token/scenario.toml
+++ b/examples/contracts/simple-token/scenario.toml
@@ -33,3 +33,10 @@ expected_return = "700"
 
 [steps.expected_storage]
 "TotalSupply" = "1000"
+
+# Failure assertion: transferring more than the balance should error
+[[steps]]
+name = "Overdraw Transfer Should Fail"
+function = "transfer"
+args = '["GD726E62Z6XU6KD5J2EPOHG5NQZ5K5I5J5QZQZQZQZQZQZQZQZQZQZQ", "GD826E62Z6XU6KD5J2EPOHG5NQZ5K5I5J5QZQZQZQZQZQZQZQZQZQZQ", 9999]'
+expected_error = "insufficient"

--- a/src/analyzer/security.rs
+++ b/src/analyzer/security.rs
@@ -204,10 +204,7 @@ impl SecurityRule for HardcodedAddressRule {
                                 rule_id: self.name().to_string(),
                                 severity: Severity::Medium,
                                 location: "Data Section".to_string(),
-                                description: format!(
-                                    "Found potential hardcoded address: {}",
-                                    word
-                                ),
+                                description: format!("Found potential hardcoded address: {}", word),
                                 remediation:
                                     "Use Address::from_str from configuration or function \
                                      arguments instead of hardcoding."
@@ -673,16 +670,28 @@ mod tests {
     #[test]
     fn strkey_accepts_well_formed_g_address() {
         let addr = build_strkey(6 << 3, &[0u8; 32]);
-        assert!(addr.starts_with('G'), "sanity: version 0x30 encodes to 'G' prefix");
-        assert!(is_valid_strkey(&addr), "well-formed G address must be accepted");
+        assert!(
+            addr.starts_with('G'),
+            "sanity: version 0x30 encodes to 'G' prefix"
+        );
+        assert!(
+            is_valid_strkey(&addr),
+            "well-formed G address must be accepted"
+        );
     }
 
     /// Same for the contract ('C') variant.
     #[test]
     fn strkey_accepts_well_formed_c_address() {
         let addr = build_strkey(2 << 3, &[0u8; 32]);
-        assert!(addr.starts_with('C'), "sanity: version 0x10 encodes to 'C' prefix");
-        assert!(is_valid_strkey(&addr), "well-formed C address must be accepted");
+        assert!(
+            addr.starts_with('C'),
+            "sanity: version 0x10 encodes to 'C' prefix"
+        );
+        assert!(
+            is_valid_strkey(&addr),
+            "well-formed C address must be accepted"
+        );
     }
 
     /// 56 uppercase-ASCII chars starting with 'G' but with all-'A' payload have
@@ -695,7 +704,10 @@ mod tests {
         // Length sanity
         assert_eq!(fake.len(), 58); // <-- deliberately over-long to be safe; trim to 56
         let fake56 = &fake[..56];
-        assert!(!is_valid_strkey(fake56), "all-A token must be rejected (bad CRC)");
+        assert!(
+            !is_valid_strkey(fake56),
+            "all-A token must be rejected (bad CRC)"
+        );
     }
 
     /// A string that is 56 chars, starts with 'G', but contains characters
@@ -706,19 +718,26 @@ mod tests {
         // Contains '0', '1', and lower-case letters — all outside A-Z/2-7.
         let bad_chars = "G0001111abcdefghABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDE";
         assert_eq!(bad_chars.len(), 53); // not 56, show next case is the real one
-        // Craft exactly 56 chars with an invalid char ('0') at position 1.
+                                         // Craft exactly 56 chars with an invalid char ('0') at position 1.
         let with_zero = "G0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         assert_eq!(with_zero.len(), 57);
         let with_zero56 = &with_zero[..56];
-        assert!(!is_valid_strkey(with_zero56), "token with '0' must be rejected");
+        assert!(
+            !is_valid_strkey(with_zero56),
+            "token with '0' must be rejected"
+        );
     }
 
     /// Strings shorter or longer than 56 characters must always be rejected,
     /// regardless of prefix.
     #[test]
     fn strkey_rejects_wrong_length() {
-        assert!(!is_valid_strkey("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")); // 55
-        assert!(!is_valid_strkey("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")); // 57
+        assert!(!is_valid_strkey(
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )); // 55
+        assert!(!is_valid_strkey(
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )); // 57
         assert!(!is_valid_strkey("")); // empty
     }
 
@@ -792,7 +811,7 @@ mod tests {
         // valid base32 characters, yet none carries a correct CRC-16 checksum.
         let fake_tokens = [
             "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", // 57 → trim
-            "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",   // 55 → skip
+            "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",  // 55 → skip
             // Exactly 56 chars, valid base32, but wrong CRC:
             "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
             "CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
@@ -807,7 +826,9 @@ mod tests {
                 continue; // shorter than 56 — would not be picked up anyway
             }
             let wasm = wasm_with_data_string(&t);
-            let findings = rule.analyze_static(&wasm).expect("analyze_static should not error");
+            let findings = rule
+                .analyze_static(&wasm)
+                .expect("analyze_static should not error");
             assert!(
                 findings.is_empty(),
                 "token '{}' must not produce a finding (not a valid StrKey): {:?}",
@@ -827,7 +848,9 @@ mod tests {
 
         let wasm = wasm_with_data_string(&valid_addr);
         let rule = HardcodedAddressRule;
-        let findings = rule.analyze_static(&wasm).expect("analyze_static should not error");
+        let findings = rule
+            .analyze_static(&wasm)
+            .expect("analyze_static should not error");
 
         assert_eq!(
             findings.len(),
@@ -846,7 +869,7 @@ mod tests {
     #[test]
     fn hardcoded_address_rule_mixed_tokens() {
         let valid_addr = build_strkey(2 << 3, &[0x11u8; 32]); // C-prefix contract address
-        // Pad the two strings with a space so they end up as separate tokens.
+                                                              // Pad the two strings with a space so they end up as separate tokens.
         let payload = format!(
             "{} GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV",
             valid_addr
@@ -854,7 +877,9 @@ mod tests {
 
         let wasm = wasm_with_data_string(&payload);
         let rule = HardcodedAddressRule;
-        let findings = rule.analyze_static(&wasm).expect("analyze_static should not error");
+        let findings = rule
+            .analyze_static(&wasm)
+            .expect("analyze_static should not error");
 
         assert_eq!(
             findings.len(),

--- a/src/debugger/source_map.rs
+++ b/src/debugger/source_map.rs
@@ -1,4 +1,4 @@
-use crate::{Result, DebuggerError};
+use crate::{DebuggerError, Result};
 use gimli::{Dwarf, EndianSlice, RunTimeEndian};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -40,8 +40,9 @@ impl SourceMap {
 
         let mut custom_sections: HashMap<String, &[u8]> = HashMap::new();
         for payload in Parser::new(0).parse_all(wasm_bytes) {
-            let payload = payload
-                .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to parse WASM: {}", e)))?;
+            let payload = payload.map_err(|e| {
+                DebuggerError::WasmLoadError(format!("Failed to parse WASM: {}", e))
+            })?;
             if let Payload::CustomSection(reader) = payload {
                 custom_sections.insert(reader.name().to_string(), reader.data());
             }
@@ -67,18 +68,22 @@ impl SourceMap {
         })?;
 
         let mut units = dwarf.units();
-        while let Some(header) = units.next()
-            .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to read DWARF unit: {}", e)))? {
-            let unit = dwarf.unit(header)
-                .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to load DWARF unit: {}", e)))?;
+        while let Some(header) = units.next().map_err(|e| {
+            DebuggerError::WasmLoadError(format!("Failed to read DWARF unit: {}", e))
+        })? {
+            let unit = dwarf.unit(header).map_err(|e| {
+                DebuggerError::WasmLoadError(format!("Failed to load DWARF unit: {}", e))
+            })?;
             if let Some(program) = unit.line_program.clone() {
                 let mut rows = program.rows();
-                while let Some((header, row)) = rows.next_row()
-                    .map_err(|e| DebuggerError::WasmLoadError(format!("Failed to read DWARF line row: {}", e)))? {
+                while let Some((header, row)) = rows.next_row().map_err(|e| {
+                    DebuggerError::WasmLoadError(format!("Failed to read DWARF line row: {}", e))
+                })? {
                     if let Some(file_path) =
                         self.get_file_path(&dwarf, &unit, header, row.file_index())
                     {
-                        let offset = self.normalize_wasm_offset(row.address() as usize, wasm_bytes.len());
+                        let offset =
+                            self.normalize_wasm_offset(row.address() as usize, wasm_bytes.len());
                         let line = row.line().map(|l| l.get() as u32).unwrap_or(0);
                         let column = match row.column() {
                             gimli::ColumnType::LeftEdge => None,

--- a/src/repl/commands.rs
+++ b/src/repl/commands.rs
@@ -23,7 +23,9 @@ pub enum ReplCommand {
 impl ReplCommand {
     /// Built-in REPL commands for completion
     pub fn builtins() -> &'static [&'static str] {
-        &["call", "storage", "history", "clear", "help", "exit", "quit"]
+        &[
+            "call", "storage", "history", "clear", "help", "exit", "quit",
+        ]
     }
 
     /// Parse a command string into a ReplCommand

--- a/src/repl/executor.rs
+++ b/src/repl/executor.rs
@@ -36,14 +36,13 @@ impl ReplExecutor {
         executor.enable_mock_all_auths();
 
         if let Some(snapshot_path) = &config.network_snapshot {
-            let loader = crate::simulator::SnapshotLoader::from_file(snapshot_path)
-                .map_err(|e| miette::miette!("Failed to load network snapshot {:?}: {}", snapshot_path, e))?;
+            let loader =
+                crate::simulator::SnapshotLoader::from_file(snapshot_path).map_err(|e| {
+                    miette::miette!("Failed to load network snapshot {:?}: {}", snapshot_path, e)
+                })?;
             let loaded = loader.apply_to_environment()?;
             executor.apply_snapshot_ledger(&loaded)?;
-            crate::logging::log_display(
-                loaded.format_summary(),
-                crate::logging::LogLevel::Info,
-            );
+            crate::logging::log_display(loaded.format_summary(), crate::logging::LogLevel::Info);
         }
 
         if let Some(storage_json) = &config.storage {

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -9,9 +9,9 @@ use crate::ui::formatter::Formatter;
 use crate::Result;
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
-use rustyline::history::FileHistory;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
+use rustyline::history::FileHistory;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{Context, Editor, Helper};
 use std::path::PathBuf;
@@ -95,10 +95,7 @@ impl Hinter for ReplHelper {
 impl Highlighter for ReplHelper {}
 
 impl Validator for ReplHelper {
-    fn validate(
-        &self,
-        _ctx: &mut ValidationContext<'_>,
-    ) -> rustyline::Result<ValidationResult> {
+    fn validate(&self, _ctx: &mut ValidationContext<'_>) -> rustyline::Result<ValidationResult> {
         Ok(ValidationResult::Valid(None))
     }
 }

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -24,6 +24,10 @@ pub struct ScenarioStep {
     pub expected_storage: Option<HashMap<String, String>>,
     pub expected_events: Option<Vec<ScenarioEventAssertion>>,
     pub budget_limits: Option<ScenarioBudgetAssertion>,
+    /// When set, the step is expected to fail with an error message containing this substring.
+    pub expected_error: Option<String>,
+    /// When set, the step is expected to panic with a message containing this substring.
+    pub expected_panic: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -104,34 +108,88 @@ pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
         let result = engine.execute(&step.function, parsed_args.as_deref());
 
         let mut step_passed = true;
+        let expects_failure = step.expected_error.is_some() || step.expected_panic.is_some();
 
         match result {
             Ok(res) => {
-                println!("  Result: {}", res);
-                if let Some(expected) = &step.expected_return {
-                    if res.trim() == expected.trim() {
+                if expects_failure {
+                    // Step was expected to fail, but it succeeded — that's a test failure.
+                    println!(
+                        "  {}",
+                        Formatter::error(format!(
+                            "✗ Step succeeded with '{}', but was expected to fail",
+                            res
+                        ))
+                    );
+                    step_passed = false;
+                } else {
+                    println!("  Result: {}", res);
+                    if let Some(expected) = &step.expected_return {
+                        if res.trim() == expected.trim() {
+                            println!(
+                                "  {}",
+                                Formatter::success("✓ Return value assertion passed")
+                            );
+                        } else {
+                            println!(
+                                "  {}",
+                                Formatter::error(format!(
+                                    "✗ Return value assertion failed! Expected '{}', got '{}'",
+                                    expected, res
+                                ))
+                            );
+                            step_passed = false;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let err_msg = format!("{}", e);
+                if let Some(expected_error) = &step.expected_error {
+                    if err_msg.contains(expected_error.as_str()) {
                         println!(
                             "  {}",
-                            Formatter::success("✓ Return value assertion passed")
+                            Formatter::success(format!(
+                                "✓ Expected error assertion passed (matched '{}')",
+                                expected_error
+                            ))
                         );
                     } else {
                         println!(
                             "  {}",
                             Formatter::error(format!(
-                                "✗ Return value assertion failed! Expected '{}', got '{}'",
-                                expected, res
+                                "✗ Expected error '{}', but got '{}'",
+                                expected_error, err_msg
                             ))
                         );
                         step_passed = false;
                     }
+                } else if let Some(expected_panic) = &step.expected_panic {
+                    if err_msg.contains(expected_panic.as_str()) {
+                        println!(
+                            "  {}",
+                            Formatter::success(format!(
+                                "✓ Expected panic assertion passed (matched '{}')",
+                                expected_panic
+                            ))
+                        );
+                    } else {
+                        println!(
+                            "  {}",
+                            Formatter::error(format!(
+                                "✗ Expected panic '{}', but got '{}'",
+                                expected_panic, err_msg
+                            ))
+                        );
+                        step_passed = false;
+                    }
+                } else {
+                    println!(
+                        "  {}",
+                        Formatter::error(format!("✗ Execution failed: {}", e))
+                    );
+                    step_passed = false;
                 }
-            }
-            Err(e) => {
-                println!(
-                    "  {}",
-                    Formatter::error(format!("✗ Execution failed: {}", e))
-                );
-                step_passed = false;
             }
         }
 
@@ -341,6 +399,8 @@ mod tests {
         assert!(scenario.steps[0].expected_storage.is_none());
         assert!(scenario.steps[0].expected_events.is_none());
         assert!(scenario.steps[0].budget_limits.is_none());
+        assert!(scenario.steps[0].expected_error.is_none());
+        assert!(scenario.steps[0].expected_panic.is_none());
 
         assert_eq!(scenario.steps[1].name.as_deref(), Some("Get Counter"));
         assert_eq!(scenario.steps[1].function, "get");
@@ -371,6 +431,59 @@ mod tests {
                 .map(|s| s.as_str()),
             Some("1")
         );
+    }
+
+    #[test]
+    fn test_expected_error_deserialization() {
+        let toml_str = r#"
+            [[steps]]
+            name = "Should fail"
+            function = "bad_fn"
+            expected_error = "unauthorized"
+        "#;
+
+        let scenario: Scenario = toml::from_str(toml_str).unwrap();
+        assert_eq!(scenario.steps.len(), 1);
+        assert_eq!(
+            scenario.steps[0].expected_error.as_deref(),
+            Some("unauthorized")
+        );
+        assert!(scenario.steps[0].expected_panic.is_none());
+        assert!(scenario.steps[0].expected_return.is_none());
+    }
+
+    #[test]
+    fn test_expected_panic_deserialization() {
+        let toml_str = r#"
+            [[steps]]
+            name = "Should panic"
+            function = "panic_fn"
+            expected_panic = "index out of bounds"
+        "#;
+
+        let scenario: Scenario = toml::from_str(toml_str).unwrap();
+        assert_eq!(scenario.steps.len(), 1);
+        assert_eq!(
+            scenario.steps[0].expected_panic.as_deref(),
+            Some("index out of bounds")
+        );
+        assert!(scenario.steps[0].expected_error.is_none());
+    }
+
+    #[test]
+    fn test_backward_compat_no_error_fields() {
+        let toml_str = r#"
+            [[steps]]
+            function = "increment"
+            args = "[]"
+            expected_return = "1"
+        "#;
+
+        let scenario: Scenario = toml::from_str(toml_str).unwrap();
+        assert_eq!(scenario.steps.len(), 1);
+        assert!(scenario.steps[0].expected_error.is_none());
+        assert!(scenario.steps[0].expected_panic.is_none());
+        assert_eq!(scenario.steps[0].expected_return.as_deref(), Some("1"));
     }
 
     #[test]

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -512,26 +512,21 @@ impl DebugServer {
                                     }
                                 } else {
                                     // Try matching built-in state fields
-                                    let state_result =
-                                        engine.state().lock().ok().and_then(|state| {
-                                            match expression.as_str() {
-                                                "function" | "current_function" => {
-                                                    state.current_function().map(|f| {
-                                                        (f.to_string(), "string".to_string())
-                                                    })
-                                                }
-                                                "args" | "arguments" => {
-                                                    state.current_args().map(|a| {
-                                                        (a.to_string(), "string".to_string())
-                                                    })
-                                                }
-                                                "step_count" | "steps" => Some((
-                                                    state.step_count().to_string(),
-                                                    "number".to_string(),
-                                                )),
-                                                _ => None,
-                                            }
-                                        });
+                                    let state_result = engine.state().lock().ok().and_then(
+                                        |state| match expression.as_str() {
+                                            "function" | "current_function" => state
+                                                .current_function()
+                                                .map(|f| (f.to_string(), "string".to_string())),
+                                            "args" | "arguments" => state
+                                                .current_args()
+                                                .map(|a| (a.to_string(), "string".to_string())),
+                                            "step_count" | "steps" => Some((
+                                                state.step_count().to_string(),
+                                                "number".to_string(),
+                                            )),
+                                            _ => None,
+                                        },
+                                    );
 
                                     match state_result {
                                         Some((result, result_type)) => {
@@ -553,10 +548,7 @@ impl DebugServer {
                                 }
                             }
                             Err(e) => DebugResponse::Error {
-                                message: format!(
-                                    "Failed to access storage for evaluation: {}",
-                                    e
-                                ),
+                                message: format!("Failed to access storage for evaluation: {}", e),
                             },
                         }
                     }

--- a/tests/command_feature_tests.rs
+++ b/tests/command_feature_tests.rs
@@ -259,6 +259,93 @@ max_cpu_instructions = 0
 }
 
 #[test]
+fn scenario_passes_when_expected_error_matches() {
+    let wasm = fixture_wasm("counter");
+    let scenario = NamedTempFile::new().unwrap();
+    // Assuming `decrement` isn't a valid function and will fail
+    fs::write(
+        scenario.path(),
+        r#"
+[[steps]]
+name = "Should fail and match"
+function = "decrement"
+expected_error = "Invalid function name"
+"#,
+    )
+    .unwrap();
+
+    base_cmd()
+        .args([
+            "scenario",
+            "--scenario",
+            scenario.path().to_str().unwrap(),
+            "--contract",
+            wasm.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Expected error assertion passed"));
+}
+
+#[test]
+fn scenario_fails_when_expected_error_mismatches() {
+    let wasm = fixture_wasm("counter");
+    let scenario = NamedTempFile::new().unwrap();
+    fs::write(
+        scenario.path(),
+        r#"
+[[steps]]
+name = "Should error with wrong message"
+function = "decrement"
+expected_error = "Totally different error"
+"#,
+    )
+    .unwrap();
+
+    base_cmd()
+        .args([
+            "scenario",
+            "--scenario",
+            scenario.path().to_str().unwrap(),
+            "--contract",
+            wasm.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Expected error 'Totally different error', but got",
+        ));
+}
+
+#[test]
+fn scenario_fails_when_expected_to_fail_but_succeeds() {
+    let wasm = fixture_wasm("counter");
+    let scenario = NamedTempFile::new().unwrap();
+    fs::write(
+        scenario.path(),
+        r#"
+[[steps]]
+name = "Should fail but succeeds"
+function = "increment"
+expected_error = "unauthorized"
+"#,
+    )
+    .unwrap();
+
+    base_cmd()
+        .args([
+            "scenario",
+            "--scenario",
+            scenario.path().to_str().unwrap(),
+            "--contract",
+            wasm.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Step succeeded with"));
+}
+
+#[test]
 fn repl_accepts_commands_and_exits() {
     let wasm = fixture_wasm("counter");
     let output = Command::new(env!("CARGO_BIN_EXE_soroban-debug"))


### PR DESCRIPTION
### Add expected-error/panic assertions to scenarios (#362)

Extends the scenario schema to support [expected_error](cci:1://file:///home/rampop/drips/soroban-debugger/src/scenario.rs:435:4-452:5) and [expected_panic](cci:1://file:///home/rampop/drips/soroban-debugger/src/scenario.rs:454:4-470:5) assertions.

- **Failure Assertions**: If specified, an execution failure that matches the substring will now pass the step.
- **Improved Validation**: Steps fail if they succeed when a failure was expected, or if the failure message doesn't match.
- **Backward Compatible**: Existing success-only scenarios are unaffected.
- **Tests**: Added integration tests and updated the `simple-token` example for demonstration.

Closes #362
