### PR TITLE
test: add regression coverage for remote client buffered stream reuse

### DIFF
--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -320,9 +320,10 @@ impl RemoteClient {
         let response = self.send_request(DebugRequest::ListBreakpoints)?;
 
         match response {
-            DebugResponse::BreakpointsList { breakpoints } => {
-                Ok(breakpoints.into_iter().map(|breakpoint| breakpoint.function).collect())
-            }
+            DebugResponse::BreakpointsList { breakpoints } => Ok(breakpoints
+                .into_iter()
+                .map(|breakpoint| breakpoint.function)
+                .collect()),
             DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
             _ => Err(DebuggerError::ExecutionError(
                 "Unexpected response to ListBreakpoints".to_string(),
@@ -472,6 +473,10 @@ impl Drop for RemoteClient {
 mod tests {
     use super::*;
     use crate::server::protocol::DebugResponse;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
 
     #[test]
     fn parse_response_line_rejects_mismatched_ids() {
@@ -493,6 +498,64 @@ mod tests {
     fn connect_failure_is_network_error_category() {
         let err = RemoteClient::connect("127.0.0.1:1", None).unwrap_err();
         assert!(err.to_string().contains("Network/transport error"));
+    }
+
+    #[test]
+    fn reuses_buffered_stream_across_rapid_requests() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let addr = listener.local_addr().expect("listener address");
+
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept client");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(3)))
+                .expect("set read timeout");
+
+            let read_stream = stream.try_clone().expect("clone stream for reader");
+            let mut reader = BufReader::new(read_stream);
+            let mut writer = stream;
+
+            for id in 1..=7 {
+                let mut request_line = String::new();
+                let bytes_read = reader.read_line(&mut request_line).expect("read request");
+                assert!(bytes_read > 0, "client closed before request {id}");
+
+                let request: DebugMessage =
+                    serde_json::from_str(&request_line).expect("parse request");
+                assert_eq!(request.id, id);
+
+                let response = match request.request.expect("request payload") {
+                    DebugRequest::Handshake { .. } => DebugMessage::response(
+                        request.id,
+                        DebugResponse::HandshakeAck {
+                            selected_version: PROTOCOL_MAX_VERSION,
+                            server_name: "test-server".to_string(),
+                            server_version: "0.0.0".to_string(),
+                        },
+                    ),
+                    DebugRequest::Ping => DebugMessage::response(request.id, DebugResponse::Pong),
+                    DebugRequest::Disconnect => {
+                        DebugMessage::response(request.id, DebugResponse::Disconnected)
+                    }
+                    other => panic!("unexpected request: {other:?}"),
+                };
+
+                let response_json = serde_json::to_string(&response).expect("serialize response");
+                writer
+                    .write_all(format!("{response_json}\n").as_bytes())
+                    .expect("write response");
+                writer.flush().expect("flush response");
+            }
+        });
+
+        let mut client = RemoteClient::connect(&addr.to_string(), None).expect("connect client");
+
+        for _ in 0..5 {
+            client.ping().expect("ping over persistent stream");
+        }
+
+        client.disconnect().expect("disconnect client");
+        server.join().expect("server thread");
     }
 
     #[test]


### PR DESCRIPTION

## Overview
This PR adds regression coverage for issue `#407` by verifying that the remote client can handle multiple rapid request/response exchanges over the same TCP stream without recreating buffered read state. The test protects the existing persistent `BufReader<TcpStream>` behavior so buffered bytes are not lost under streaming transport patterns.

## Related Issue
Closes #407

## Changes

### ⚙️ Remote Client Regression Coverage
- **[MODIFY]** `src/client/remote_client.rs`
  - Added a persistent streaming regression test for repeated requests on a single connection.
  - Simulated a lightweight server that handles the initial handshake, multiple rapid `Ping` requests, and `Disconnect`.
  - Verified request IDs continue increasing correctly across the same buffered stream.
  - Confirmed the client can reuse the same connection without dropped or blocked reads.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Remote client keeps working across multiple rapid requests on one stream | ✅ |
| Buffered read state is reused across request/response cycles | ✅ |
| Regression coverage exists for the streaming edge case described in the issue | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run the targeted regression test
cargo test reuses_buffered_stream_across_rapid_requests -- --nocapture

# 3. Optional: inspect the changed file
git diff -- src/client/remote_client.rs
```

## Screenshots

### ✅ Regression test passes
A screenshot of:

```bash
cargo test reuses_buffered_stream_across_rapid_requests -- --nocapture
```
<img width="683" height="385" alt="image" src="https://github.com/user-attachments/assets/b3cb435a-bcb7-4322-9150-cda2d0d7c13b" />
