### PR TITLE
Missing-auth

### DIFF
--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,4 +17,16 @@ Shell to generate completion script for
 .br
 
 .br
-[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+bash
+.IP \(bu 2
+elvish
+.IP \(bu 2
+fish
+.IP \(bu 2
+powershell
+.IP \(bu 2
+zsh
+.RE

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -26,7 +26,13 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-[\fIpossible values: \fRdot, mermaid]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+dot
+.IP \(bu 2
+mermaid
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -56,7 +56,13 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/src/analyzer/security.rs
+++ b/src/analyzer/security.rs
@@ -340,24 +340,44 @@ impl SecurityRule for AuthorizationCheckRule {
         trace: &[DynamicTraceEvent]
     ) -> Result<Vec<SecurityFinding>> {
         let mut findings = Vec::new();
-        let mut auth_seen = false;
-        let mut storage_write_seen = false;
+        let mut auth_sequence = None;
+        let mut problematic_storage_writes = Vec::new();
 
+        // First pass: find the earliest authorization event and any storage writes before it
         for entry in trace {
             if entry.kind == DynamicTraceEventKind::Authorization {
-                auth_seen = true;
-            }
-            if entry.kind == DynamicTraceEventKind::StorageWrite {
-                storage_write_seen = true;
+                // Record the earliest authorization event
+                match auth_sequence {
+                    None => auth_sequence = Some(entry.sequence),
+                    Some(current_auth_seq) => {
+                        if entry.sequence < current_auth_seq {
+                            auth_sequence = Some(entry.sequence);
+                        }
+                    }
+                }
+            } else if entry.kind == DynamicTraceEventKind::StorageWrite {
+                // Check if this storage write happens before any authorization
+                if let Some(auth_seq) = auth_sequence {
+                    if entry.sequence < auth_seq {
+                        problematic_storage_writes.push(entry.sequence);
+                    }
+                } else {
+                    // No auth seen yet, this storage write is problematic
+                    problematic_storage_writes.push(entry.sequence);
+                }
             }
         }
 
-        if storage_write_seen && !auth_seen {
+        // If we have storage writes without preceding auth, report a finding
+        if !problematic_storage_writes.is_empty() {
             findings.push(SecurityFinding {
                 rule_id: self.name().to_string(),
                 severity: Severity::High,
                 location: "Dynamic trace".to_string(),
-                description: "Storage mutation detected without an authorization event in the execution trace.".to_string(),
+                description: format!(
+                    "Storage mutation detected without preceding authorization. Found {} storage write(s) occurring before any authorization event.",
+                    problematic_storage_writes.len()
+                ),
                 remediation: "Ensure all sensitive functions call `address.require_auth()` before mutating state.".to_string(),
                 confidence: None,
                 context: None,
@@ -1353,5 +1373,144 @@ mod tests {
         assert!(!is_storage_read_import("not_env", "storage_get"));
         assert!(!is_storage_read_import("mylib", "storage_get"));
         assert!(!is_storage_read_import("environments", "storage_get"));
+    }
+
+    // -----------------------------------------------------------------------
+    // AuthorizationCheckRule — dynamic trace tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn auth_rule_detects_storage_before_auth() {
+        let rule = AuthorizationCheckRule;
+        
+        // Test case: storage write happens before authorization
+        let trace = vec![
+            DynamicTraceEvent {
+                sequence: 0,
+                kind: DynamicTraceEventKind::StorageWrite,
+                message: "write key1".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: Some("key1".to_string()),
+                storage_value: Some("value1".to_string()),
+                call_depth: 0,
+            },
+            DynamicTraceEvent {
+                sequence: 1,
+                kind: DynamicTraceEventKind::Authorization,
+                message: "auth check".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: None,
+                storage_value: None,
+                call_depth: 0,
+            },
+        ];
+
+        let findings = rule.analyze_dynamic(None, &trace).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "missing-auth");
+        assert!(findings[0].description.contains("1 storage write(s) occurring before any authorization event"));
+    }
+
+    #[test]
+    fn auth_rule_allows_storage_after_auth() {
+        let rule = AuthorizationCheckRule;
+        
+        // Test case: authorization happens before storage write (should be OK)
+        let trace = vec![
+            DynamicTraceEvent {
+                sequence: 0,
+                kind: DynamicTraceEventKind::Authorization,
+                message: "auth check".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: None,
+                storage_value: None,
+                call_depth: 0,
+            },
+            DynamicTraceEvent {
+                sequence: 1,
+                kind: DynamicTraceEventKind::StorageWrite,
+                message: "write key1".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: Some("key1".to_string()),
+                storage_value: Some("value1".to_string()),
+                call_depth: 0,
+            },
+        ];
+
+        let findings = rule.analyze_dynamic(None, &trace).unwrap();
+        assert_eq!(findings.len(), 0);
+    }
+
+    #[test]
+    fn auth_rule_detects_multiple_storage_before_auth() {
+        let rule = AuthorizationCheckRule;
+        
+        // Test case: multiple storage writes happen before authorization
+        let trace = vec![
+            DynamicTraceEvent {
+                sequence: 0,
+                kind: DynamicTraceEventKind::StorageWrite,
+                message: "write key1".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: Some("key1".to_string()),
+                storage_value: Some("value1".to_string()),
+                call_depth: 0,
+            },
+            DynamicTraceEvent {
+                sequence: 1,
+                kind: DynamicTraceEventKind::StorageWrite,
+                message: "write key2".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: Some("key2".to_string()),
+                storage_value: Some("value2".to_string()),
+                call_depth: 0,
+            },
+            DynamicTraceEvent {
+                sequence: 2,
+                kind: DynamicTraceEventKind::Authorization,
+                message: "auth check".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: None,
+                storage_value: None,
+                call_depth: 0,
+            },
+        ];
+
+        let findings = rule.analyze_dynamic(None, &trace).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "missing-auth");
+        assert!(findings[0].description.contains("2 storage write(s) occurring before any authorization event"));
+    }
+
+    #[test]
+    fn auth_rule_detects_storage_without_any_auth() {
+        let rule = AuthorizationCheckRule;
+        
+        // Test case: storage writes with no authorization at all
+        let trace = vec![
+            DynamicTraceEvent {
+                sequence: 0,
+                kind: DynamicTraceEventKind::StorageWrite,
+                message: "write key1".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: Some("key1".to_string()),
+                storage_value: Some("value1".to_string()),
+                call_depth: 0,
+            },
+            DynamicTraceEvent {
+                sequence: 1,
+                kind: DynamicTraceEventKind::StorageWrite,
+                message: "write key2".to_string(),
+                function: Some("test_function".to_string()),
+                storage_key: Some("key2".to_string()),
+                storage_value: Some("value2".to_string()),
+                call_depth: 0,
+            },
+        ];
+
+        let findings = rule.analyze_dynamic(None, &trace).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "missing-auth");
+        assert!(findings[0].description.contains("2 storage write(s) occurring before any authorization event"));
     }
 }


### PR DESCRIPTION
Closes #386

Problem Fixed: The AuthorizationCheckRule in src/analyzer/security.rs was only checking if ANY auth event existed anywhere in the trace, but not verifying that auth happened BEFORE storage writes.

Impact: Storage writes occurring before auth could be missed, creating a security vulnerability.

Solution Implemented:

Modified the analyze_dynamic method in AuthorizationCheckRule to track the sequence/timing of events:
Now tracks the earliest authorization event sequence number
Identifies storage writes that occur before any authorization
Reports findings with detailed count of problematic storage writes
Added comprehensive tests to verify the fix:
auth_rule_detects_storage_before_auth - detects storage before auth
auth_rule_allows_storage_after_auth - allows auth before storage (correct behavior)
auth_rule_detects_multiple_storage_before_auth - detects multiple problematic writes
auth_rule_detects_storage_without_any_auth - detects storage with no auth at all
Verification:

All new tests pass ✅
All existing security tests still pass ✅
Build succeeds with no errors ✅
No CLI errors ✅
The rule now correctly checks the temporal order of events in the trace, ensuring that authorization must precede any storage writes to be considered secure. This fixes the security gap where late authorization could mask earlier unauthorized storage mutations.