### PR TITLE
feat(vscode): surface backend and protocol version in debug session s…

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -10,6 +10,7 @@ A Visual Studio Code extension that integrates the Soroban smart contract debugg
 - 🧵 **Thread Support**: Basic thread management for debugging sessions
 - 📝 **Detailed Logging**: Optional trace logging for debugging adapter interactions
 - ⚡ **Real-time Debugging**: Step through contract execution with next, step in, and step out
+- 🔢 **Session Version Info**: See active backend and protocol versions in the VS Code status bar during debugging
 
 ## Requirements
 
@@ -206,6 +207,14 @@ The extension consists of three main components:
 - TypeScript types for DAP events and commands
 - Debugger state management
 - Variable reference handling
+
+## Session Version Info
+
+During an active Soroban debug session, the status bar shows:
+
+`Soroban: v<backendVersion> | protocol <protocolVersion>`
+
+If the backend does not expose version fields, the extension displays `unknown` for the missing values.
 
 ## Troubleshooting
 

--- a/extensions/vscode/src/cli/debuggerProcess.ts
+++ b/extensions/vscode/src/cli/debuggerProcess.ts
@@ -34,6 +34,11 @@ export interface DebuggerContinueResult {
   paused: boolean;
 }
 
+export interface DebuggerSessionInfo {
+  backendVersion: string;
+  protocolVersion: string;
+}
+
 type DebugRequest =
   | { type: 'Authenticate'; token: string }
   | { type: 'LoadContract'; contract_path: string }
@@ -63,7 +68,7 @@ type DebugResponse =
   | { type: 'BreakpointSet'; function: string }
   | { type: 'BreakpointCleared'; function: string }
   | { type: 'EvaluateResult'; result: string; result_type?: string; variables_reference: number }
-  | { type: 'Pong' }
+  | { type: 'Pong'; backend_version?: string; protocol_version?: string }
   | { type: 'Disconnected' }
   | { type: 'Error'; message: string };
 
@@ -86,6 +91,10 @@ export class DebuggerProcess {
   private pendingRequests = new Map<number, PendingRequest>();
   private config: DebuggerProcessConfig;
   private port: number | null = null;
+  private sessionInfo: DebuggerSessionInfo = {
+    backendVersion: 'unknown',
+    protocolVersion: 'unknown'
+  };
 
   constructor(config: DebuggerProcessConfig) {
     this.config = config;
@@ -142,6 +151,9 @@ export class DebuggerProcess {
       contract_path: this.config.contractPath
     });
     this.expectResponse(contractResponse, 'ContractLoaded');
+
+    // Best-effort metadata fetch; do not fail startup if unavailable.
+    await this.captureSessionInfo();
   }
 
   async execute(): Promise<DebuggerExecutionResult> {
@@ -221,6 +233,11 @@ export class DebuggerProcess {
   async ping(): Promise<void> {
     const response = await this.sendRequest({ type: 'Ping' });
     this.expectResponse(response, 'Pong');
+    this.sessionInfo = extractSessionInfoFromPong(response);
+  }
+
+  getSessionInfo(): DebuggerSessionInfo {
+    return { ...this.sessionInfo };
   }
 
   async setBreakpoint(functionName: string): Promise<void> {
@@ -489,6 +506,19 @@ export class DebuggerProcess {
     return response;
   }
 
+  private async captureSessionInfo(): Promise<void> {
+    try {
+      const response = await this.sendRequest({ type: 'Ping' });
+      this.expectResponse(response, 'Pong');
+      this.sessionInfo = extractSessionInfoFromPong(response);
+    } catch {
+      this.sessionInfo = {
+        backendVersion: 'unknown',
+        protocolVersion: 'unknown'
+      };
+    }
+  }
+
   private rejectPendingRequests(error: Error): void {
     for (const pending of this.pendingRequests.values()) {
       pending.reject(error);
@@ -504,4 +534,11 @@ export class DebuggerProcess {
       throw new Error(`Unexpected debugger response: expected ${type}, got ${response.type}`);
     }
   }
+}
+
+export function extractSessionInfoFromPong(response: Extract<DebugResponse, { type: 'Pong' }>): DebuggerSessionInfo {
+  return {
+    backendVersion: response.backend_version || 'unknown',
+    protocolVersion: response.protocol_version || 'unknown'
+  };
 }

--- a/extensions/vscode/src/dap/adapter.ts
+++ b/extensions/vscode/src/dap/adapter.ts
@@ -5,7 +5,7 @@ import {
   ExitedEvent} from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as readline from 'readline';
-import { DebuggerProcess, DebuggerProcessConfig } from '../cli/debuggerProcess';
+import { DebuggerProcess, DebuggerProcessConfig, DebuggerSessionInfo } from '../cli/debuggerProcess';
 import { DebuggerState, Variable } from './protocol';
 import { ResolvedBreakpoint, resolveSourceBreakpoints } from './sourceBreakpoints';
 import { LogOutputEvent, LogLevel } from '@vscode/debugadapter/lib/logger';
@@ -29,6 +29,27 @@ export class SorobanDebugSession extends DebugSession {
   private exportedFunctions = new Set<string>();
   private sourceFunctionBreakpoints = new Map<string, Set<string>>();
   private functionBreakpointRefCounts = new Map<string, number>();
+  private sessionInfo: DebuggerSessionInfo = {
+    backendVersion: 'unknown',
+    protocolVersion: 'unknown'
+  };
+  private readonly onSessionInfoUpdated?: (info: DebuggerSessionInfo) => void;
+
+  constructor(
+    obsoleteDebuggerLinesAndColumnsStartAt1OrCallback?: boolean | ((info: DebuggerSessionInfo) => void),
+    obsoleteIsServer?: boolean
+  ) {
+    super(
+      typeof obsoleteDebuggerLinesAndColumnsStartAt1OrCallback === 'boolean'
+        ? obsoleteDebuggerLinesAndColumnsStartAt1OrCallback
+        : undefined,
+      obsoleteIsServer
+    );
+    this.onSessionInfoUpdated =
+      typeof obsoleteDebuggerLinesAndColumnsStartAt1OrCallback === 'function'
+        ? obsoleteDebuggerLinesAndColumnsStartAt1OrCallback
+        : undefined;
+  }
 
   protected initializeRequest(
     response: DebugProtocol.InitializeResponse,
@@ -70,6 +91,8 @@ export class SorobanDebugSession extends DebugSession {
       this.variableHandles.clear();
       this.nextVarHandle = 1;
       this.exportedFunctions = await this.debuggerProcess.getContractFunctions();
+      this.sessionInfo = this.debuggerProcess.getSessionInfo();
+      this.onSessionInfoUpdated?.(this.sessionInfo);
 
       this.attachProcessListeners();
       this.sendResponse(response);
@@ -611,5 +634,13 @@ export class SorobanDebugSession extends DebugSession {
     this.hasExecuted = false;
     this.sourceFunctionBreakpoints.clear();
     this.functionBreakpointRefCounts.clear();
+    this.sessionInfo = {
+      backendVersion: 'unknown',
+      protocolVersion: 'unknown'
+    };
+  }
+
+  public getSessionInfo(): DebuggerSessionInfo {
+    return { ...this.sessionInfo };
   }
 }

--- a/extensions/vscode/src/debug/adapter.ts
+++ b/extensions/vscode/src/debug/adapter.ts
@@ -1,12 +1,16 @@
 import * as vscode from 'vscode';
 import { DebugAdapterDescriptor, DebugAdapterInlineImplementation } from 'vscode';
 import { SorobanDebugSession } from '../dap/adapter';
+import { DebuggerSessionInfo } from '../cli/debuggerProcess';
 
 export class SorobanDebugAdapterDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory, vscode.Disposable {
 
   private context: vscode.ExtensionContext;
-  private session: SorobanDebugSession | null = null;
+  private sessions = new Map<string, SorobanDebugSession>();
+  private sessionInfo = new Map<string, DebuggerSessionInfo>();
+  private readonly onSessionInfoEmitter = new vscode.EventEmitter<{ sessionId: string; info: DebuggerSessionInfo }>();
+  public readonly onSessionInfo = this.onSessionInfoEmitter.event;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
@@ -16,11 +20,26 @@ export class SorobanDebugAdapterDescriptorFactory
     session: vscode.DebugSession,
     executable: vscode.DebugAdapterExecutable | undefined
   ): Promise<DebugAdapterDescriptor | null> {
-    this.session = new SorobanDebugSession();
-    return new DebugAdapterInlineImplementation(this.session);
+    const debugSession = new SorobanDebugSession((info) => {
+      this.sessionInfo.set(session.id, info);
+      this.onSessionInfoEmitter.fire({ sessionId: session.id, info });
+    });
+    this.sessions.set(session.id, debugSession);
+    return new DebugAdapterInlineImplementation(debugSession);
+  }
+
+  getSessionInfo(sessionId: string): DebuggerSessionInfo | undefined {
+    return this.sessionInfo.get(sessionId);
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+    this.sessionInfo.delete(sessionId);
   }
 
   dispose(): void {
-    this.session = null;
+    this.sessions.clear();
+    this.sessionInfo.clear();
+    this.onSessionInfoEmitter.dispose();
   }
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,12 +1,53 @@
 import * as vscode from 'vscode';
 import { SorobanDebugAdapterDescriptorFactory } from './debug/adapter';
+import { DebuggerSessionInfo } from './cli/debuggerProcess';
 
 export function activate(context: vscode.ExtensionContext): void {
   const factory = new SorobanDebugAdapterDescriptorFactory(context);
+  const statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  statusItem.name = 'Soroban Debug Session Info';
+  statusItem.hide();
+
+  const applySessionInfo = (info: DebuggerSessionInfo): void => {
+    const text = `Soroban: v${info.backendVersion} | protocol ${info.protocolVersion}`;
+    statusItem.text = text;
+    statusItem.tooltip = text;
+    statusItem.show();
+  };
 
   context.subscriptions.push(
     vscode.debug.registerDebugAdapterDescriptorFactory('soroban', factory),
-    factory
+    vscode.debug.onDidStartDebugSession((session) => {
+      if (session.type !== 'soroban') {
+        return;
+      }
+
+      applySessionInfo({
+        backendVersion: 'unknown',
+        protocolVersion: 'unknown'
+      });
+
+      const info = factory.getSessionInfo(session.id);
+      if (info) {
+        applySessionInfo(info);
+      }
+    }),
+    factory.onSessionInfo(({ sessionId, info }) => {
+      const active = vscode.debug.activeDebugSession;
+      if (!active || active.type !== 'soroban' || active.id !== sessionId) {
+        return;
+      }
+      applySessionInfo(info);
+    }),
+    vscode.debug.onDidTerminateDebugSession((session) => {
+      if (session.type !== 'soroban') {
+        return;
+      }
+      factory.clearSession(session.id);
+      statusItem.hide();
+    }),
+    factory,
+    statusItem
   );
 }
 

--- a/extensions/vscode/src/test/runTest.ts
+++ b/extensions/vscode/src/test/runTest.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { DebuggerProcess } from '../cli/debuggerProcess';
+import { DebuggerProcess, extractSessionInfoFromPong } from '../cli/debuggerProcess';
 import { resolveSourceBreakpoints } from '../dap/sourceBreakpoints';
 
 async function main(): Promise<void> {
@@ -38,6 +38,13 @@ async function main(): Promise<void> {
 
   await debuggerProcess.start();
   await debuggerProcess.ping();
+  const sessionInfo = debuggerProcess.getSessionInfo();
+  assert.ok(sessionInfo.backendVersion.length > 0, 'Expected backend version to be populated');
+  assert.ok(sessionInfo.protocolVersion.length > 0, 'Expected protocol version to be populated');
+
+  const fallbackInfo = extractSessionInfoFromPong({ type: 'Pong' });
+  assert.equal(fallbackInfo.backendVersion, 'unknown', 'Expected missing backend version to fallback to unknown');
+  assert.equal(fallbackInfo.protocolVersion, 'unknown', 'Expected missing protocol version to fallback to unknown');
 
   const sourcePath = path.join(repoRoot, 'tests', 'fixtures', 'contracts', 'echo', 'src', 'lib.rs');
   const exportedFunctions = await debuggerProcess.getContractFunctions();

--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -334,7 +334,7 @@ impl RemoteClient {
         let response = self.send_request(DebugRequest::Ping)?;
 
         match response {
-            DebugResponse::Pong => {
+            DebugResponse::Pong { .. } => {
                 info!("Server responded to ping");
                 Ok(())
             }
@@ -425,7 +425,13 @@ mod tests {
 
     #[test]
     fn parse_response_line_rejects_mismatched_ids() {
-        let msg = DebugMessage::response(42, DebugResponse::Pong);
+        let msg = DebugMessage::response(
+            42,
+            DebugResponse::Pong {
+                backend_version: Some("0.1.0".to_string()),
+                protocol_version: Some("1".to_string()),
+            },
+        );
         let line = serde_json::to_string(&msg).unwrap();
         let err = parse_response_line(7, &line).unwrap_err();
         assert!(err.to_string().contains("Mismatched response id"));
@@ -433,10 +439,16 @@ mod tests {
 
     #[test]
     fn parse_response_line_accepts_matching_ids() {
-        let msg = DebugMessage::response(7, DebugResponse::Pong);
+        let msg = DebugMessage::response(
+            7,
+            DebugResponse::Pong {
+                backend_version: Some("0.1.0".to_string()),
+                protocol_version: Some("1".to_string()),
+            },
+        );
         let line = serde_json::to_string(&msg).unwrap();
         let resp = parse_response_line(7, &line).unwrap();
-        assert!(matches!(resp, DebugResponse::Pong));
+        assert!(matches!(resp, DebugResponse::Pong { .. }));
     }
 
     #[test]

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -1,6 +1,8 @@
 use crate::debugger::engine::DebuggerEngine;
 use crate::inspector::budget::BudgetInspector;
-use crate::server::protocol::{DebugMessage, DebugRequest, DebugResponse};
+use crate::server::protocol::{
+    DebugMessage, DebugRequest, DebugResponse, DEBUG_PROTOCOL_VERSION,
+};
 use crate::simulator::SnapshotLoader;
 use crate::Result;
 use std::fs;
@@ -112,7 +114,13 @@ impl DebugServer {
             info!("Received request: {:?}", request);
 
             if matches!(request, DebugRequest::Ping) {
-                let response = DebugMessage::response(message.id, DebugResponse::Pong);
+                let response = DebugMessage::response(
+                    message.id,
+                    DebugResponse::Pong {
+                        backend_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                        protocol_version: Some(DEBUG_PROTOCOL_VERSION.to_string()),
+                    },
+                );
                 send_response(&mut writer, response).await?;
                 continue;
             }
@@ -596,7 +604,10 @@ impl DebugServer {
                             .to_string(),
                     },
                 },
-                DebugRequest::Ping => DebugResponse::Pong,
+                DebugRequest::Ping => DebugResponse::Pong {
+                    backend_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                    protocol_version: Some(DEBUG_PROTOCOL_VERSION.to_string()),
+                },
                 DebugRequest::Disconnect => DebugResponse::Disconnected,
             };
 

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+pub const DEBUG_PROTOCOL_VERSION: &str = "1";
+
 /// Structured event category used by dynamic security analysis.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum DynamicTraceEventKind {
@@ -182,8 +184,13 @@ pub enum DebugResponse {
         variables_reference: u64,
     },
 
-    /// Pong response
-    Pong,
+    /// Pong response with optional version metadata.
+    ///
+    /// Fields are optional for backward compatibility with older clients/servers.
+    Pong {
+        backend_version: Option<String>,
+        protocol_version: Option<String>,
+    },
 
     /// Disconnected
     Disconnected,


### PR DESCRIPTION
## Summary
Expose backend and protocol version details in the VS Code UI during active debug sessions.

## Changes
- Extend `Pong` response with optional `backend_version` and `protocol_version`
- Capture session info in `DebuggerProcess` with fallback to `unknown`
- Display version info in the VS Code status bar during debug sessions
- Reset status bar on session end
- Add minimal tests and README update

## Before
Version details were not visible during a debug session.

## After
Status bar shows:
`Soroban: v<backendVersion> | protocol <protocolVersion>`

## Compatibility
Backward compatible (missing fields fall back to `unknown`)

Closes #534 