### PR TITLE
ci(dev workflow): add automated man page sync check (#469)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,29 @@ jobs:
 
           exit "$status"
 
+  check-manpages:
+    name: Check man page sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-manpages-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-manpages-
+
+      - name: Check man pages are up to date
+        run: make check-man
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ Thank you for your interest in contributing to the **Soroban Debugger** project!
 9. [Issue Guidelines](#issue-guidelines)
 10. [Areas for Contribution](#areas-for-contribution)
 11. [Project Structure](#project-structure)
-12. [Code of Conduct](#code-of-conduct)
-13. [Communication](#communication)
+12. [Updating Man Pages](#updating-man-pages)
+13. [Code of Conduct](#code-of-conduct)
+14. [Communication](#communication)
 
 ---
 
@@ -257,6 +258,7 @@ Tips:
 - [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
 - [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
 - [ ] PR description mentions the related issue(s)
+- [ ] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed
 
 **Steps:**
 
@@ -344,6 +346,41 @@ If you have ideas outside these areas, feel free to discuss them by opening an i
 - `src/utils/` — Utility functions
 - `tests/` — Integration tests
 - `examples/` — Example usage
+
+---
+
+## Updating Man Pages
+
+Man pages in `man/man1/` are generated automatically from the CLI source via `build.rs` and `clap_mangen`. **Do not hand-edit `.1` files** — changes will be overwritten on the next regeneration.
+
+### When to regenerate
+
+Regenerate whenever you:
+- Add, remove, or rename a CLI subcommand
+- Add, remove, or rename a CLI flag or argument
+- Change any help text or description string
+
+### How to regenerate
+
+```bash
+make regen-man
+```
+
+Commit the updated `.1` files alongside your CLI changes in the same PR.
+
+### CI enforcement
+
+The `check-manpages` CI job runs on every PR and push to `main`. It regenerates man pages into a temp directory and diffs them against the committed versions. The job fails if any drift is detected — PRs cannot be merged with stale man pages.
+
+To verify locally before pushing:
+
+```bash
+# Regenerate from current source
+make regen-man
+
+# Verify in sync (should exit 0)
+make check-man
+```
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Soroban Debugger — developer convenience targets
+#
+# Targets:
+#   regen-man   Regenerate all man pages from current CLI source
+#   check-man   Verify committed man pages match generated output (used in CI)
+
+.PHONY: regen-man check-man
+
+# Regenerate all man pages from current CLI source.
+# Run after any CLI flag, subcommand, or help text change, then commit the .1 files.
+regen-man:
+	@echo "Regenerating man pages..."
+	cargo build --quiet
+	@echo "Man pages updated in man/man1/ — remember to commit the .1 files."
+
+# Verify committed man pages match generated output.
+# Exits non-zero with a diff if drift is detected.
+check-man:
+	@bash scripts/check_manpages.sh

--- a/build.rs
+++ b/build.rs
@@ -70,16 +70,23 @@ fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
 
 fn generate_man_pages() -> std::io::Result<()> {
     let cmd = Cli::command();
-    let repo_man_dir = Path::new("man").join("man1");
 
-    match render_to_dir(&cmd, &repo_man_dir) {
+    // Allow CI diff script to redirect output to a temp dir via MAN_OUT_DIR env var.
+    // Falls back to the committed man/man1 directory for normal builds.
+    let target_dir = if let Ok(override_dir) = std::env::var("MAN_OUT_DIR") {
+        std::path::PathBuf::from(override_dir)
+    } else {
+        Path::new("man").join("man1")
+    };
+
+    match render_to_dir(&cmd, &target_dir) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
             let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
             let fallback_dir = Path::new(&out_dir).join("man1");
             println!(
                 "cargo:warning=Cannot write man pages to {} (permission denied). Writing to {} instead.",
-                repo_man_dir.display(),
+                target_dir.display(),
                 fallback_dir.display()
             );
             render_to_dir(&cmd, &fallback_dir)

--- a/scripts/check_manpages.sh
+++ b/scripts/check_manpages.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regenerates man pages into a temp directory and diffs against committed versions.
+# Exits non-zero with a clear diff output if drift is detected.
+#
+# Usage: bash scripts/check_manpages.sh
+#   or:  make check-man
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMMITTED_DIR="$REPO_ROOT/man/man1"
+TEMP_DIR=$(mktemp -d)
+
+# Always clean up temp dir, even on failure or Ctrl-C
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+TEMP_MAN_DIR="$TEMP_DIR/man/man1"
+
+echo "Generating fresh man pages into $TEMP_DIR..."
+
+# MAN_OUT_DIR is read by build.rs to redirect man page output to a temp directory.
+# This avoids touching the committed man/man1/ during the diff check.
+MAN_OUT_DIR="$TEMP_MAN_DIR" cargo build --quiet 2>/dev/null
+
+if [ ! -d "$TEMP_MAN_DIR" ]; then
+    echo "❌ Man page generation failed: $TEMP_MAN_DIR was not created."
+    exit 2
+fi
+
+if [ ! -d "$COMMITTED_DIR" ]; then
+    echo "❌ Committed man page directory not found: $COMMITTED_DIR"
+    echo "   Run 'make regen-man' to generate and commit man pages."
+    exit 1
+fi
+
+echo "Diffing against committed man pages in $COMMITTED_DIR..."
+
+diff_output=$(diff -r "$COMMITTED_DIR" "$TEMP_MAN_DIR" 2>&1) || diff_status=$?
+diff_status=${diff_status:-0}
+
+if [ "$diff_status" -eq 0 ]; then
+    echo "✅ Man pages are in sync."
+    exit 0
+elif [ "$diff_status" -eq 1 ]; then
+    echo ""
+    echo "❌ Drift detected between committed man pages and current CLI source."
+    echo "   Run 'make regen-man' and commit the updated .1 files."
+    echo ""
+    echo "--- diff output ---"
+    echo "$diff_output"
+    exit 1
+else
+    echo "❌ diff exited with error (status $diff_status)."
+    echo "$diff_output"
+    exit 2
+fi


### PR DESCRIPTION
ci: add automated man page sync check

Problem
Man pages in man/man1/ were generated manually and had no enforcement preventing them from drifting out of sync when CLI flags, subcommands, or help text changed. Stale docs could ship undetected.

Solution
Wires man page generation into a deterministic, CI-enforced workflow so drift is caught automatically on every PR.

Changes
build.rs Added MAN_OUT_DIR env var support. When set, man pages are written to that path instead of man/man1/. This lets the CI diff script redirect generation to a temp directory without touching committed files.

check_manpages.sh
 (new) Generates fresh man pages into a temp dir via MAN_OUT_DIR, then diffs against the committed man/man1/. Exits 0 if in sync, 1 with diff output if drift is detected, 2 on error. Temp dir is always cleaned up via trap.

Makefile (new) Two targets:

make regen-man — regenerates and updates committed man pages
make check-man — runs the diff script (used by CI)
ci.yml
 Added check-manpages job that runs make check-man on every PR and push to main, with Cargo registry caching.

CONTRIBUTING.md Added "Updating Man Pages" section covering when to regenerate, how to run make regen-man, and how CI enforcement works. Added a checklist item to the PR template for CLI-touching changes.

Closes #469 
