### PR TITLE
feat: Add VS Code session version info display

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -12,6 +12,7 @@ A Visual Studio Code extension that integrates the Soroban smart contract debugg
 - 🧵 **Thread Support**: Basic thread management for debugging sessions
 - 📝 **Detailed Logging**: Optional trace logging for debugging adapter interactions
 - ⚡ **Real-time Debugging**: Step through contract execution with next, step in, and step out
+- 🔢 **Session Version Info**: See active backend and protocol versions in the VS Code status bar during debugging
 
 ## Requirements
 
@@ -25,22 +26,26 @@ A Visual Studio Code extension that integrates the Soroban smart contract debugg
 ### From Source
 
 1. Clone the soroban-debugger repository:
+
 ```bash
 git clone https://github.com/stellar/soroban-debugger.git
 cd soroban-debugger
 ```
 
 2. Navigate to the extension directory:
+
 ```bash
 cd extensions/vscode
 ```
 
 3. Install dependencies:
+
 ```bash
 npm install
 ```
 
 4. Compile the extension:
+
 ```bash
 npm run compile
 ```
@@ -195,35 +200,35 @@ The following features are **not available** in the extension.
 
 ### Not supported in the extension
 
-| CLI feature | CLI flag | Workaround |
-|---|---|---|
-| Instruction-level stepping | `--instruction-debug`, `--step-instructions`, `--step-mode [block]` | Use `soroban-debug interactive --instruction-debug` in a terminal |
-| Storage key filtering | `--storage-filter <pattern>` | All storage is shown unfiltered in the Variables panel; filter via CLI |
-| Auth tree display | `--show-auth` | Use `soroban-debug run --show-auth` in a terminal |
-| Batch execution | `--batch-args <file>`, `--repeat N` | Use `soroban-debug run --batch-args` in a terminal |
-| Remote client mode | `soroban-debug remote --remote host:port` | Use CLI; see [Remote Debugging](../../docs/remote-debugging.md) |
-| TLS configuration | `--tls-cert`, `--tls-key` | Use CLI server/remote commands directly |
-| Storage export | `--export-storage <file>` | Use `soroban-debug run --export-storage` in a terminal |
-| Storage import | `--import-storage <file>` | Use `snapshotPath` in `launch.json` for initial state |
-| Event display and filtering | `--show-events`, `--event-filter` | Use `soroban-debug run --show-events` in a terminal |
-| Dry-run mode | `--dry-run` | Use `soroban-debug run --dry-run` in a terminal |
-| Cross-contract mocking | `--mock CONTRACT.fn=value` | Use `soroban-debug run --mock` in a terminal |
-| Conditional breakpoints | (not in CLI either) | Not supported on either surface |
-| Hit-count conditions | (not in CLI either) | Not supported on either surface |
-| Log points | (not in CLI either) | Not supported on either surface |
-| Analysis subcommands | `analyze`, `symbolic`, `optimize`, `profile`, `compare`, `replay`, `upgrade-check`, `scenario` | Use CLI subcommands directly |
+| CLI feature                 | CLI flag                                                                                       | Workaround                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Instruction-level stepping  | `--instruction-debug`, `--step-instructions`, `--step-mode [block]`                            | Use `soroban-debug interactive --instruction-debug` in a terminal      |
+| Storage key filtering       | `--storage-filter <pattern>`                                                                   | All storage is shown unfiltered in the Variables panel; filter via CLI |
+| Auth tree display           | `--show-auth`                                                                                  | Use `soroban-debug run --show-auth` in a terminal                      |
+| Batch execution             | `--batch-args <file>`, `--repeat N`                                                            | Use `soroban-debug run --batch-args` in a terminal                     |
+| Remote client mode          | `soroban-debug remote --remote host:port`                                                      | Use CLI; see [Remote Debugging](../../docs/remote-debugging.md)        |
+| TLS configuration           | `--tls-cert`, `--tls-key`                                                                      | Use CLI server/remote commands directly                                |
+| Storage export              | `--export-storage <file>`                                                                      | Use `soroban-debug run --export-storage` in a terminal                 |
+| Storage import              | `--import-storage <file>`                                                                      | Use `snapshotPath` in `launch.json` for initial state                  |
+| Event display and filtering | `--show-events`, `--event-filter`                                                              | Use `soroban-debug run --show-events` in a terminal                    |
+| Dry-run mode                | `--dry-run`                                                                                    | Use `soroban-debug run --dry-run` in a terminal                        |
+| Cross-contract mocking      | `--mock CONTRACT.fn=value`                                                                     | Use `soroban-debug run --mock` in a terminal                           |
+| Conditional breakpoints     | (not in CLI either)                                                                            | Not supported on either surface                                        |
+| Hit-count conditions        | (not in CLI either)                                                                            | Not supported on either surface                                        |
+| Log points                  | (not in CLI either)                                                                            | Not supported on either surface                                        |
+| Analysis subcommands        | `analyze`, `symbolic`, `optimize`, `profile`, `compare`, `replay`, `upgrade-check`, `scenario` | Use CLI subcommands directly                                           |
 
 ### Supported in the extension
 
-| Feature | Details |
-|---|---|
-| Step in / over / out | F11, F10, Shift+F11 |
-| Continue | F5 |
-| Breakpoints | Set by clicking source line; resolves to the enclosing exported function boundary |
-| Variable inspection — storage | Shown in the Variables panel (Storage scope) when paused |
-| Variable inspection — arguments | Shown in the Variables panel (Arguments scope) when paused |
-| Call stack | Up to 50 frames, clickable to navigate to frame source |
-| Expression evaluation | Debug Console when paused; hover evaluation over identifiers |
+| Feature                         | Details                                                                           |
+| ------------------------------- | --------------------------------------------------------------------------------- |
+| Step in / over / out            | F11, F10, Shift+F11                                                               |
+| Continue                        | F5                                                                                |
+| Breakpoints                     | Set by clicking source line; resolves to the enclosing exported function boundary |
+| Variable inspection — storage   | Shown in the Variables panel (Storage scope) when paused                          |
+| Variable inspection — arguments | Shown in the Variables panel (Arguments scope) when paused                        |
+| Call stack                      | Up to 50 frames, clickable to navigate to frame source                            |
+| Expression evaluation           | Debug Console when paused; hover evaluation over identifiers                      |
 
 For the full feature comparison, see [docs/feature-matrix.md](../../docs/feature-matrix.md).
 
@@ -279,21 +284,25 @@ The extension now maintains persistent, structured logs for all debug sessions. 
 The extension consists of three main components:
 
 ### Extension Host (extension.ts)
+
 - Initializes the extension
 - Registers the debug adapter factory
 - Manages extension lifecycle
 
 ### Debug Adapter (src/dap/adapter.ts)
+
 - Implements the Debug Adapter Protocol
 - Handles breakpoints, stepping, and variable inspection
 - Manages debug session state
 
 ### CLI Process Wrapper (src/cli/debuggerProcess.ts)
+
 - Spawns the `soroban-debug server` process
 - Connects to the remote debug protocol over TCP
 - Handles process lifecycle and request/response transport
 
 ### Protocol Types (src/dap/protocol.ts)
+
 - TypeScript types for DAP events and commands
 - Debugger state management
 - Variable reference handling

--- a/extensions/vscode/src/cli/debuggerProcess.ts
+++ b/extensions/vscode/src/cli/debuggerProcess.ts
@@ -1,9 +1,12 @@
-import { ChildProcess, execFile, spawn } from 'child_process';
-import * as fs from 'fs';
-import * as net from 'net';
-import * as path from 'path';
-import { WIRE_PROTOCOL_MAX_VERSION, WIRE_PROTOCOL_MIN_VERSION } from '../dap/protocol';
-import { LogManager, LogLevel, LogPhase } from '../debug/logManager';
+import { ChildProcess, execFile, spawn } from "child_process";
+import * as fs from "fs";
+import * as net from "net";
+import * as path from "path";
+import {
+  WIRE_PROTOCOL_MAX_VERSION,
+  WIRE_PROTOCOL_MIN_VERSION,
+} from "../dap/protocol";
+import { LogManager, LogLevel, LogPhase } from "../debug/logManager";
 
 export interface DebuggerProcessConfig {
   contractPath: string;
@@ -23,6 +26,11 @@ export interface DebuggerProcessConfig {
    * Intended for tests and advanced embedding.
    */
   spawnServer?: boolean;
+}
+
+export interface DebuggerSessionInfo {
+  backendVersion: string;
+  protocolVersion: string;
 }
 
 export interface DebuggerExecutionResult {
@@ -52,15 +60,22 @@ export interface BackendBreakpointCapabilities {
 }
 
 export type LaunchPreflightQuickFix =
-  | 'pickBinary'
-  | 'pickContract'
-  | 'pickSnapshot'
-  | 'openLaunchConfig'
-  | 'generateLaunchConfig'
-  | 'openSettings';
+  | "pickBinary"
+  | "pickContract"
+  | "pickSnapshot"
+  | "openLaunchConfig"
+  | "generateLaunchConfig"
+  | "openSettings";
 
 export interface LaunchPreflightIssue {
-  field: 'binaryPath' | 'contractPath' | 'snapshotPath' | 'entrypoint' | 'args' | 'port' | 'token';
+  field:
+    | "binaryPath"
+    | "contractPath"
+    | "snapshotPath"
+    | "entrypoint"
+    | "args"
+    | "port"
+    | "token";
   message: string;
   expected: string;
   quickFixes: LaunchPreflightQuickFix[];
@@ -82,83 +97,171 @@ type ProtocolMismatchDetails = {
 };
 
 export class DebuggerTimeoutError extends Error {
-  name = 'TimeoutError';
+  name = "TimeoutError";
 
   constructor(
     public readonly requestType: string,
-    public readonly timeoutMs: number
+    public readonly timeoutMs: number,
   ) {
     super(`${requestType} timed out after ${timeoutMs}ms`);
   }
 }
 
-export function formatProtocolMismatchMessage(details: ProtocolMismatchDetails): string {
-  const backendName = details.backendName ?? 'soroban-debug';
-  const backendVersion = details.backendVersion ?? 'unknown';
-  const backendProtocol = details.backendProtocolMin !== undefined && details.backendProtocolMax !== undefined
-    ? `[${details.backendProtocolMin}..=${details.backendProtocolMax}]`
-    : 'unknown';
+export function formatProtocolMismatchMessage(
+  details: ProtocolMismatchDetails,
+): string {
+  const backendName = details.backendName ?? "soroban-debug";
+  const backendVersion = details.backendVersion ?? "unknown";
+  const backendProtocol =
+    details.backendProtocolMin !== undefined &&
+    details.backendProtocolMax !== undefined
+      ? `[${details.backendProtocolMin}..=${details.backendProtocolMax}]`
+      : "unknown";
 
   const extra = details.extra?.trim();
-  const extraLine = extra ? `\nDetails: ${extra}` : '';
+  const extraLine = extra ? `\nDetails: ${extra}` : "";
 
   return [
-    'Soroban debugger protocol negotiation failed.',
+    "Soroban debugger protocol negotiation failed.",
     `Extension version: ${details.extensionVersion} (supports protocol [${WIRE_PROTOCOL_MIN_VERSION}..=${WIRE_PROTOCOL_MAX_VERSION}]).`,
     `Backend: ${backendName} ${backendVersion} (supports protocol ${backendProtocol}).`,
-    'Remediation: rebuild or reinstall the VS Code extension and the soroban-debug backend so they come from the same revision.',
-    extraLine
-  ].filter((line) => line.length > 0).join('\n');
+    "Remediation: rebuild or reinstall the VS Code extension and the soroban-debug backend so they come from the same revision.",
+    extraLine,
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+export function extractSessionInfoFromPong(response: {
+  backend_version?: string;
+  protocol_version?: string;
+}): DebuggerSessionInfo {
+  return {
+    backendVersion: response.backend_version ?? "unknown",
+    protocolVersion: response.protocol_version ?? "unknown",
+  };
 }
 
 type DebugRequest =
-  | { type: 'Handshake'; client_name: string; client_version: string; protocol_min: number; protocol_max: number }
-  | { type: 'Authenticate'; token: string }
-  | { type: 'LoadContract'; contract_path: string }
-  | { type: 'Execute'; function: string; args?: string }
-  | { type: 'StepIn' }
-  | { type: 'Next' }
-  | { type: 'StepOut' }
-  | { type: 'Continue' }
-  | { type: 'Inspect' }
-  | { type: 'GetStorage' }
-  | { type: 'SetBreakpoint'; function: string }
-  | { type: 'ClearBreakpoint'; function: string }
-  | { type: 'ResolveSourceBreakpoints'; source_path: string; lines: number[]; exported_functions: string[] }
-  | { type: 'Evaluate'; expression: string; frame_id?: number }
-  | { type: 'Ping' }
-  | { type: 'Disconnect' }
-  | { type: 'LoadSnapshot'; snapshot_path: string }
-  | { type: 'GetCapabilities' }
-  | { type: 'Unknown' };
+  | {
+      type: "Handshake";
+      client_name: string;
+      client_version: string;
+      protocol_min: number;
+      protocol_max: number;
+    }
+  | { type: "Authenticate"; token: string }
+  | { type: "LoadContract"; contract_path: string }
+  | { type: "Execute"; function: string; args?: string }
+  | { type: "StepIn" }
+  | { type: "Next" }
+  | { type: "StepOut" }
+  | { type: "Continue" }
+  | { type: "Inspect" }
+  | { type: "GetStorage" }
+  | {
+      type: "SetBreakpoint";
+      id: string;
+      function: string;
+      condition?: string;
+      hit_condition?: string;
+      log_message?: string;
+    }
+  | { type: "ClearBreakpoint"; id: string }
+  | {
+      type: "ResolveSourceBreakpoints";
+      source_path: string;
+      lines: number[];
+      exported_functions: string[];
+    }
+  | { type: "Evaluate"; expression: string; frame_id?: number }
+  | { type: "Ping" }
+  | { type: "Disconnect" }
+  | { type: "LoadSnapshot"; snapshot_path: string }
+  | { type: "GetCapabilities" }
+  | { type: "Unknown" };
 
 type DebugResponse =
-  | { type: 'HandshakeAck'; server_name: string; server_version: string; protocol_min: number; protocol_max: number; selected_version: number }
-  | { type: 'IncompatibleProtocol'; message: string; server_name: string; server_version: string; protocol_min: number; protocol_max: number }
-  | { type: 'Authenticated'; success: boolean; message: string }
-  | { type: 'ContractLoaded'; size: number }
-  | { type: 'ExecutionResult'; success: boolean; output: string; error?: string; paused: boolean; completed: boolean }
-  | { type: 'StepResult'; paused: boolean; current_function?: string; step_count: number }
-  | { type: 'ContinueResult'; completed: boolean; output?: string; error?: string; paused: boolean }
-  | { type: 'InspectionResult'; function?: string; args?: string; step_count: number; paused: boolean; call_stack: string[] }
-  | { type: 'StorageState'; storage_json: string }
-  | { type: 'SnapshotLoaded'; summary: string }
-  | { type: 'BreakpointSet'; function: string }
-  | { type: 'BreakpointCleared'; function: string }
-  | { type: 'SourceBreakpointsResolved'; breakpoints: Array<{ requested_line: number; line: number; verified: boolean; function?: string; reason_code: string; message: string }> }
-  | { type: 'EvaluateResult'; result: string; result_type?: string; variables_reference: number }
   | {
-      type: 'Capabilities';
+      type: "HandshakeAck";
+      server_name: string;
+      server_version: string;
+      protocol_min: number;
+      protocol_max: number;
+      selected_version: number;
+    }
+  | {
+      type: "IncompatibleProtocol";
+      message: string;
+      server_name: string;
+      server_version: string;
+      protocol_min: number;
+      protocol_max: number;
+    }
+  | { type: "Authenticated"; success: boolean; message: string }
+  | { type: "ContractLoaded"; size: number }
+  | {
+      type: "ExecutionResult";
+      success: boolean;
+      output: string;
+      error?: string;
+      paused: boolean;
+      completed: boolean;
+    }
+  | {
+      type: "StepResult";
+      paused: boolean;
+      current_function?: string;
+      step_count: number;
+    }
+  | {
+      type: "ContinueResult";
+      completed: boolean;
+      output?: string;
+      error?: string;
+      paused: boolean;
+    }
+  | {
+      type: "InspectionResult";
+      function?: string;
+      args?: string;
+      step_count: number;
+      paused: boolean;
+      call_stack: string[];
+    }
+  | { type: "StorageState"; storage_json: string }
+  | { type: "SnapshotLoaded"; summary: string }
+  | { type: "BreakpointSet"; function: string }
+  | { type: "BreakpointCleared"; function: string }
+  | {
+      type: "SourceBreakpointsResolved";
+      breakpoints: Array<{
+        requested_line: number;
+        line: number;
+        verified: boolean;
+        function?: string;
+        reason_code: string;
+        message: string;
+      }>;
+    }
+  | {
+      type: "EvaluateResult";
+      result: string;
+      result_type?: string;
+      variables_reference: number;
+    }
+  | {
+      type: "Capabilities";
       breakpoints: {
         conditional_breakpoints: boolean;
         hit_conditional_breakpoints: boolean;
         log_points: boolean;
       };
     }
-  | { type: 'Pong' }
-  | { type: 'Disconnected' }
-  | { type: 'Unknown' }
-  | { type: 'Error'; message: string };
+  | { type: "Pong"; backend_version?: string; protocol_version?: string }
+  | { type: "Disconnected" }
+  | { type: "Unknown" }
+  | { type: "Error"; message: string };
 
 type DebugMessage = {
   id: number;
@@ -178,8 +281,8 @@ type RequestOptions = {
 };
 
 class RequestAbortedError extends Error {
-  name = 'AbortError';
-  constructor(message = 'Request aborted') {
+  name = "AbortError";
+  constructor(message = "Request aborted") {
     super(message);
   }
 }
@@ -187,7 +290,7 @@ class RequestAbortedError extends Error {
 export class DebuggerProcess {
   private childProcess: ChildProcess | null = null;
   private socket: net.Socket | null = null;
-  private buffer = '';
+  private buffer = "";
   private requestId = 0;
   private pendingRequests = new Map<number, PendingRequest>();
   private config: DebuggerProcessConfig;
@@ -196,21 +299,33 @@ export class DebuggerProcess {
   private negotiatedProtocolVersion: number | null = null;
   private defaultRequestTimeoutMs: number;
   private defaultConnectTimeoutMs: number;
+  private sessionInfo: DebuggerSessionInfo = {
+    backendVersion: "unknown",
+    protocolVersion: "unknown",
+  };
 
   constructor(config: DebuggerProcessConfig, logManager?: LogManager) {
     this.config = config;
     this.logManager = logManager;
 
-    const envRequestTimeout = Number(process.env.SOROBAN_DEBUG_REQUEST_TIMEOUT_MS);
-    const envConnectTimeout = Number(process.env.SOROBAN_DEBUG_CONNECT_TIMEOUT_MS);
+    const envRequestTimeout = Number(
+      process.env.SOROBAN_DEBUG_REQUEST_TIMEOUT_MS,
+    );
+    const envConnectTimeout = Number(
+      process.env.SOROBAN_DEBUG_CONNECT_TIMEOUT_MS,
+    );
 
     this.defaultRequestTimeoutMs = Number.isFinite(config.requestTimeoutMs)
       ? Number(config.requestTimeoutMs)
-      : (Number.isFinite(envRequestTimeout) ? envRequestTimeout : 30_000);
+      : Number.isFinite(envRequestTimeout)
+        ? envRequestTimeout
+        : 30_000;
 
     this.defaultConnectTimeoutMs = Number.isFinite(config.connectTimeoutMs)
       ? Number(config.connectTimeoutMs)
-      : (Number.isFinite(envConnectTimeout) ? envConnectTimeout : 10_000);
+      : Number.isFinite(envConnectTimeout)
+        ? envConnectTimeout
+        : 10_000;
   }
 
   async start(): Promise<void> {
@@ -219,64 +334,92 @@ export class DebuggerProcess {
     }
 
     const shouldSpawnServer = this.config.spawnServer !== false;
-    const binaryPath = shouldSpawnServer ? resolveDebuggerBinaryPath(this.config) : null;
-    const port = this.config.port ?? await this.findAvailablePort();
+    const binaryPath = shouldSpawnServer
+      ? resolveDebuggerBinaryPath(this.config)
+      : null;
+    const port = this.config.port ?? (await this.findAvailablePort());
     this.port = port;
 
     if (shouldSpawnServer) {
       const child = spawn(binaryPath as string, this.buildArgs(port), {
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ["ignore", "pipe", "pipe"],
         env: {
           ...process.env,
-          ...(this.config.trace ? { RUST_LOG: 'debug' } : {})
-        }
+          ...(this.config.trace ? { RUST_LOG: "debug" } : {}),
+        },
       });
       this.childProcess = child;
 
-      child.once('exit', () => {
-        this.rejectPendingRequests(new Error('Debugger server exited'));
+      child.once("exit", () => {
+        this.rejectPendingRequests(new Error("Debugger server exited"));
         this.socket?.destroy();
         this.socket = null;
       });
     } else if (!this.config.port) {
-      throw new Error('DebuggerProcessConfig.port is required when spawnServer is false');
+      throw new Error(
+        "DebuggerProcessConfig.port is required when spawnServer is false",
+      );
     }
 
     try {
       await this.waitForServer(port);
-      this.logManager?.log(LogLevel.Info, LogPhase.Connect, `Connecting to debugger server on port ${port}...`);
+      this.logManager?.log(
+        LogLevel.Info,
+        LogPhase.Connect,
+        `Connecting to debugger server on port ${port}...`,
+      );
       await this.connect(port);
-      this.logManager?.log(LogLevel.Info, LogPhase.Connect, 'Connection established. Negotiating protocol...');
+      this.logManager?.log(
+        LogLevel.Info,
+        LogPhase.Connect,
+        "Connection established. Negotiating protocol...",
+      );
       await this.negotiateProtocol();
-      this.logManager?.log(LogLevel.Info, LogPhase.Connect, `Protocol negotiated: ${this.negotiatedProtocolVersion || 'unknown'}`);
+      this.logManager?.log(
+        LogLevel.Info,
+        LogPhase.Connect,
+        `Protocol negotiated: ${this.negotiatedProtocolVersion || "unknown"}`,
+      );
 
       if (this.config.token) {
-        this.logManager?.log(LogLevel.Info, LogPhase.Auth, 'Authenticating with token...');
+        this.logManager?.log(
+          LogLevel.Info,
+          LogPhase.Auth,
+          "Authenticating with token...",
+        );
         const response = await this.sendRequest({
-          type: 'Authenticate',
-          token: this.config.token
+          type: "Authenticate",
+          token: this.config.token,
         });
-        this.expectResponse(response, 'Authenticated');
+        this.expectResponse(response, "Authenticated");
         if (!response.success) {
           throw new Error(response.message);
         }
       }
 
       if (this.config.snapshotPath) {
-        this.logManager?.log(LogLevel.Info, LogPhase.Load, `Loading snapshot: ${this.config.snapshotPath}`);
+        this.logManager?.log(
+          LogLevel.Info,
+          LogPhase.Load,
+          `Loading snapshot: ${this.config.snapshotPath}`,
+        );
         const response = await this.sendRequest({
-          type: 'LoadSnapshot',
-          snapshot_path: this.config.snapshotPath
+          type: "LoadSnapshot",
+          snapshot_path: this.config.snapshotPath,
         });
-        this.expectResponse(response, 'SnapshotLoaded');
+        this.expectResponse(response, "SnapshotLoaded");
       }
 
-      this.logManager?.log(LogLevel.Info, LogPhase.Load, `Loading contract: ${this.config.contractPath}`);
+      this.logManager?.log(
+        LogLevel.Info,
+        LogPhase.Load,
+        `Loading contract: ${this.config.contractPath}`,
+      );
       const contractResponse = await this.sendRequest({
-        type: 'LoadContract',
-        contract_path: this.config.contractPath
+        type: "LoadContract",
+        contract_path: this.config.contractPath,
       });
-      this.expectResponse(contractResponse, 'ContractLoaded');
+      this.expectResponse(contractResponse, "ContractLoaded");
     } catch (error) {
       await this.stop().catch(() => undefined);
       throw error;
@@ -285,90 +428,114 @@ export class DebuggerProcess {
 
   async execute(): Promise<DebuggerExecutionResult> {
     const response = await this.sendRequest({
-      type: 'Execute',
-      function: this.config.entrypoint || 'main',
-      args: this.config.args && this.config.args.length > 0
-        ? JSON.stringify(this.config.args)
-        : undefined
+      type: "Execute",
+      function: this.config.entrypoint || "main",
+      args:
+        this.config.args && this.config.args.length > 0
+          ? JSON.stringify(this.config.args)
+          : undefined,
     });
-    this.expectResponse(response, 'ExecutionResult');
+    this.expectResponse(response, "ExecutionResult");
 
     if (!response.success) {
-      throw new Error(response.error || 'Execution failed');
+      throw new Error(response.error || "Execution failed");
     }
 
     return {
       output: response.output,
       paused: response.paused,
-      completed: response.completed
+      completed: response.completed,
     };
   }
 
-  async stepIn(): Promise<{ paused: boolean; current_function?: string; step_count: number }> {
-    const response = await this.sendRequest({ type: 'StepIn' });
-    this.expectResponse(response, 'StepResult');
+  async stepIn(): Promise<{
+    paused: boolean;
+    current_function?: string;
+    step_count: number;
+  }> {
+    const response = await this.sendRequest({ type: "StepIn" });
+    this.expectResponse(response, "StepResult");
     return response as any;
   }
 
-  async next(): Promise<{ paused: boolean; current_function?: string; step_count: number }> {
-    const response = await this.sendRequest({ type: 'Next' });
-    this.expectResponse(response, 'StepResult');
+  async next(): Promise<{
+    paused: boolean;
+    current_function?: string;
+    step_count: number;
+  }> {
+    const response = await this.sendRequest({ type: "Next" });
+    this.expectResponse(response, "StepResult");
     return response as any;
   }
 
-  async stepOut(): Promise<{ paused: boolean; current_function?: string; step_count: number }> {
-    const response = await this.sendRequest({ type: 'StepOut' });
-    this.expectResponse(response, 'StepResult');
+  async stepOut(): Promise<{
+    paused: boolean;
+    current_function?: string;
+    step_count: number;
+  }> {
+    const response = await this.sendRequest({ type: "StepOut" });
+    this.expectResponse(response, "StepResult");
     return response as any;
   }
 
   async continueExecution(): Promise<DebuggerContinueResult> {
-    const response = await this.sendRequest({ type: 'Continue' });
-    this.expectResponse(response, 'ContinueResult');
+    const response = await this.sendRequest({ type: "Continue" });
+    this.expectResponse(response, "ContinueResult");
     if (response.error) {
       throw new Error(response.error);
     }
     return {
       completed: response.completed,
       output: response.output,
-      paused: response.paused
+      paused: response.paused,
     };
   }
 
   async inspect(options?: RequestOptions): Promise<DebuggerInspection> {
-    const response = await this.sendRequest({ type: 'Inspect' }, options);
-    this.expectResponse(response, 'InspectionResult');
+    const response = await this.sendRequest({ type: "Inspect" }, options);
+    this.expectResponse(response, "InspectionResult");
     return {
       function: response.function,
       args: response.args,
       stepCount: response.step_count,
       paused: response.paused,
-      callStack: response.call_stack
+      callStack: response.call_stack,
     };
   }
 
   async getStorage(options?: RequestOptions): Promise<Record<string, unknown>> {
-    const response = await this.sendRequest({ type: 'GetStorage' }, options);
-    this.expectResponse(response, 'StorageState');
+    const response = await this.sendRequest({ type: "GetStorage" }, options);
+    this.expectResponse(response, "StorageState");
     const parsed = JSON.parse(response.storage_json);
-    if (parsed && typeof parsed === 'object') {
+    if (parsed && typeof parsed === "object") {
       return parsed as Record<string, unknown>;
     }
     return {};
   }
 
   async ping(): Promise<void> {
-    const response = await this.sendRequest({ type: 'Ping' });
-    this.expectResponse(response, 'Pong');
+    const response = await this.sendRequest({ type: "Ping" });
+    this.expectResponse(response, "Pong");
+  }
+
+  async captureSessionInfo(): Promise<void> {
+    const response = await this.sendRequest({ type: "Ping" });
+    this.expectResponse(response, "Pong");
+    this.sessionInfo = extractSessionInfoFromPong(response);
+  }
+
+  getSessionInfo(): DebuggerSessionInfo {
+    return { ...this.sessionInfo };
   }
 
   async getCapabilities(): Promise<BackendBreakpointCapabilities> {
-    const response = await this.sendRequest({ type: 'GetCapabilities' });
-    this.expectResponse(response, 'Capabilities');
+    const response = await this.sendRequest({ type: "GetCapabilities" });
+    this.expectResponse(response, "Capabilities");
     return {
       conditionalBreakpoints: response.breakpoints.conditional_breakpoints,
-      hitConditionalBreakpoints: response.breakpoints.hit_conditional_breakpoints,
-      logPoints: response.breakpoints.log_points
+      hitConditionalBreakpoints:
+        response.breakpoints.hit_conditional_breakpoints,
+      logPoints: response.breakpoints.log_points,
     };
   }
 
@@ -380,42 +547,42 @@ export class DebuggerProcess {
     logMessage?: string;
   }): Promise<void> {
     const response = await this.sendRequest({
-      type: 'SetBreakpoint',
+      type: "SetBreakpoint",
       id: breakpoint.id,
       function: breakpoint.functionName,
       condition: breakpoint.condition,
       hit_condition: breakpoint.hitCondition,
-      log_message: breakpoint.logMessage
+      log_message: breakpoint.logMessage,
     });
-    this.expectResponse(response, 'BreakpointSet');
+    this.expectResponse(response, "BreakpointSet");
   }
 
   async clearBreakpoint(breakpointId: string): Promise<void> {
     const response = await this.sendRequest({
-      type: 'ClearBreakpoint',
-      id: breakpointId
+      type: "ClearBreakpoint",
+      id: breakpointId,
     });
-    this.expectResponse(response, 'BreakpointCleared');
+    this.expectResponse(response, "BreakpointCleared");
   }
 
   async evaluate(
     expression: string,
     frameId?: number,
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<{ result: string; type?: string; variablesReference: number }> {
     const response = await this.sendRequest(
       {
-        type: 'Evaluate',
+        type: "Evaluate",
         expression,
-        frame_id: frameId
+        frame_id: frameId,
       },
-      options
+      options,
     );
-    this.expectResponse(response, 'EvaluateResult');
+    this.expectResponse(response, "EvaluateResult");
     return {
       result: response.result,
       type: response.result_type,
-      variablesReference: response.variables_reference
+      variablesReference: response.variables_reference,
     };
   }
 
@@ -425,7 +592,7 @@ export class DebuggerProcess {
     const output = await new Promise<string>((resolve, reject) => {
       const child = execFile(
         binaryPath,
-        ['inspect', '--contract', this.config.contractPath, '--functions'],
+        ["inspect", "--contract", this.config.contractPath, "--functions"],
         { env: process.env },
         (error, stdout, stderr) => {
           clearTimeout(timer);
@@ -434,12 +601,17 @@ export class DebuggerProcess {
             return;
           }
           resolve(stdout);
-        }
+        },
       );
 
       const timer = setTimeout(() => {
         child.kill();
-        reject(new DebuggerTimeoutError('InspectFunctions', this.defaultRequestTimeoutMs));
+        reject(
+          new DebuggerTimeoutError(
+            "InspectFunctions",
+            this.defaultRequestTimeoutMs,
+          ),
+        );
       }, this.defaultRequestTimeoutMs);
     });
 
@@ -458,19 +630,28 @@ export class DebuggerProcess {
     sourcePath: string,
     lines: number[],
     exportedFunctions: Set<string>,
-    options?: RequestOptions
-  ): Promise<Array<{ requestedLine: number; line: number; verified: boolean; functionName?: string; reasonCode: string; message: string }>> {
+    options?: RequestOptions,
+  ): Promise<
+    Array<{
+      requestedLine: number;
+      line: number;
+      verified: boolean;
+      functionName?: string;
+      reasonCode: string;
+      message: string;
+    }>
+  > {
     const response = await this.sendRequest(
       {
-        type: 'ResolveSourceBreakpoints',
+        type: "ResolveSourceBreakpoints",
         source_path: sourcePath,
         lines,
-        exported_functions: Array.from(exportedFunctions)
+        exported_functions: Array.from(exportedFunctions),
       },
-      options
+      options,
     );
 
-    this.expectResponse(response, 'SourceBreakpointsResolved');
+    this.expectResponse(response, "SourceBreakpointsResolved");
 
     return response.breakpoints.map((bp) => ({
       requestedLine: bp.requested_line,
@@ -478,14 +659,14 @@ export class DebuggerProcess {
       verified: bp.verified,
       functionName: bp.function,
       reasonCode: bp.reason_code,
-      message: bp.message
+      message: bp.message,
     }));
   }
 
   async stop(): Promise<void> {
     try {
       if (this.socket && !this.socket.destroyed) {
-        await this.sendRequest({ type: 'Disconnect' }).catch(() => undefined);
+        await this.sendRequest({ type: "Disconnect" }).catch(() => undefined);
       }
     } finally {
       this.socket?.destroy();
@@ -510,15 +691,15 @@ export class DebuggerProcess {
       const child = this.childProcess;
       const timeout = setTimeout(() => {
         if (!child.killed) {
-          child.kill('SIGKILL');
+          child.kill("SIGKILL");
         }
       }, 5000);
 
-      child.once('exit', () => {
+      child.once("exit", () => {
         clearTimeout(timeout);
         resolve();
       });
-      child.kill('SIGTERM');
+      child.kill("SIGTERM");
     });
 
     this.childProcess = null;
@@ -533,26 +714,30 @@ export class DebuggerProcess {
   }
 
   private buildArgs(port: number): string[] {
-    const args = ['server', '--port', String(port)];
+    const args = ["server", "--port", String(port)];
 
     if (this.config.token) {
-      args.push('--token', this.config.token);
+      args.push("--token", this.config.token);
     }
 
     return args;
   }
 
   isRunning(): boolean {
-    return this.childProcess !== null && this.socket !== null && !this.socket.destroyed;
+    return (
+      this.childProcess !== null &&
+      this.socket !== null &&
+      !this.socket.destroyed
+    );
   }
 
   private async findAvailablePort(): Promise<number> {
     return await new Promise<number>((resolve, reject) => {
       const server = net.createServer();
-      server.listen(0, '127.0.0.1', () => {
+      server.listen(0, "127.0.0.1", () => {
         const address = server.address();
-        if (!address || typeof address === 'string') {
-          reject(new Error('Failed to determine an available port'));
+        if (!address || typeof address === "string") {
+          reject(new Error("Failed to determine an available port"));
           return;
         }
 
@@ -565,7 +750,7 @@ export class DebuggerProcess {
           resolve(port);
         });
       });
-      server.on('error', reject);
+      server.on("error", reject);
     });
   }
 
@@ -574,14 +759,16 @@ export class DebuggerProcess {
 
     while (Date.now() < deadline) {
       if (this.childProcess && this.childProcess.exitCode !== null) {
-        throw new Error(`Debugger server exited with code ${this.childProcess.exitCode}`);
+        throw new Error(
+          `Debugger server exited with code ${this.childProcess.exitCode}`,
+        );
       }
 
       if (await this.canConnect(port)) {
         return;
       }
 
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
 
     throw new Error(`Timed out waiting for debugger server on port ${port}`);
@@ -589,12 +776,12 @@ export class DebuggerProcess {
 
   private async canConnect(port: number): Promise<boolean> {
     return await new Promise<boolean>((resolve) => {
-      const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
+      const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
         socket.destroy();
         resolve(true);
       });
 
-      socket.on('error', () => {
+      socket.on("error", () => {
         socket.destroy();
         resolve(false);
       });
@@ -603,19 +790,19 @@ export class DebuggerProcess {
 
   private async connect(port: number): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
+      const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
         this.socket = socket;
         resolve();
       });
 
-      socket.setEncoding('utf8');
-      socket.on('data', (chunk: string) => {
+      socket.setEncoding("utf8");
+      socket.on("data", (chunk: string) => {
         this.buffer += chunk;
         this.consumeMessages();
       });
-      socket.on('error', reject);
-      socket.on('close', () => {
-        this.rejectPendingRequests(new Error('Debugger connection closed'));
+      socket.on("error", reject);
+      socket.on("close", () => {
+        this.rejectPendingRequests(new Error("Debugger connection closed"));
         this.socket = null;
       });
     });
@@ -623,7 +810,7 @@ export class DebuggerProcess {
 
   private consumeMessages(): void {
     while (true) {
-      const newlineIndex = this.buffer.indexOf('\n');
+      const newlineIndex = this.buffer.indexOf("\n");
       if (newlineIndex === -1) {
         return;
       }
@@ -639,7 +826,11 @@ export class DebuggerProcess {
       try {
         message = JSON.parse(line) as DebugMessage;
       } catch (err) {
-        this.logManager?.log(LogLevel.Error, LogPhase.Connect, `Failed to parse backend message: ${err}\nLine: ${line}`);
+        this.logManager?.log(
+          LogLevel.Error,
+          LogPhase.Connect,
+          `Failed to parse backend message: ${err}\nLine: ${line}`,
+        );
         continue;
       }
       const pending = this.pendingRequests.get(message.id);
@@ -653,9 +844,12 @@ export class DebuggerProcess {
     }
   }
 
-  private async sendRequest(request: DebugRequest, options?: RequestOptions): Promise<DebugResponse> {
+  private async sendRequest(
+    request: DebugRequest,
+    options?: RequestOptions,
+  ): Promise<DebugResponse> {
     if (!this.socket) {
-      throw new Error('Debugger connection is not established');
+      throw new Error("Debugger connection is not established");
     }
 
     if (options?.signal?.aborted) {
@@ -673,7 +867,7 @@ export class DebuggerProcess {
           timeout = undefined;
         }
         if (abortHandler && options?.signal) {
-          options.signal.removeEventListener('abort', abortHandler);
+          options.signal.removeEventListener("abort", abortHandler);
         }
       };
 
@@ -704,16 +898,20 @@ export class DebuggerProcess {
           pending.cleanup();
           pending.reject(new RequestAbortedError());
         };
-        options.signal.addEventListener('abort', abortHandler, { once: true });
+        options.signal.addEventListener("abort", abortHandler, { once: true });
       }
 
       this.pendingRequests.set(id, { resolve, reject, cleanup });
     });
 
-    this.logManager?.log(LogLevel.Debug, LogPhase.Connect, `Backend request [${id}]: ${JSON.stringify(request)}`);
+    this.logManager?.log(
+      LogLevel.Debug,
+      LogPhase.Connect,
+      `Backend request [${id}]: ${JSON.stringify(request)}`,
+    );
     this.socket.write(`${JSON.stringify(message)}\n`);
     const response = await responsePromise;
-    if (response.type === 'Error') {
+    if (response.type === "Error") {
       throw new Error(response.message);
     }
     return response;
@@ -721,11 +919,18 @@ export class DebuggerProcess {
 
   private getExtensionVersion(): string {
     try {
-      const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { version?: string };
-      return pkg.version || 'unknown';
+      const packageJsonPath = path.resolve(
+        __dirname,
+        "..",
+        "..",
+        "package.json",
+      );
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+        version?: string;
+      };
+      return pkg.version || "unknown";
     } catch {
-      return 'unknown';
+      return "unknown";
     }
   }
 
@@ -734,40 +939,49 @@ export class DebuggerProcess {
 
     let response: DebugResponse;
     try {
-      response = await this.sendRequest({
-        type: 'Handshake',
-        client_name: 'vscode-extension',
-        client_version: extensionVersion,
-        protocol_min: WIRE_PROTOCOL_MIN_VERSION,
-        protocol_max: WIRE_PROTOCOL_MAX_VERSION
-      }, { timeoutMs: 2_500 });
+      response = await this.sendRequest(
+        {
+          type: "Handshake",
+          client_name: "vscode-extension",
+          client_version: extensionVersion,
+          protocol_min: WIRE_PROTOCOL_MIN_VERSION,
+          protocol_max: WIRE_PROTOCOL_MAX_VERSION,
+        },
+        { timeoutMs: 2_500 },
+      );
     } catch (error) {
-      throw new Error(formatProtocolMismatchMessage({
-        extensionVersion,
-        extra: String(error)
-      }));
+      throw new Error(
+        formatProtocolMismatchMessage({
+          extensionVersion,
+          extra: String(error),
+        }),
+      );
     }
 
-    if (response.type === 'HandshakeAck') {
+    if (response.type === "HandshakeAck") {
       this.negotiatedProtocolVersion = response.selected_version;
       return;
     }
 
-    if (response.type === 'IncompatibleProtocol') {
-      throw new Error(formatProtocolMismatchMessage({
-        extensionVersion,
-        backendName: response.server_name,
-        backendVersion: response.server_version,
-        backendProtocolMin: response.protocol_min,
-        backendProtocolMax: response.protocol_max,
-        extra: response.message
-      }));
+    if (response.type === "IncompatibleProtocol") {
+      throw new Error(
+        formatProtocolMismatchMessage({
+          extensionVersion,
+          backendName: response.server_name,
+          backendVersion: response.server_version,
+          backendProtocolMin: response.protocol_min,
+          backendProtocolMax: response.protocol_max,
+          extra: response.message,
+        }),
+      );
     }
 
-    throw new Error(formatProtocolMismatchMessage({
-      extensionVersion,
-      extra: `Unexpected handshake response: ${response.type}`
-    }));
+    throw new Error(
+      formatProtocolMismatchMessage({
+        extensionVersion,
+        extra: `Unexpected handshake response: ${response.type}`,
+      }),
+    );
   }
 
   private rejectPendingRequests(error: Error): void {
@@ -778,25 +992,29 @@ export class DebuggerProcess {
     this.pendingRequests.clear();
   }
 
-  private expectResponse<T extends DebugResponse['type']>(
+  private expectResponse<T extends DebugResponse["type"]>(
     response: DebugResponse,
-    type: T
+    type: T,
   ): asserts response is Extract<DebugResponse, { type: T }> {
     if (response.type !== type) {
-      throw new Error(`Unexpected debugger response: expected ${type}, got ${response.type}`);
+      throw new Error(
+        `Unexpected debugger response: expected ${type}, got ${response.type}`,
+      );
     }
   }
 }
 
 function debuggerBinaryName(): string {
-  return process.platform === 'win32' ? 'soroban-debug.exe' : 'soroban-debug';
+  return process.platform === "win32" ? "soroban-debug.exe" : "soroban-debug";
 }
 
 function looksLikeVariableReference(value: string): boolean {
-  return value.includes('${');
+  return value.includes("${");
 }
 
-export function resolveDebuggerBinaryPath(config: DebuggerProcessConfig): string {
+export function resolveDebuggerBinaryPath(
+  config: DebuggerProcessConfig,
+): string {
   const configured = config.binaryPath?.trim();
   if (configured) {
     return configured;
@@ -811,7 +1029,7 @@ export function resolveDebuggerBinaryPath(config: DebuggerProcessConfig): string
 }
 
 export async function validateLaunchConfig(
-  config: DebuggerProcessConfig
+  config: DebuggerProcessConfig,
 ): Promise<LaunchPreflightResult> {
   const issues: LaunchPreflightIssue[] = [];
   const resolvedBinaryPath = resolveDebuggerBinaryPath(config);
@@ -819,46 +1037,50 @@ export async function validateLaunchConfig(
   if (!looksLikeVariableReference(resolvedBinaryPath)) {
     pushFileIssue(
       issues,
-      'binaryPath',
+      "binaryPath",
       resolvedBinaryPath,
-      'a readable soroban-debug binary path or a command available on PATH.',
-      ['pickBinary', 'openLaunchConfig', 'openSettings']
+      "a readable soroban-debug binary path or a command available on PATH.",
+      ["pickBinary", "openLaunchConfig", "openSettings"],
     );
   }
 
   if (!config.contractPath || config.contractPath.trim().length === 0) {
     issues.push({
-      field: 'contractPath',
-      message: "Launch config field 'contractPath' must point to a readable contract WASM file.",
-      expected: 'A readable .wasm file.',
-      quickFixes: ['pickContract', 'openLaunchConfig', 'generateLaunchConfig']
+      field: "contractPath",
+      message:
+        "Launch config field 'contractPath' must point to a readable contract WASM file.",
+      expected: "A readable .wasm file.",
+      quickFixes: ["pickContract", "openLaunchConfig", "generateLaunchConfig"],
     });
   } else if (!looksLikeVariableReference(config.contractPath)) {
     pushFileIssue(
       issues,
-      'contractPath',
+      "contractPath",
       config.contractPath,
-      'a readable contract WASM file.',
-      ['pickContract', 'openLaunchConfig', 'generateLaunchConfig']
+      "a readable contract WASM file.",
+      ["pickContract", "openLaunchConfig", "generateLaunchConfig"],
     );
   }
 
   if (config.snapshotPath && !looksLikeVariableReference(config.snapshotPath)) {
     pushFileIssue(
       issues,
-      'snapshotPath',
+      "snapshotPath",
       config.snapshotPath,
-      'a readable snapshot JSON file.',
-      ['pickSnapshot', 'openLaunchConfig', 'generateLaunchConfig']
+      "a readable snapshot JSON file.",
+      ["pickSnapshot", "openLaunchConfig", "generateLaunchConfig"],
     );
   }
 
-  if (config.entrypoint !== undefined && config.entrypoint.trim().length === 0) {
+  if (
+    config.entrypoint !== undefined &&
+    config.entrypoint.trim().length === 0
+  ) {
     issues.push({
-      field: 'entrypoint',
+      field: "entrypoint",
       message: "Launch config field 'entrypoint' must be a non-empty string.",
       expected: "A Soroban function name such as 'main' or 'transfer'.",
-      quickFixes: ['openLaunchConfig', 'generateLaunchConfig']
+      quickFixes: ["openLaunchConfig", "generateLaunchConfig"],
     });
   }
 
@@ -868,19 +1090,23 @@ export async function validateLaunchConfig(
   }
 
   if (config.port !== undefined) {
-    if (!Number.isInteger(config.port) || config.port < 1 || config.port > 65_535) {
+    if (
+      !Number.isInteger(config.port) ||
+      config.port < 1 ||
+      config.port > 65_535
+    ) {
       issues.push({
-        field: 'port',
+        field: "port",
         message: `Launch config field 'port' must be an integer between 1 and 65535; received ${String(config.port)}.`,
-        expected: 'An available TCP port between 1 and 65535.',
-        quickFixes: ['openLaunchConfig']
+        expected: "An available TCP port between 1 and 65535.",
+        quickFixes: ["openLaunchConfig"],
       });
     } else if (!(await isPortAvailable(config.port))) {
       issues.push({
-        field: 'port',
+        field: "port",
         message: `Launch config field 'port' is set to ${config.port}, but that port is already in use on 127.0.0.1.`,
-        expected: 'An available TCP port between 1 and 65535.',
-        quickFixes: ['openLaunchConfig']
+        expected: "An available TCP port between 1 and 65535.",
+        quickFixes: ["openLaunchConfig"],
       });
     }
   }
@@ -888,10 +1114,11 @@ export async function validateLaunchConfig(
   if (config.token !== undefined) {
     if (config.token.trim().length === 0 || /[\r\n]/.test(config.token)) {
       issues.push({
-        field: 'token',
-        message: "Launch config field 'token' must be a single-line non-empty string.",
-        expected: 'A non-empty authentication token without line breaks.',
-        quickFixes: ['openLaunchConfig']
+        field: "token",
+        message:
+          "Launch config field 'token' must be a single-line non-empty string.",
+        expected: "A non-empty authentication token without line breaks.",
+        quickFixes: ["openLaunchConfig"],
       });
     }
   }
@@ -899,28 +1126,28 @@ export async function validateLaunchConfig(
   return {
     ok: issues.length === 0,
     issues,
-    resolvedBinaryPath
+    resolvedBinaryPath,
   };
 }
 
 function pushFileIssue(
   issues: LaunchPreflightIssue[],
-  field: 'binaryPath' | 'contractPath' | 'snapshotPath',
+  field: "binaryPath" | "contractPath" | "snapshotPath",
   filePath: string | undefined,
   expected: string,
-  quickFixes: LaunchPreflightQuickFix[]
+  quickFixes: LaunchPreflightQuickFix[],
 ): void {
   if (!filePath || filePath.trim().length === 0) {
     issues.push({
       field,
       message: `Launch config field '${field}' must point to ${expected}.`,
       expected,
-      quickFixes
+      quickFixes,
     });
     return;
   }
 
-  if (field === 'binaryPath' && isCommandOnPath(filePath)) {
+  if (field === "binaryPath" && isCommandOnPath(filePath)) {
     return;
   }
 
@@ -931,7 +1158,7 @@ function pushFileIssue(
         field,
         message: `Launch config field '${field}' points to '${filePath}', but that path is not a file.`,
         expected,
-        quickFixes
+        quickFixes,
       });
       return;
     }
@@ -942,13 +1169,17 @@ function pushFileIssue(
       field,
       message: `Launch config field '${field}' points to '${filePath}', but the file does not exist or is not readable.`,
       expected,
-      quickFixes
+      quickFixes,
     });
   }
 }
 
 function isCommandOnPath(command: string): boolean {
-  if (path.isAbsolute(command) || command.includes(path.sep) || command.includes('/')) {
+  if (
+    path.isAbsolute(command) ||
+    command.includes(path.sep) ||
+    command.includes("/")
+  ) {
     return false;
   }
 
@@ -957,15 +1188,19 @@ function isCommandOnPath(command: string): boolean {
     return false;
   }
 
-  const extensions = process.platform === 'win32'
-    ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM')
-        .split(';')
-        .filter((ext) => ext.length > 0)
-    : [''];
+  const extensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT || ".EXE;.CMD;.BAT;.COM")
+          .split(";")
+          .filter((ext) => ext.length > 0)
+      : [""];
 
   for (const directory of pathValue.split(path.delimiter)) {
     for (const extension of extensions) {
-      const candidate = path.join(directory, command.endsWith(extension) ? command : `${command}${extension}`);
+      const candidate = path.join(
+        directory,
+        command.endsWith(extension) ? command : `${command}${extension}`,
+      );
       if (fs.existsSync(candidate)) {
         return true;
       }
@@ -978,45 +1213,50 @@ function isCommandOnPath(command: string): boolean {
 function validateArgs(args: unknown): LaunchPreflightIssue | undefined {
   if (!Array.isArray(args)) {
     return {
-      field: 'args',
+      field: "args",
       message: `Launch config field 'args' must be an array; received ${describeValue(args)}.`,
       expected: 'A JSON array such as [] or ["alice", 10].',
-      quickFixes: ['openLaunchConfig', 'generateLaunchConfig']
+      quickFixes: ["openLaunchConfig", "generateLaunchConfig"],
     };
   }
 
   const seen = new Set<unknown>();
-  const invalidPath = findNonSerializableValue(args, '$', seen);
+  const invalidPath = findNonSerializableValue(args, "$", seen);
   if (invalidPath) {
     return {
-      field: 'args',
+      field: "args",
       message: `Launch config field 'args' contains a non-JSON-serializable value at ${invalidPath}.`,
-      expected: 'Only JSON-serializable values: strings, numbers, booleans, null, arrays, and objects.',
-      quickFixes: ['openLaunchConfig', 'generateLaunchConfig']
+      expected:
+        "Only JSON-serializable values: strings, numbers, booleans, null, arrays, and objects.",
+      quickFixes: ["openLaunchConfig", "generateLaunchConfig"],
     };
   }
 
   return undefined;
 }
 
-function findNonSerializableValue(value: unknown, pathLabel: string, seen: Set<unknown>): string | undefined {
+function findNonSerializableValue(
+  value: unknown,
+  pathLabel: string,
+  seen: Set<unknown>,
+): string | undefined {
   if (
     value === null ||
-    typeof value === 'string' ||
-    typeof value === 'boolean'
+    typeof value === "string" ||
+    typeof value === "boolean"
   ) {
     return undefined;
   }
 
-  if (typeof value === 'number') {
+  if (typeof value === "number") {
     return Number.isFinite(value) ? undefined : pathLabel;
   }
 
   if (
-    typeof value === 'undefined' ||
-    typeof value === 'function' ||
-    typeof value === 'symbol' ||
-    typeof value === 'bigint'
+    typeof value === "undefined" ||
+    typeof value === "function" ||
+    typeof value === "symbol" ||
+    typeof value === "bigint"
   ) {
     return pathLabel;
   }
@@ -1027,7 +1267,11 @@ function findNonSerializableValue(value: unknown, pathLabel: string, seen: Set<u
     }
     seen.add(value);
     for (let index = 0; index < value.length; index += 1) {
-      const found = findNonSerializableValue(value[index], `${pathLabel}[${index}]`, seen);
+      const found = findNonSerializableValue(
+        value[index],
+        `${pathLabel}[${index}]`,
+        seen,
+      );
       if (found) {
         return found;
       }
@@ -1036,7 +1280,7 @@ function findNonSerializableValue(value: unknown, pathLabel: string, seen: Set<u
     return undefined;
   }
 
-  if (typeof value === 'object') {
+  if (typeof value === "object") {
     const record = value as Record<string, unknown>;
     if (seen.has(record)) {
       return pathLabel;
@@ -1057,10 +1301,10 @@ function findNonSerializableValue(value: unknown, pathLabel: string, seen: Set<u
 
 function describeValue(value: unknown): string {
   if (Array.isArray(value)) {
-    return 'an array';
+    return "an array";
   }
   if (value === null) {
-    return 'null';
+    return "null";
   }
   return typeof value;
 }
@@ -1068,13 +1312,13 @@ function describeValue(value: unknown): string {
 async function isPortAvailable(port: number): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const server = net.createServer();
-    server.once('error', () => {
+    server.once("error", () => {
       server.close();
       resolve(false);
     });
-    server.once('listening', () => {
+    server.once("listening", () => {
       server.close(() => resolve(true));
     });
-    server.listen(port, '127.0.0.1');
+    server.listen(port, "127.0.0.1");
   });
 }

--- a/extensions/vscode/src/dap/adapter.ts
+++ b/extensions/vscode/src/dap/adapter.ts
@@ -2,22 +2,37 @@ import {
   DebugSession,
   InitializedEvent,
   StoppedEvent,
-  ExitedEvent} from '@vscode/debugadapter';
-import { DebugProtocol } from '@vscode/debugprotocol';
-import * as readline from 'readline';
+  ExitedEvent,
+} from "@vscode/debugadapter";
+import { DebugProtocol } from "@vscode/debugprotocol";
+import * as readline from "readline";
 import {
   DebuggerProcess,
   DebuggerProcessConfig,
   DebuggerTimeoutError,
-  validateLaunchConfig
-} from '../cli/debuggerProcess';
-import { BreakpointCapabilities, BreakpointLocation, DebuggerState, Variable } from './protocol';
-import { VariableStore } from './variableStore';
-import { ResolvedBreakpoint, resolveSourceBreakpoints } from './sourceBreakpoints';
-import { LogOutputEvent, LogLevel } from '@vscode/debugadapter/lib/logger';
-import { LogManager, LogLevel as ManagerLogLevel, LogPhase } from '../debug/logManager';
+  validateLaunchConfig,
+  DebuggerSessionInfo,
+} from "../cli/debuggerProcess";
+import {
+  BreakpointCapabilities,
+  BreakpointLocation,
+  DebuggerState,
+  Variable,
+} from "./protocol";
+import { VariableStore } from "./variableStore";
+import {
+  ResolvedBreakpoint,
+  resolveSourceBreakpoints,
+} from "./sourceBreakpoints";
+import { LogOutputEvent, LogLevel } from "@vscode/debugadapter/lib/logger";
+import {
+  LogManager,
+  LogLevel as ManagerLogLevel,
+  LogPhase,
+} from "../debug/logManager";
 
-type LaunchRequestArgs = DebugProtocol.LaunchRequestArguments & DebuggerProcessConfig;
+type LaunchRequestArgs = DebugProtocol.LaunchRequestArguments &
+  DebuggerProcessConfig;
 
 export class SorobanDebugSession extends DebugSession {
   private logManager: LogManager | undefined;
@@ -27,7 +42,7 @@ export class SorobanDebugSession extends DebugSession {
     isPaused: false,
     breakpoints: new Map(),
     callStack: [],
-    storage: {}
+    storage: {},
   };
   private variableStore = new VariableStore();
   private threadId = 1;
@@ -42,30 +57,42 @@ export class SorobanDebugSession extends DebugSession {
   private backendCapabilities: BreakpointCapabilities = {
     conditionalBreakpoints: false,
     hitConditionalBreakpoints: false,
-    logPoints: false
+    logPoints: false,
   };
+  private sessionInfo: DebuggerSessionInfo = {
+    backendVersion: "unknown",
+    protocolVersion: "unknown",
+  };
+  public onSessionInfoUpdated?: (info: DebuggerSessionInfo) => void;
 
   constructor(
     obsoleteDebuggerLinesAndColumnsStartAt1?: boolean | LogManager,
-    obsoleteIsServer?: boolean
+    obsoleteIsServer?: boolean,
   ) {
     super(
-      typeof obsoleteDebuggerLinesAndColumnsStartAt1 === 'boolean'
+      typeof obsoleteDebuggerLinesAndColumnsStartAt1 === "boolean"
         ? obsoleteDebuggerLinesAndColumnsStartAt1
         : undefined,
-      obsoleteIsServer
+      obsoleteIsServer,
     );
 
-    if (obsoleteDebuggerLinesAndColumnsStartAt1 && typeof obsoleteDebuggerLinesAndColumnsStartAt1 !== 'boolean') {
+    if (
+      obsoleteDebuggerLinesAndColumnsStartAt1 &&
+      typeof obsoleteDebuggerLinesAndColumnsStartAt1 !== "boolean"
+    ) {
       this.logManager = obsoleteDebuggerLinesAndColumnsStartAt1;
     }
   }
 
   protected initializeRequest(
     response: DebugProtocol.InitializeResponse,
-    args: DebugProtocol.InitializeRequestArguments
+    args: DebugProtocol.InitializeRequestArguments,
   ): void {
-    this.logManager?.log(ManagerLogLevel.Info, LogPhase.DAP, `InitializeRequest: ${JSON.stringify(args)}`);
+    this.logManager?.log(
+      ManagerLogLevel.Info,
+      LogPhase.DAP,
+      `InitializeRequest: ${JSON.stringify(args)}`,
+    );
     response.body = response.body || {};
     response.body.supportsConfigurationDoneRequest = true;
     response.body.supportsEvaluateForHovers = true;
@@ -83,9 +110,13 @@ export class SorobanDebugSession extends DebugSession {
 
   protected async launchRequest(
     response: DebugProtocol.LaunchResponse,
-    args: LaunchRequestArgs
+    args: LaunchRequestArgs,
   ): Promise<void> {
-    this.logManager?.log(ManagerLogLevel.Info, LogPhase.DAP, `LaunchRequest: ${JSON.stringify(args)}`);
+    this.logManager?.log(
+      ManagerLogLevel.Info,
+      LogPhase.DAP,
+      `LaunchRequest: ${JSON.stringify(args)}`,
+    );
     try {
       const preflight = await validateLaunchConfig(args);
       if (!preflight.ok) {
@@ -93,50 +124,60 @@ export class SorobanDebugSession extends DebugSession {
         throw new Error(`${issue.message} Expected: ${issue.expected}`);
       }
 
-      this.debuggerProcess = new DebuggerProcess({
-        contractPath: args.contractPath,
-        snapshotPath: args.snapshotPath,
-        entrypoint: args.entrypoint || 'main',
-        args: args.args || [],
-        trace: args.trace || false,
-        binaryPath: args.binaryPath,
-        port: args.port,
-        token: args.token,
-        requestTimeoutMs: args.requestTimeoutMs,
-        connectTimeoutMs: args.connectTimeoutMs
-      }, this.logManager);
+      this.debuggerProcess = new DebuggerProcess(
+        {
+          contractPath: args.contractPath,
+          snapshotPath: args.snapshotPath,
+          entrypoint: args.entrypoint || "main",
+          args: args.args || [],
+          trace: args.trace || false,
+          binaryPath: args.binaryPath,
+          port: args.port,
+          token: args.token,
+          requestTimeoutMs: args.requestTimeoutMs,
+          connectTimeoutMs: args.connectTimeoutMs,
+        },
+        this.logManager,
+      );
 
       await this.debuggerProcess.start();
       this.state.isRunning = true;
       this.state.isPaused = false;
       this.hasExecuted = false;
       this.variableStore.reset();
-      this.exportedFunctions = await this.debuggerProcess.getContractFunctions();
-      this.backendCapabilities = await this.debuggerProcess.getCapabilities().catch(() => ({
-        conditionalBreakpoints: false,
-        hitConditionalBreakpoints: false,
-        logPoints: false
-      }));
+      this.exportedFunctions =
+        await this.debuggerProcess.getContractFunctions();
+      this.backendCapabilities = await this.debuggerProcess
+        .getCapabilities()
+        .catch(() => ({
+          conditionalBreakpoints: false,
+          hitConditionalBreakpoints: false,
+          logPoints: false,
+        }));
+      await this.debuggerProcess.captureSessionInfo();
+      this.sessionInfo = this.debuggerProcess.getSessionInfo();
+      this.onSessionInfoUpdated?.(this.sessionInfo);
 
       this.attachProcessListeners();
       this.sendResponse(response);
     } catch (error) {
-      const message = error instanceof DebuggerTimeoutError
-        ? `Failed to launch debugger (timeout): ${error.message}\n\nNext steps: ensure the backend process is running, reachable, and not stalled; then retry the session.`
-        : `Failed to launch debugger: ${error}`;
+      const message =
+        error instanceof DebuggerTimeoutError
+          ? `Failed to launch debugger (timeout): ${error.message}\n\nNext steps: ensure the backend process is running, reachable, and not stalled; then retry the session.`
+          : `Failed to launch debugger: ${error}`;
       this.sendErrorResponse(response, {
         id: 1001,
         format: message,
-        showUser: true
+        showUser: true,
       });
     }
   }
 
   protected async setBreakPointsRequest(
     response: DebugProtocol.SetBreakpointsResponse,
-    args: DebugProtocol.SetBreakpointsArguments
+    args: DebugProtocol.SetBreakpointsArguments,
   ): Promise<void> {
-    const source = args.source.path || args.source.name || '';
+    const source = args.source.path || args.source.name || "";
     const breakpoints = args.breakpoints || [];
     const lines = breakpoints.map((bp) => bp.line);
 
@@ -147,24 +188,45 @@ export class SorobanDebugSession extends DebugSession {
           requestedLine: line,
           line,
           verified: false,
-          reasonCode: 'NO_DEBUGGER',
+          reasonCode: "NO_DEBUGGER",
           setBreakpoint: false,
-          message: 'Debugger is not launched or source path is unavailable'
+          message: "Debugger is not launched or source path is unavailable",
         }));
       } else {
-        let serverResolved: Array<{ requestedLine: number; line: number; verified: boolean; functionName?: string; reasonCode: string; message: string }> | null = null;
+        let serverResolved: Array<{
+          requestedLine: number;
+          line: number;
+          verified: boolean;
+          functionName?: string;
+          reasonCode: string;
+          message: string;
+        }> | null = null;
         try {
-          serverResolved = await this.debuggerProcess.resolveSourceBreakpoints(source, lines, this.exportedFunctions);
+          serverResolved = await this.debuggerProcess.resolveSourceBreakpoints(
+            source,
+            lines,
+            this.exportedFunctions,
+          );
         } catch {
           serverResolved = null;
         }
 
         const shouldFallbackHeuristic = serverResolved
-          ? serverResolved.every((bp) => ['NO_DEBUG_INFO', 'FILE_NOT_IN_DEBUG_INFO', 'WASM_PARSE_ERROR'].includes(bp.reasonCode))
+          ? serverResolved.every((bp) =>
+              [
+                "NO_DEBUG_INFO",
+                "FILE_NOT_IN_DEBUG_INFO",
+                "WASM_PARSE_ERROR",
+              ].includes(bp.reasonCode),
+            )
           : false;
 
         if (serverResolved && shouldFallbackHeuristic) {
-          resolved = resolveSourceBreakpoints(source, lines, this.exportedFunctions);
+          resolved = resolveSourceBreakpoints(
+            source,
+            lines,
+            this.exportedFunctions,
+          );
         } else if (serverResolved) {
           resolved = serverResolved.map((bp) => ({
             requestedLine: bp.requestedLine,
@@ -173,33 +235,43 @@ export class SorobanDebugSession extends DebugSession {
             functionName: bp.functionName,
             reasonCode: bp.reasonCode,
             message: bp.message,
-            setBreakpoint: bp.verified && Boolean(bp.functionName)
+            setBreakpoint: bp.verified && Boolean(bp.functionName),
           }));
         } else {
-          resolved = resolveSourceBreakpoints(source, lines, this.exportedFunctions);
+          resolved = resolveSourceBreakpoints(
+            source,
+            lines,
+            this.exportedFunctions,
+          );
         }
       }
 
-      const managedBreakpoints: BreakpointLocation[] = breakpoints.map((bp, index) => {
-        const match = resolved.find((resolvedBreakpoint) => resolvedBreakpoint.line === bp.line);
-        return {
-          id: `${source}:${bp.line}:${bp.column ?? 1}:${index}`,
-          source,
-          line: bp.line,
-          column: bp.column,
-          functionName: match?.functionName,
-          condition: bp.condition,
-          hitCondition: bp.hitCondition,
-          logMessage: bp.logMessage
-        };
-      });
+      const managedBreakpoints: BreakpointLocation[] = breakpoints.map(
+        (bp, index) => {
+          const match = resolved.find(
+            (resolvedBreakpoint) => resolvedBreakpoint.line === bp.line,
+          );
+          return {
+            id: `${source}:${bp.line}:${bp.column ?? 1}:${index}`,
+            source,
+            line: bp.line,
+            column: bp.column,
+            functionName: match?.functionName,
+            condition: bp.condition,
+            hitCondition: bp.hitCondition,
+            logMessage: bp.logMessage,
+          };
+        },
+      );
 
       const syncErrors = await this.syncSourceBreakpoints(
         source,
         managedBreakpoints.filter((bp) => {
-          const match = resolved.find((resolvedBreakpoint) => resolvedBreakpoint.line === bp.line);
+          const match = resolved.find(
+            (resolvedBreakpoint) => resolvedBreakpoint.line === bp.line,
+          );
           return Boolean(match?.verified && bp.functionName);
-        })
+        }),
       );
 
       this.state.breakpoints.set(source, managedBreakpoints);
@@ -208,21 +280,24 @@ export class SorobanDebugSession extends DebugSession {
         new Set(
           resolved
             .filter((bp) => bp.setBreakpoint && bp.functionName)
-            .map((bp) => bp.functionName as string)
-        )
+            .map((bp) => bp.functionName as string),
+        ),
       );
 
       response.body = {
         breakpoints: breakpoints.map((bp) => {
-          const match = resolved.find((resolvedBreakpoint) => resolvedBreakpoint.requestedLine === bp.line);
+          const match = resolved.find(
+            (resolvedBreakpoint) =>
+              resolvedBreakpoint.requestedLine === bp.line,
+          );
           return {
             verified: match?.verified ?? false,
             line: match?.line ?? bp.line,
             column: bp.column,
             source: args.source,
-            message: [match?.message, syncMessage, capabilityMessages].filter(Boolean).join(' ')
+            message: match?.message,
           };
-        })
+        }),
       };
 
       this.sendResponse(response);
@@ -230,29 +305,29 @@ export class SorobanDebugSession extends DebugSession {
       this.sendErrorResponse(response, {
         id: 1003,
         format: `Failed to resolve breakpoints: ${error}`,
-        showUser: true
+        showUser: true,
       });
     }
   }
 
   protected async stackTraceRequest(
     response: DebugProtocol.StackTraceResponse,
-    args: DebugProtocol.StackTraceArguments
+    args: DebugProtocol.StackTraceArguments,
   ): Promise<void> {
     const stackFrames = this.state.callStack || [];
 
     response.body = {
-      stackFrames: stackFrames.slice(0, 50).map(frame => ({
+      stackFrames: stackFrames.slice(0, 50).map((frame) => ({
         id: frame.id,
         name: frame.name,
         source: {
           name: frame.source,
-          path: frame.source
+          path: frame.source,
         },
         line: frame.line,
         column: frame.column,
-        instructionPointerReference: frame.instructionPointerReference
-      }))
+        instructionPointerReference: frame.instructionPointerReference,
+      })),
     };
 
     this.sendResponse(response);
@@ -260,28 +335,36 @@ export class SorobanDebugSession extends DebugSession {
 
   protected async scopesRequest(
     response: DebugProtocol.ScopesResponse,
-    args: DebugProtocol.ScopesArguments
+    args: DebugProtocol.ScopesArguments,
   ): Promise<void> {
     // Rebuild handles each time to reflect the latest paused state.
     this.variableStore.reset();
 
     const scopes: DebugProtocol.Scope[] = [];
 
-    const argsRef = this.variableStore.createListHandle(this.variableStore.variablesFromArgs(this.state.args));
+    const argsRef = this.variableStore.createListHandle(
+      this.variableStore.variablesFromArgs(this.state.args),
+    );
     scopes.push({
-      name: 'Arguments',
+      name: "Arguments",
       variablesReference: argsRef,
-      expensive: false
+      expensive: false,
     });
 
-    const storageKeys = this.state.storage ? Object.keys(this.state.storage) : [];
+    const storageKeys = this.state.storage
+      ? Object.keys(this.state.storage)
+      : [];
     if (storageKeys.length > 0) {
-      const variablesRef = this.variableStore.createListHandle(this.variableStore.variablesFromStorage(this.state.storage as Record<string, unknown>));
+      const variablesRef = this.variableStore.createListHandle(
+        this.variableStore.variablesFromStorage(
+          this.state.storage as Record<string, unknown>,
+        ),
+      );
 
       scopes.push({
-        name: 'Storage',
+        name: "Storage",
         variablesReference: variablesRef,
-        expensive: false
+        expensive: false,
       });
     }
 
@@ -291,11 +374,11 @@ export class SorobanDebugSession extends DebugSession {
 
   protected async variablesRequest(
     response: DebugProtocol.VariablesResponse,
-    args: DebugProtocol.VariablesArguments
+    args: DebugProtocol.VariablesArguments,
   ): Promise<void> {
     const variables = this.variableStore.getVariables(args.variablesReference, {
       start: (args as any).start as number | undefined,
-      count: (args as any).count as number | undefined
+      count: (args as any).count as number | undefined,
     });
 
     response.body = {
@@ -305,18 +388,18 @@ export class SorobanDebugSession extends DebugSession {
         type: v.type,
         variablesReference: v.variablesReference || 0,
         indexedVariables: v.indexedVariables,
-        namedVariables: v.namedVariables
-      }))
+        namedVariables: v.namedVariables,
+      })),
     };
 
     this.sendResponse(response);
   }
 
-   protected async evaluateRequest(
+  protected async evaluateRequest(
     response: DebugProtocol.EvaluateResponse,
-    args: DebugProtocol.EvaluateArguments
+    args: DebugProtocol.EvaluateArguments,
   ): Promise<void> {
-    const expression = (args.expression || '').trim();
+    const expression = (args.expression || "").trim();
 
     try {
       if (this.debuggerProcess && this.state.isPaused) {
@@ -324,34 +407,37 @@ export class SorobanDebugSession extends DebugSession {
       }
 
       // 1. Check for "magic" variables (local overrides)
-      if (expression === 'args' || expression === 'Arguments') {
+      if (expression === "args" || expression === "Arguments") {
         response.body = {
-          result: this.state.args ?? '(none)',
-          variablesReference: 0
+          result: this.state.args ?? "(none)",
+          variablesReference: 0,
         };
         this.sendResponse(response);
         return;
       }
 
-      if (expression === 'storage' || expression === 'Storage') {
+      if (expression === "storage" || expression === "Storage") {
         const storageObject = this.state.storage || {};
         response.body = {
           result: JSON.stringify(storageObject),
-          variablesReference: 0
+          variablesReference: 0,
         };
         this.sendResponse(response);
         return;
       }
 
-      if (expression.startsWith('storage.')) {
-        const key = expression.slice('storage.'.length);
+      if (expression.startsWith("storage.")) {
+        const key = expression.slice("storage.".length);
         const storageValue = (this.state.storage || {})[key];
         if (storageValue === undefined) {
           throw new Error(`Unknown storage key: ${key}`);
         }
         response.body = {
-          result: typeof storageValue === 'string' ? storageValue : JSON.stringify(storageValue),
-          variablesReference: 0
+          result:
+            typeof storageValue === "string"
+              ? storageValue
+              : JSON.stringify(storageValue),
+          variablesReference: 0,
         };
         this.sendResponse(response);
         return;
@@ -359,17 +445,22 @@ export class SorobanDebugSession extends DebugSession {
 
       // 2. Fall back to backend evaluation if available and paused
       if (this.debuggerProcess && this.state.isPaused) {
-        const result = await this.debuggerProcess.evaluate(args.expression, args.frameId);
+        const result = await this.debuggerProcess.evaluate(
+          args.expression,
+          args.frameId,
+        );
         response.body = {
           result: result.result,
           type: result.type,
-          variablesReference: result.variablesReference
+          variablesReference: result.variablesReference,
         };
         this.sendResponse(response);
         return;
       }
 
-      throw new Error('Unsupported expression or debugger not paused. Try `args`, `storage`, or `storage.<key>`.');
+      throw new Error(
+        "Unsupported expression or debugger not paused. Try `args`, `storage`, or `storage.<key>`.",
+      );
     } catch (error) {
       if (error instanceof DebuggerTimeoutError) {
         this.sendErrorResponse(response, {
@@ -377,7 +468,7 @@ export class SorobanDebugSession extends DebugSession {
           format:
             `Evaluate timed out (${error.requestType}). The backend may be stalled.\n\n` +
             `Next steps: restart the debug session; if it persists, verify the backend binary and connectivity.`,
-          showUser: true
+          showUser: true,
         });
         return;
       }
@@ -385,37 +476,39 @@ export class SorobanDebugSession extends DebugSession {
       this.sendErrorResponse(response, {
         id: 1010,
         format: `Evaluate failed: ${error}`,
-        showUser: false
+        showUser: false,
       });
     }
   }
 
   protected async continueRequest(
     response: DebugProtocol.ContinueResponse,
-    args: DebugProtocol.ContinueArguments
+    args: DebugProtocol.ContinueArguments,
   ): Promise<void> {
     try {
       if (!this.debuggerProcess) {
-        throw new Error('Debugger process is not running');
+        throw new Error("Debugger process is not running");
       }
 
       response.body = { allThreadsContinued: true };
       this.sendResponse(response);
 
       if (!this.hasExecuted) {
-        await this.runExecution('step');
+        await this.runExecution("step");
         return;
       }
 
       const result = await this.debuggerProcess.continueExecution();
       if (result.output) {
-        this.sendEvent(new LogOutputEvent(`Result: ${result.output}\n`, LogLevel.Log));
+        this.sendEvent(
+          new LogOutputEvent(`Result: ${result.output}\n`, LogLevel.Log),
+        );
       }
 
       if (result.paused) {
         await this.refreshState();
         this.state.isPaused = true;
-        this.sendEvent(new StoppedEvent('breakpoint', this.threadId));
+        this.sendEvent(new StoppedEvent("breakpoint", this.threadId));
         return;
       }
 
@@ -423,11 +516,13 @@ export class SorobanDebugSession extends DebugSession {
       await this.stop();
     } catch (error) {
       if (error instanceof DebuggerTimeoutError) {
-        this.sendEvent(new LogOutputEvent(
-          `Debugger request timed out (${error.requestType}). The backend may be stalled or the connection is unhealthy.\n` +
-          `Next steps: restart the debug session; if it persists, verify the backend binary and network connectivity.\n`,
-          LogLevel.Error
-        ));
+        this.sendEvent(
+          new LogOutputEvent(
+            `Debugger request timed out (${error.requestType}). The backend may be stalled or the connection is unhealthy.\n` +
+              `Next steps: restart the debug session; if it persists, verify the backend binary and network connectivity.\n`,
+            LogLevel.Error,
+          ),
+        );
         this.sendEvent(new ExitedEvent(1));
         await this.stop();
         return;
@@ -436,47 +531,49 @@ export class SorobanDebugSession extends DebugSession {
       this.sendErrorResponse(response, {
         id: 1002,
         format: `Continue failed: ${error}`,
-        showUser: true
+        showUser: true,
       });
     }
   }
 
   protected async nextRequest(
     response: DebugProtocol.NextResponse,
-    args: DebugProtocol.NextArguments
+    args: DebugProtocol.NextArguments,
   ): Promise<void> {
-    await this.stepOnce(response, 'next');
+    await this.stepOnce(response, "next");
   }
 
   protected async stepInRequest(
     response: DebugProtocol.StepInResponse,
-    args: DebugProtocol.StepInArguments
+    args: DebugProtocol.StepInArguments,
   ): Promise<void> {
-    await this.stepOnce(response, 'step in');
+    await this.stepOnce(response, "step in");
   }
 
   protected async stepOutRequest(
     response: DebugProtocol.StepOutResponse,
-    args: DebugProtocol.StepOutArguments
+    args: DebugProtocol.StepOutArguments,
   ): Promise<void> {
-    await this.stepOnce(response, 'step out');
+    await this.stepOnce(response, "step out");
   }
 
   protected async threadsRequest(
-    response: DebugProtocol.ThreadsResponse
+    response: DebugProtocol.ThreadsResponse,
   ): Promise<void> {
     response.body = {
-      threads: [{
-        id: this.threadId,
-        name: 'Main Thread'
-      }]
+      threads: [
+        {
+          id: this.threadId,
+          name: "Main Thread",
+        },
+      ],
     };
     this.sendResponse(response);
   }
 
   protected async configurationDoneRequest(
     response: DebugProtocol.ConfigurationDoneResponse,
-    args: DebugProtocol.ConfigurationDoneArguments
+    args: DebugProtocol.ConfigurationDoneArguments,
   ): Promise<void> {
     try {
       this.sendResponse(response);
@@ -485,24 +582,27 @@ export class SorobanDebugSession extends DebugSession {
         return;
       }
 
-      await this.runExecution('entry');
+      await this.runExecution("entry");
     } catch (error) {
-      if ((error as any)?.name === 'AbortError' || (error as any)?.name === 'TimeoutError') {
+      if (
+        (error as any)?.name === "AbortError" ||
+        (error as any)?.name === "TimeoutError"
+      ) {
         this.sendErrorResponse(response, {
           id: 1006,
-          format: 'Configuration completion canceled',
-          showUser: false
+          format: "Configuration completion canceled",
+          showUser: false,
         });
         return;
       }
       this.sendErrorResponse(response, {
         id: 1009,
         format: `Configuration failed: ${error}`,
-        showUser: true
+        showUser: true,
       });
     } finally {
       const requestSeq = (response as any).request_seq as number | undefined;
-      if (typeof requestSeq === 'number') {
+      if (typeof requestSeq === "number") {
         this.requestAbortControllers.delete(requestSeq);
       }
     }
@@ -512,7 +612,7 @@ export class SorobanDebugSession extends DebugSession {
   // We only support canceling long-running evaluate() calls at the moment.
   protected cancelRequest(response: any, args: any): void {
     const requestId = args?.requestId as number | undefined;
-    if (typeof requestId === 'number') {
+    if (typeof requestId === "number") {
       const controller = this.requestAbortControllers.get(requestId);
       controller?.abort();
       this.requestAbortControllers.delete(requestId);
@@ -523,9 +623,13 @@ export class SorobanDebugSession extends DebugSession {
 
   protected async disconnectRequest(
     response: DebugProtocol.DisconnectResponse,
-    args: DebugProtocol.DisconnectArguments
+    args: DebugProtocol.DisconnectArguments,
   ): Promise<void> {
-    this.logManager?.log(ManagerLogLevel.Info, LogPhase.DAP, `DisconnectRequest: ${JSON.stringify(args)}`);
+    this.logManager?.log(
+      ManagerLogLevel.Info,
+      LogPhase.DAP,
+      `DisconnectRequest: ${JSON.stringify(args)}`,
+    );
     await this.stop();
     this.sendResponse(response);
   }
@@ -537,12 +641,12 @@ export class SorobanDebugSession extends DebugSession {
     if (stdout) {
       const reader = readline.createInterface({
         input: stdout,
-        crlfDelay: Infinity
+        crlfDelay: Infinity,
       });
 
-      reader.on('line', (line: string) => {
+      reader.on("line", (line: string) => {
         this.logManager?.log(ManagerLogLevel.Debug, LogPhase.Backend, line);
-        this.sendEvent(new LogOutputEvent(line + '\n', LogLevel.Log));
+        this.sendEvent(new LogOutputEvent(line + "\n", LogLevel.Log));
       });
       this.outputReaders.push(reader);
     }
@@ -551,27 +655,31 @@ export class SorobanDebugSession extends DebugSession {
     if (stderr) {
       const reader = readline.createInterface({
         input: stderr,
-        crlfDelay: Infinity
+        crlfDelay: Infinity,
       });
 
-      reader.on('line', (line: string) => {
+      reader.on("line", (line: string) => {
         this.logManager?.log(ManagerLogLevel.Error, LogPhase.Backend, line);
-        this.sendEvent(new LogOutputEvent(line + '\n', LogLevel.Error));
+        this.sendEvent(new LogOutputEvent(line + "\n", LogLevel.Error));
       });
       this.outputReaders.push(reader);
     }
   }
 
-  private async runExecution(reason: 'step' | 'entry' | 'breakpoint' | 'pause'): Promise<void> {
+  private async runExecution(
+    reason: "step" | "entry" | "breakpoint" | "pause",
+  ): Promise<void> {
     if (!this.debuggerProcess) {
-      throw new Error('Debugger process is not running');
+      throw new Error("Debugger process is not running");
     }
 
     const result = await this.debuggerProcess.execute();
     this.hasExecuted = true;
     await this.refreshState();
     if (result.output) {
-      this.sendEvent(new LogOutputEvent(`Result: ${result.output}\n`, LogLevel.Log));
+      this.sendEvent(
+        new LogOutputEvent(`Result: ${result.output}\n`, LogLevel.Log),
+      );
     }
 
     if (result.paused) {
@@ -590,26 +698,26 @@ export class SorobanDebugSession extends DebugSession {
       | DebugProtocol.NextResponse
       | DebugProtocol.StepInResponse
       | DebugProtocol.StepOutResponse,
-    label: string
+    label: string,
   ): Promise<void> {
     try {
       if (!this.debuggerProcess) {
-        throw new Error('Debugger process is not running');
+        throw new Error("Debugger process is not running");
       }
 
       this.sendResponse(response);
 
       if (!this.hasExecuted) {
-        await this.runExecution('step');
+        await this.runExecution("step");
         return;
       }
 
       let result;
-      if (label === 'next') {
+      if (label === "next") {
         result = await this.debuggerProcess.next();
-      } else if (label === 'step in') {
+      } else if (label === "step in") {
         result = await this.debuggerProcess.stepIn();
-      } else if (label === 'step out') {
+      } else if (label === "step out") {
         result = await this.debuggerProcess.stepOut();
       } else {
         result = await this.debuggerProcess.stepIn(); // Fallback
@@ -618,7 +726,7 @@ export class SorobanDebugSession extends DebugSession {
       if (result.paused) {
         await this.refreshState();
         this.state.isPaused = true;
-        this.sendEvent(new StoppedEvent('step', this.threadId));
+        this.sendEvent(new StoppedEvent("step", this.threadId));
         return;
       }
 
@@ -626,23 +734,27 @@ export class SorobanDebugSession extends DebugSession {
       await this.stop();
     } catch (error) {
       if (error instanceof DebuggerTimeoutError) {
-        this.sendEvent(new LogOutputEvent(
-          `${label} timed out (${error.requestType}). The backend may be stalled.\n` +
-          `Next steps: restart the debug session.\n`,
-          LogLevel.Error
-        ));
+        this.sendEvent(
+          new LogOutputEvent(
+            `${label} timed out (${error.requestType}). The backend may be stalled.\n` +
+              `Next steps: restart the debug session.\n`,
+            LogLevel.Error,
+          ),
+        );
         this.sendEvent(new ExitedEvent(1));
         await this.stop();
         return;
       }
 
-      this.sendEvent(new LogOutputEvent(`${label} failed: ${error}\n`, LogLevel.Error));
+      this.sendEvent(
+        new LogOutputEvent(`${label} failed: ${error}\n`, LogLevel.Error),
+      );
     }
   }
 
   private async syncSourceBreakpoints(
     source: string,
-    nextBreakpoints: BreakpointLocation[]
+    nextBreakpoints: BreakpointLocation[],
   ): Promise<Map<string, string>> {
     if (!this.debuggerProcess) {
       return new Map();
@@ -662,12 +774,12 @@ export class SorobanDebugSession extends DebugSession {
           functionName: breakpoint.functionName as string,
           condition: breakpoint.condition,
           hitCondition: breakpoint.hitCondition,
-          logMessage: breakpoint.logMessage
+          logMessage: breakpoint.logMessage,
         });
       } catch (error) {
         errors.set(
           breakpoint.id,
-          error instanceof Error ? error.message : String(error)
+          error instanceof Error ? error.message : String(error),
         );
       }
     }
@@ -690,10 +802,13 @@ export class SorobanDebugSession extends DebugSession {
     try {
       [inspection, storage] = await Promise.all([
         this.debuggerProcess.inspect({ signal: controller.signal }),
-        this.debuggerProcess.getStorage({ signal: controller.signal })
+        this.debuggerProcess.getStorage({ signal: controller.signal }),
       ]);
     } catch (error) {
-      if ((error as any)?.name === 'AbortError' || (error as any)?.name === 'TimeoutError') {
+      if (
+        (error as any)?.name === "AbortError" ||
+        (error as any)?.name === "TimeoutError"
+      ) {
         return;
       }
       throw error;
@@ -703,16 +818,19 @@ export class SorobanDebugSession extends DebugSession {
       return;
     }
 
-      this.state.callStack = inspection.callStack.map((frame, index) => {
+    this.state.callStack = inspection.callStack.map((frame, index) => {
       let sourcePath = frame;
       let line = 1;
 
       // Try to find the range for the function to resolve the actual source line
-      for (const [sourceFilePath, sourceBpSet] of this.sourceFunctionBreakpoints.entries()) {
+      for (const [
+        sourceFilePath,
+        sourceBpSet,
+      ] of this.sourceFunctionBreakpoints.entries()) {
         if (sourceBpSet.has(frame)) {
           sourcePath = sourceFilePath;
           try {
-            const { parseFunctionRanges } = require('./sourceBreakpoints');
+            const { parseFunctionRanges } = require("./sourceBreakpoints");
             const ranges = parseFunctionRanges(sourcePath);
             const range = ranges.find((r: any) => r.name === frame);
             if (range) {
@@ -730,7 +848,7 @@ export class SorobanDebugSession extends DebugSession {
         name: frame,
         source: sourcePath,
         line: line,
-        column: 1
+        column: 1,
       };
     });
     this.state.args = inspection.args;
@@ -765,19 +883,28 @@ export class SorobanDebugSession extends DebugSession {
     this.sourceFunctionBreakpoints.clear();
   }
 
-  private describeCapabilityFallback(bp: DebugProtocol.SourceBreakpoint): string | undefined {
+  private describeCapabilityFallback(
+    bp: DebugProtocol.SourceBreakpoint,
+  ): string | undefined {
     const notices: string[] = [];
 
     if (bp.condition && !this.backendCapabilities.conditionalBreakpoints) {
-      notices.push('Conditional evaluation is unavailable in the current backend.');
+      notices.push(
+        "Conditional evaluation is unavailable in the current backend.",
+      );
     }
-    if (bp.hitCondition && !this.backendCapabilities.hitConditionalBreakpoints) {
-      notices.push('Hit-count filtering is unavailable in the current backend.');
+    if (
+      bp.hitCondition &&
+      !this.backendCapabilities.hitConditionalBreakpoints
+    ) {
+      notices.push(
+        "Hit-count filtering is unavailable in the current backend.",
+      );
     }
     if (bp.logMessage && !this.backendCapabilities.logPoints) {
-      notices.push('Logpoints are unavailable in the current backend.');
+      notices.push("Logpoints are unavailable in the current backend.");
     }
 
-    return notices.length > 0 ? notices.join(' ') : undefined;
+    return notices.length > 0 ? notices.join(" ") : undefined;
   }
 }

--- a/extensions/vscode/src/debug/adapter.ts
+++ b/extensions/vscode/src/debug/adapter.ts
@@ -1,14 +1,24 @@
-import * as vscode from 'vscode';
-import { DebugAdapterDescriptor, DebugAdapterInlineImplementation } from 'vscode';
-import { SorobanDebugSession } from '../dap/adapter';
-import { LogManager } from './logManager';
+import * as vscode from "vscode";
+import {
+  DebugAdapterDescriptor,
+  DebugAdapterInlineImplementation,
+} from "vscode";
+import { SorobanDebugSession } from "../dap/adapter";
+import { DebuggerSessionInfo } from "../cli/debuggerProcess";
+import { LogManager } from "./logManager";
 
 export class SorobanDebugAdapterDescriptorFactory
-  implements vscode.DebugAdapterDescriptorFactory, vscode.Disposable {
-
+  implements vscode.DebugAdapterDescriptorFactory, vscode.Disposable
+{
   private context: vscode.ExtensionContext;
   private logManager: LogManager;
-  private session: SorobanDebugSession | null = null;
+  private sessions = new Map<string, SorobanDebugSession>();
+  private sessionInfo = new Map<string, DebuggerSessionInfo>();
+  private readonly onSessionInfoEmitter = new vscode.EventEmitter<{
+    sessionId: string;
+    info: DebuggerSessionInfo;
+  }>();
+  public readonly onSessionInfo = this.onSessionInfoEmitter.event;
 
   constructor(context: vscode.ExtensionContext, logManager: LogManager) {
     this.context = context;
@@ -17,13 +27,29 @@ export class SorobanDebugAdapterDescriptorFactory
 
   async createDebugAdapterDescriptor(
     session: vscode.DebugSession,
-    executable: vscode.DebugAdapterExecutable | undefined
+    executable: vscode.DebugAdapterExecutable | undefined,
   ): Promise<DebugAdapterDescriptor | null> {
-    this.session = new SorobanDebugSession(this.logManager);
-    return new DebugAdapterInlineImplementation(this.session);
+    const debugSession = new SorobanDebugSession(this.logManager);
+    debugSession.onSessionInfoUpdated = (info) => {
+      this.sessionInfo.set(session.id, info);
+      this.onSessionInfoEmitter.fire({ sessionId: session.id, info });
+    };
+    this.sessions.set(session.id, debugSession);
+    return new DebugAdapterInlineImplementation(debugSession);
+  }
+
+  getSessionInfo(sessionId: string): DebuggerSessionInfo | undefined {
+    return this.sessionInfo.get(sessionId);
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+    this.sessionInfo.delete(sessionId);
   }
 
   dispose(): void {
-    this.session = null;
+    this.sessions.clear();
+    this.sessionInfo.clear();
+    this.onSessionInfoEmitter.dispose();
   }
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,37 +1,45 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import {
   DebuggerProcessConfig,
   LaunchPreflightIssue,
   LaunchPreflightQuickFix,
-  validateLaunchConfig
-} from './cli/debuggerProcess';
-import { SorobanDebugAdapterDescriptorFactory } from './debug/adapter';
-import { LogManager } from './debug/logManager';
+  validateLaunchConfig,
+  DebuggerSessionInfo,
+} from "./cli/debuggerProcess";
+import { SorobanDebugAdapterDescriptorFactory } from "./debug/adapter";
+import { LogManager } from "./debug/logManager";
 import {
   fromQuickPickLabel,
   runLaunchPreflightCommand,
-  toQuickPickLabel
-} from './preflightCommand';
+  toQuickPickLabel,
+} from "./preflightCommand";
 
 type SorobanLaunchConfig = vscode.DebugConfiguration & DebuggerProcessConfig;
-const RUN_LAUNCH_PREFLIGHT_COMMAND = 'soroban-debugger.runLaunchPreflight';
+const RUN_LAUNCH_PREFLIGHT_COMMAND = "soroban-debugger.runLaunchPreflight";
 
-class SorobanDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+class SorobanDebugConfigurationProvider
+  implements vscode.DebugConfigurationProvider
+{
   async resolveDebugConfiguration(
     folder: vscode.WorkspaceFolder | undefined,
-    config: SorobanLaunchConfig
+    config: SorobanLaunchConfig,
   ): Promise<vscode.DebugConfiguration | null | undefined> {
     if (!config.type && !config.request && !config.name) {
       return this.createDefaultLaunchConfig(folder);
     }
 
-    if (config.type !== 'soroban' || config.request !== 'launch') {
+    if (config.type !== "soroban" || config.request !== "launch") {
       return config;
     }
 
-    const settings = vscode.workspace.getConfiguration('soroban-debugger', folder);
-    config.requestTimeoutMs = config.requestTimeoutMs ?? settings.get<number>('requestTimeoutMs');
-    config.connectTimeoutMs = config.connectTimeoutMs ?? settings.get<number>('connectTimeoutMs');
+    const settings = vscode.workspace.getConfiguration(
+      "soroban-debugger",
+      folder,
+    );
+    config.requestTimeoutMs =
+      config.requestTimeoutMs ?? settings.get<number>("requestTimeoutMs");
+    config.connectTimeoutMs =
+      config.connectTimeoutMs ?? settings.get<number>("connectTimeoutMs");
 
     const preflight = await validateLaunchConfig(config);
     if (preflight.ok) {
@@ -43,8 +51,12 @@ class SorobanDebugConfigurationProvider implements vscode.DebugConfigurationProv
     return undefined;
   }
 
-  private createDefaultLaunchConfig(folder: vscode.WorkspaceFolder | undefined): vscode.DebugConfiguration {
-    return createDefaultLaunchConfig(folder?.uri.fsPath ?? '${workspaceFolder}');
+  private createDefaultLaunchConfig(
+    folder: vscode.WorkspaceFolder | undefined,
+  ): vscode.DebugConfiguration {
+    return createDefaultLaunchConfig(
+      folder?.uri.fsPath ?? "${workspaceFolder}",
+    );
   }
 }
 
@@ -54,14 +66,60 @@ export function activate(context: vscode.ExtensionContext): void {
   logManager = new LogManager(context);
   const factory = new SorobanDebugAdapterDescriptorFactory(context, logManager);
   const configurationProvider = new SorobanDebugConfigurationProvider();
+  const statusItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    100,
+  );
+  statusItem.name = "Soroban Debug Session Info";
+  statusItem.hide();
+
+  const applySessionInfo = (info: DebuggerSessionInfo): void => {
+    const text = `Soroban: v${info.backendVersion} | protocol ${info.protocolVersion}`;
+    statusItem.text = text;
+    statusItem.tooltip = text;
+    statusItem.show();
+  };
 
   context.subscriptions.push(
-    vscode.debug.registerDebugAdapterDescriptorFactory('soroban', factory),
-    vscode.debug.registerDebugConfigurationProvider('soroban', configurationProvider),
+    vscode.debug.registerDebugAdapterDescriptorFactory("soroban", factory),
+    vscode.debug.registerDebugConfigurationProvider(
+      "soroban",
+      configurationProvider,
+    ),
     vscode.commands.registerCommand(RUN_LAUNCH_PREFLIGHT_COMMAND, async () => {
       await runStandaloneLaunchPreflight();
     }),
-    factory
+    vscode.debug.onDidStartDebugSession((session) => {
+      if (session.type !== "soroban") {
+        return;
+      }
+
+      applySessionInfo({
+        backendVersion: "unknown",
+        protocolVersion: "unknown",
+      });
+
+      const info = factory.getSessionInfo(session.id);
+      if (info) {
+        applySessionInfo(info);
+      }
+    }),
+    factory.onSessionInfo(({ sessionId, info }) => {
+      const active = vscode.debug.activeDebugSession;
+      if (!active || active.type !== "soroban" || active.id !== sessionId) {
+        return;
+      }
+      applySessionInfo(info);
+    }),
+    vscode.debug.onDidTerminateDebugSession((session) => {
+      if (session.type !== "soroban") {
+        return;
+      }
+      factory.clearSession(session.id);
+      statusItem.hide();
+    }),
+    factory,
+    statusItem,
   );
 }
 
@@ -71,62 +129,75 @@ export function deactivate(): void {
   }
 }
 
-async function ensureLaunchConfig(folder: vscode.WorkspaceFolder | undefined): Promise<void> {
+async function ensureLaunchConfig(
+  folder: vscode.WorkspaceFolder | undefined,
+): Promise<void> {
   const workspaceFolder = folder ?? vscode.workspace.workspaceFolders?.[0];
   if (!workspaceFolder) {
-    await vscode.window.showInformationMessage('Open a workspace folder first to generate a Soroban launch configuration.');
+    await vscode.window.showInformationMessage(
+      "Open a workspace folder first to generate a Soroban launch configuration.",
+    );
     return;
   }
 
-  const vscodeDir = vscode.Uri.joinPath(workspaceFolder.uri, '.vscode');
-  const launchUri = vscode.Uri.joinPath(vscodeDir, 'launch.json');
+  const vscodeDir = vscode.Uri.joinPath(workspaceFolder.uri, ".vscode");
+  const launchUri = vscode.Uri.joinPath(vscodeDir, "launch.json");
 
   try {
     await vscode.workspace.fs.createDirectory(vscodeDir);
-    let launchJson: { version: string; configurations: vscode.DebugConfiguration[] };
+    let launchJson: {
+      version: string;
+      configurations: vscode.DebugConfiguration[];
+    };
 
     try {
       const existing = await vscode.workspace.fs.readFile(launchUri);
-      launchJson = JSON.parse(Buffer.from(existing).toString('utf8')) as {
+      launchJson = JSON.parse(Buffer.from(existing).toString("utf8")) as {
         version: string;
         configurations: vscode.DebugConfiguration[];
       };
     } catch {
-      launchJson = { version: '0.2.0', configurations: [] };
+      launchJson = { version: "0.2.0", configurations: [] };
     }
 
-    const alreadyPresent = launchJson.configurations.some((configuration) =>
-      configuration.type === 'soroban' &&
-      configuration.request === 'launch'
+    const alreadyPresent = launchJson.configurations.some(
+      (configuration) =>
+        configuration.type === "soroban" && configuration.request === "launch",
     );
 
     if (!alreadyPresent) {
-      launchJson.configurations.push(createDefaultLaunchConfig('${workspaceFolder}'));
+      launchJson.configurations.push(
+        createDefaultLaunchConfig("${workspaceFolder}"),
+      );
 
       await vscode.workspace.fs.writeFile(
         launchUri,
-        Buffer.from(`${JSON.stringify(launchJson, null, 2)}\n`, 'utf8')
+        Buffer.from(`${JSON.stringify(launchJson, null, 2)}\n`, "utf8"),
       );
     }
 
     const doc = await vscode.workspace.openTextDocument(launchUri);
     await vscode.window.showTextDocument(doc, { preview: false });
   } catch (error) {
-    await vscode.window.showErrorMessage(`Failed to generate launch.json: ${String(error)}`);
+    await vscode.window.showErrorMessage(
+      `Failed to generate launch.json: ${String(error)}`,
+    );
   }
 }
 
-function createDefaultLaunchConfig(workspaceFolder: string): vscode.DebugConfiguration {
+function createDefaultLaunchConfig(
+  workspaceFolder: string,
+): vscode.DebugConfiguration {
   return {
-    name: 'Soroban: Debug Contract',
-    type: 'soroban',
-    request: 'launch',
+    name: "Soroban: Debug Contract",
+    type: "soroban",
+    request: "launch",
     contractPath: `${workspaceFolder}/target/wasm32-unknown-unknown/release/contract.wasm`,
     snapshotPath: `${workspaceFolder}/snapshot.json`,
-    entrypoint: 'main',
+    entrypoint: "main",
     args: [],
     trace: false,
-    binaryPath: `${workspaceFolder}/target/debug/${process.platform === 'win32' ? 'soroban-debug.exe' : 'soroban-debug'}`
+    binaryPath: `${workspaceFolder}/target/debug/${process.platform === "win32" ? "soroban-debug.exe" : "soroban-debug"}`,
   };
 }
 
@@ -134,14 +205,20 @@ async function runStandaloneLaunchPreflight(): Promise<void> {
   const sources = (() => {
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
-      return [{
-        configurations: vscode.workspace.getConfiguration('launch').get<unknown[]>('configurations')
-      }];
+      return [
+        {
+          configurations: vscode.workspace
+            .getConfiguration("launch")
+            .get<unknown[]>("configurations"),
+        },
+      ];
     }
 
     return folders.map((folder) => ({
       folder,
-      configurations: vscode.workspace.getConfiguration('launch', folder).get<unknown[]>('configurations')
+      configurations: vscode.workspace
+        .getConfiguration("launch", folder)
+        .get<unknown[]>("configurations"),
     }));
   })();
 
@@ -153,30 +230,35 @@ async function runStandaloneLaunchPreflight(): Promise<void> {
           label: candidate.label,
           description: candidate.description,
           detail: candidate.detail,
-          candidate
+          candidate,
         })),
         {
-          placeHolder: 'Select a Soroban launch configuration to validate'
-        }
+          placeHolder: "Select a Soroban launch configuration to validate",
+        },
       );
       return picked?.candidate;
     },
-    validateLaunchConfig: async (config) => validateLaunchConfig(config as SorobanLaunchConfig),
-    showInformationMessage: async (message, ...actions) => vscode.window.showInformationMessage(message, ...actions),
-    showWarningMessage: async (message, ...actions) => vscode.window.showWarningMessage(message, ...actions),
-    showErrorMessage: async (message, ...actions) => vscode.window.showErrorMessage(message, ...actions),
-    applyQuickFix: async (quickFix, folder) => applyQuickFix(quickFix, folder as vscode.WorkspaceFolder | undefined)
+    validateLaunchConfig: async (config) =>
+      validateLaunchConfig(config as SorobanLaunchConfig),
+    showInformationMessage: async (message, ...actions) =>
+      vscode.window.showInformationMessage(message, ...actions),
+    showWarningMessage: async (message, ...actions) =>
+      vscode.window.showWarningMessage(message, ...actions),
+    showErrorMessage: async (message, ...actions) =>
+      vscode.window.showErrorMessage(message, ...actions),
+    applyQuickFix: async (quickFix, folder) =>
+      applyQuickFix(quickFix, folder as vscode.WorkspaceFolder | undefined),
   });
 }
 
 async function showPreflightIssueAndApplyFix(
   issue: LaunchPreflightIssue,
-  folder: vscode.WorkspaceFolder | undefined
+  folder: vscode.WorkspaceFolder | undefined,
 ): Promise<void> {
   const actions = issue.quickFixes.map(toQuickPickLabel);
   const selected = await vscode.window.showErrorMessage(
     `${issue.message} Expected: ${issue.expected}`,
-    ...actions
+    ...actions,
   );
   const quickFix = fromQuickPickLabel(selected);
   if (quickFix) {
@@ -186,26 +268,29 @@ async function showPreflightIssueAndApplyFix(
 
 async function applyQuickFix(
   quickFix: LaunchPreflightQuickFix,
-  folder: vscode.WorkspaceFolder | undefined
+  folder: vscode.WorkspaceFolder | undefined,
 ): Promise<void> {
   switch (quickFix) {
-    case 'pickBinary':
-      await pickFile('Select soroban-debug binary', ['exe', 'bin', '']);
+    case "pickBinary":
+      await pickFile("Select soroban-debug binary", ["exe", "bin", ""]);
       return;
-    case 'pickContract':
-      await pickFile('Select Soroban contract WASM', ['wasm']);
+    case "pickContract":
+      await pickFile("Select Soroban contract WASM", ["wasm"]);
       return;
-    case 'pickSnapshot':
-      await pickFile('Select snapshot JSON', ['json']);
+    case "pickSnapshot":
+      await pickFile("Select snapshot JSON", ["json"]);
       return;
-    case 'openLaunchConfig':
-      await vscode.commands.executeCommand('workbench.action.debug.configure');
+    case "openLaunchConfig":
+      await vscode.commands.executeCommand("workbench.action.debug.configure");
       return;
-    case 'generateLaunchConfig':
+    case "generateLaunchConfig":
       await ensureLaunchConfig(folder);
       return;
-    case 'openSettings':
-      await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:soroban.soroban-debugger');
+    case "openSettings":
+      await vscode.commands.executeCommand(
+        "workbench.action.openSettings",
+        "@ext:soroban.soroban-debugger",
+      );
       return;
     default:
       return;
@@ -219,18 +304,22 @@ async function pickFile(title: string, extensions: string[]): Promise<void> {
     canSelectFolders: false,
     canSelectMany: false,
     openLabel: title,
-    filters: filters.length > 0 ? { Files: filters } : undefined
+    filters: filters.length > 0 ? { Files: filters } : undefined,
   });
 
   if (selected && selected.length > 0) {
     await vscode.env.clipboard.writeText(selected[0].fsPath);
-    await vscode.window.showInformationMessage(
-      `Selected path copied to clipboard: ${selected[0].fsPath}`,
-      'Open launch.json'
-    ).then(async (choice) => {
-      if (choice === 'Open launch.json') {
-        await vscode.commands.executeCommand('workbench.action.debug.configure');
-      }
-    });
+    await vscode.window
+      .showInformationMessage(
+        `Selected path copied to clipboard: ${selected[0].fsPath}`,
+        "Open launch.json",
+      )
+      .then(async (choice) => {
+        if (choice === "Open launch.json") {
+          await vscode.commands.executeCommand(
+            "workbench.action.debug.configure",
+          );
+        }
+      });
   }
 }

--- a/extensions/vscode/src/test/runTest.ts
+++ b/extensions/vscode/src/test/runTest.ts
@@ -1,17 +1,23 @@
-import * as assert from 'assert';
-import { ChildProcess, spawn } from 'child_process';
-import * as fs from 'fs';
-import * as net from 'net';
-import * as path from 'path';
-import { DebuggerProcess, validateLaunchConfig, formatProtocolMismatchMessage, DebuggerTimeoutError } from '../cli/debuggerProcess';
-import { resolveSourceBreakpoints } from '../dap/sourceBreakpoints';
-import { VariableStore } from '../dap/variableStore';
+import * as assert from "assert";
+import { ChildProcess, spawn } from "child_process";
+import * as fs from "fs";
+import * as net from "net";
+import * as path from "path";
+import {
+  DebuggerProcess,
+  validateLaunchConfig,
+  formatProtocolMismatchMessage,
+  DebuggerTimeoutError,
+  extractSessionInfoFromPong,
+} from "../cli/debuggerProcess";
+import { resolveSourceBreakpoints } from "../dap/sourceBreakpoints";
+import { VariableStore } from "../dap/variableStore";
 import {
   collectSorobanLaunchConfigs,
   formatPreflightFailureMessage,
-  runLaunchPreflightCommand
-} from '../preflightCommand';
-import { DapClient } from './dapClient';
+  runLaunchPreflightCommand,
+} from "../preflightCommand";
+import { DapClient } from "./dapClient";
 
 type DebugMessage = {
   id: number;
@@ -19,19 +25,21 @@ type DebugMessage = {
   response?: { type: string; [key: string]: unknown };
 };
 
-async function startMockDebuggerServer(options: { evaluateDelayMs: number }): Promise<{ port: number; close: () => Promise<void> }> {
+async function startMockDebuggerServer(options: {
+  evaluateDelayMs: number;
+}): Promise<{ port: number; close: () => Promise<void> }> {
   const server = net.createServer();
   const sockets = new Set<net.Socket>();
 
-  server.on('connection', (socket) => {
+  server.on("connection", (socket) => {
     sockets.add(socket);
-    socket.setEncoding('utf8');
+    socket.setEncoding("utf8");
 
-    let buffer = '';
-    socket.on('data', (chunk: string) => {
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
       buffer += chunk;
       while (true) {
-        const newlineIndex = buffer.indexOf('\n');
+        const newlineIndex = buffer.indexOf("\n");
         if (newlineIndex === -1) {
           return;
         }
@@ -47,7 +55,7 @@ async function startMockDebuggerServer(options: { evaluateDelayMs: number }): Pr
           continue;
         }
 
-        const respond = (response: DebugMessage['response'], delayMs = 0) => {
+        const respond = (response: DebugMessage["response"], delayMs = 0) => {
           setTimeout(() => {
             if (socket.destroyed) {
               return;
@@ -57,61 +65,89 @@ async function startMockDebuggerServer(options: { evaluateDelayMs: number }): Pr
         };
 
         switch (message.request.type) {
-          case 'Handshake':
+          case "Handshake":
             respond({
-              type: 'HandshakeAck',
-              server_name: 'mock-soroban-debug',
-              server_version: '0.1.0',
+              type: "HandshakeAck",
+              server_name: "mock-soroban-debug",
+              server_version: "0.1.0",
               protocol_min: 1,
               protocol_max: 1,
-              selected_version: 1
+              selected_version: 1,
             });
             break;
-          case 'Authenticate':
-            respond({ type: 'Authenticated', success: true, message: 'ok' });
+          case "Authenticate":
+            respond({ type: "Authenticated", success: true, message: "ok" });
             break;
-          case 'LoadSnapshot':
-            respond({ type: 'SnapshotLoaded', summary: 'ok' });
+          case "LoadSnapshot":
+            respond({ type: "SnapshotLoaded", summary: "ok" });
             break;
-          case 'LoadContract':
-            respond({ type: 'ContractLoaded', size: 0 });
+          case "LoadContract":
+            respond({ type: "ContractLoaded", size: 0 });
             break;
-          case 'Ping':
-            respond({ type: 'Pong' });
+          case "Ping":
+            respond({
+              type: "Pong",
+              backend_version: "0.1.0",
+              protocol_version: "1",
+            });
             break;
-          case 'Evaluate':
-            respond({ type: 'EvaluateResult', result: 'ok', result_type: 'string', variables_reference: 0 }, options.evaluateDelayMs);
+          case "Evaluate":
+            respond(
+              {
+                type: "EvaluateResult",
+                result: "ok",
+                result_type: "string",
+                variables_reference: 0,
+              },
+              options.evaluateDelayMs,
+            );
             break;
-          case 'Inspect':
-            respond({ type: 'InspectionResult', function: 'main', args: '[]', step_count: 0, paused: true, call_stack: ['main'] }, options.evaluateDelayMs);
+          case "Inspect":
+            respond(
+              {
+                type: "InspectionResult",
+                function: "main",
+                args: "[]",
+                step_count: 0,
+                paused: true,
+                call_stack: ["main"],
+              },
+              options.evaluateDelayMs,
+            );
             break;
-          case 'GetStorage':
-            respond({ type: 'StorageState', storage_json: '{}' }, options.evaluateDelayMs);
+          case "GetStorage":
+            respond(
+              { type: "StorageState", storage_json: "{}" },
+              options.evaluateDelayMs,
+            );
             break;
-          case 'Disconnect':
-            respond({ type: 'Disconnected' });
+          case "Disconnect":
+            respond({ type: "Disconnected" });
             break;
           default:
-            respond({ type: 'Error', message: `Unhandled request type: ${message.request.type}` });
+            respond({
+              type: "Error",
+              message: `Unhandled request type: ${message.request.type}`,
+            });
             break;
         }
       }
     });
 
-    socket.on('close', () => sockets.delete(socket));
-    socket.on('error', () => sockets.delete(socket));
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => sockets.delete(socket));
   });
 
   const port = await new Promise<number>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, "127.0.0.1", () => {
       const address = server.address();
-      if (!address || typeof address === 'string') {
-        reject(new Error('Failed to allocate mock server port'));
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to allocate mock server port"));
         return;
       }
       resolve(address.port);
     });
-    server.on('error', reject);
+    server.on("error", reject);
   });
 
   return {
@@ -121,7 +157,7 @@ async function startMockDebuggerServer(options: { evaluateDelayMs: number }): Pr
         socket.destroy();
       }
       await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
+    },
   };
 }
 
@@ -131,104 +167,173 @@ async function wait(ms: number): Promise<void> {
 
 async function main(): Promise<void> {
   const compatibilityMessage = formatProtocolMismatchMessage({
-    extensionVersion: '0.1.0',
-    backendName: 'soroban-debug',
-    backendVersion: '0.0.0',
+    extensionVersion: "0.1.0",
+    backendName: "soroban-debug",
+    backendVersion: "0.0.0",
     backendProtocolMin: 0,
     backendProtocolMax: 0,
-    extra: 'Protocol mismatch: client supports [1..=1], server supports [0..=0]'
+    extra:
+      "Protocol mismatch: client supports [1..=1], server supports [0..=0]",
   });
-  assert.match(compatibilityMessage, /Extension version:/, 'Expected protocol mismatch message to mention extension version');
-  assert.match(compatibilityMessage, /supports protocol/, 'Expected protocol mismatch message to mention backend protocol range');
-  assert.match(compatibilityMessage, /Remediation:/, 'Expected protocol mismatch message to include remediation guidance');
+  assert.match(
+    compatibilityMessage,
+    /Extension version:/,
+    "Expected protocol mismatch message to mention extension version",
+  );
+  assert.match(
+    compatibilityMessage,
+    /supports protocol/,
+    "Expected protocol mismatch message to mention backend protocol range",
+  );
+  assert.match(
+    compatibilityMessage,
+    /Remediation:/,
+    "Expected protocol mismatch message to include remediation guidance",
+  );
 
   await assertPerRequestTimeoutBehavior();
 
   const extensionRoot = process.cwd();
-  const repoRoot = path.resolve(extensionRoot, '..', '..');
+  const repoRoot = path.resolve(extensionRoot, "..", "..");
 
   {
-    const store = new VariableStore({ pageSize: 3, maxStringPreview: 6, maxHexPreviewBytes: 2 });
+    const store = new VariableStore({
+      pageSize: 3,
+      maxStringPreview: 6,
+      maxHexPreviewBytes: 2,
+    });
 
     const bigArray = [1, 2, 3, 4, 5, 6, 7];
-    const arrayVar = store.toVariable('arr', bigArray);
-    assert.ok(arrayVar.variablesReference && arrayVar.variablesReference > 0, 'Expected array to be expandable');
+    const arrayVar = store.toVariable("arr", bigArray);
+    assert.ok(
+      arrayVar.variablesReference && arrayVar.variablesReference > 0,
+      "Expected array to be expandable",
+    );
     assert.equal(arrayVar.indexedVariables, bigArray.length);
 
     const firstPage = store.getVariables(arrayVar.variablesReference as number);
-    assert.deepEqual(firstPage.slice(0, 3).map((v) => v.name), ['[0]', '[1]', '[2]']);
-    assert.equal(firstPage[0].value, '1');
+    assert.deepEqual(
+      firstPage.slice(0, 3).map((v) => v.name),
+      ["[0]", "[1]", "[2]"],
+    );
+    assert.equal(firstPage[0].value, "1");
 
     const pager = firstPage[3];
     assert.match(pager.name, /show more/i);
-    assert.ok(pager.variablesReference && pager.variablesReference > 0, 'Expected pager to be expandable');
+    assert.ok(
+      pager.variablesReference && pager.variablesReference > 0,
+      "Expected pager to be expandable",
+    );
 
     const secondPage = store.getVariables(pager.variablesReference as number);
-    assert.deepEqual(secondPage.slice(0, 3).map((v) => v.name), ['[3]', '[4]', '[5]']);
-    assert.equal(secondPage[2].value, '6');
+    assert.deepEqual(
+      secondPage.slice(0, 3).map((v) => v.name),
+      ["[3]", "[4]", "[5]"],
+    );
+    assert.equal(secondPage[2].value, "6");
 
     const thirdPager = secondPage[3];
-    const thirdPage = store.getVariables(thirdPager.variablesReference as number);
-    assert.deepEqual(thirdPage.map((v) => v.name), ['[6]']);
+    const thirdPage = store.getVariables(
+      thirdPager.variablesReference as number,
+    );
+    assert.deepEqual(
+      thirdPage.map((v) => v.name),
+      ["[6]"],
+    );
 
-    const longString = store.toVariable('s', '1234567890');
-    assert.ok(longString.variablesReference && longString.variablesReference > 0, 'Expected long string to be expandable');
+    const longString = store.toVariable("s", "1234567890");
+    assert.ok(
+      longString.variablesReference && longString.variablesReference > 0,
+      "Expected long string to be expandable",
+    );
     assert.match(longString.value, /truncated/i);
-    const fullString = store.getVariables(longString.variablesReference as number);
-    assert.equal(fullString[0].name, '(full)');
-    assert.equal(fullString[0].value, '1234567890');
+    const fullString = store.getVariables(
+      longString.variablesReference as number,
+    );
+    assert.equal(fullString[0].name, "(full)");
+    assert.equal(fullString[0].value, "1234567890");
 
-    const bytesVar = store.toVariable('b', { type: 'bytes', value: '0x01020304' });
-    assert.ok(bytesVar.variablesReference && bytesVar.variablesReference > 0, 'Expected bytes to be expandable');
+    const bytesVar = store.toVariable("b", {
+      type: "bytes",
+      value: "0x01020304",
+    });
+    assert.ok(
+      bytesVar.variablesReference && bytesVar.variablesReference > 0,
+      "Expected bytes to be expandable",
+    );
     assert.match(bytesVar.value, /bytes\(\d+\)/);
-    const bytesDetails = store.getVariables(bytesVar.variablesReference as number);
-    assert.ok(bytesDetails.some((v) => v.name === 'hex'), 'Expected bytes details to include hex');
-    assert.ok(bytesDetails.some((v) => v.name === 'base64'), 'Expected bytes details to include base64');
+    const bytesDetails = store.getVariables(
+      bytesVar.variablesReference as number,
+    );
+    assert.ok(
+      bytesDetails.some((v) => v.name === "hex"),
+      "Expected bytes details to include hex",
+    );
+    assert.ok(
+      bytesDetails.some((v) => v.name === "base64"),
+      "Expected bytes details to include base64",
+    );
 
-    const addr = 'G' + 'A'.repeat(55);
-    const addrVar = store.toVariable('a', addr);
-    assert.equal(addrVar.type, 'address');
+    const addr = "G" + "A".repeat(55);
+    const addrVar = store.toVariable("a", addr);
+    assert.equal(addrVar.type, "address");
 
-    console.log('Variable rendering unit tests passed');
+    console.log("Variable rendering unit tests passed");
   }
 
   {
     const mockServer = await startMockDebuggerServer({ evaluateDelayMs: 150 });
     const debuggerProcess = new DebuggerProcess({
-      contractPath: 'mock.wasm',
+      contractPath: "mock.wasm",
       port: mockServer.port,
-      spawnServer: false
+      spawnServer: false,
     });
 
     await debuggerProcess.start();
 
     // Cancel-before-response: abort removes pending entry and ignores late responses.
     const controller = new AbortController();
-    const evaluatePromise = debuggerProcess.evaluate('1', undefined, { signal: controller.signal });
+    const evaluatePromise = debuggerProcess.evaluate("1", undefined, {
+      signal: controller.signal,
+    });
     setTimeout(() => controller.abort(), 10);
-    await assert.rejects(evaluatePromise, (error: any) => error?.name === 'AbortError');
+    await assert.rejects(
+      evaluatePromise,
+      (error: any) => error?.name === "AbortError",
+    );
 
     await wait(250);
-    assert.equal(((debuggerProcess as any).pendingRequests as Map<number, unknown>).size, 0);
+    assert.equal(
+      ((debuggerProcess as any).pendingRequests as Map<number, unknown>).size,
+      0,
+    );
     await debuggerProcess.ping();
 
     // Cancel-after-timeout: timeout removes pending entry and ignores late responses.
-    const timedOut = debuggerProcess.evaluate('2', undefined, { timeoutMs: 20 });
-    await assert.rejects(timedOut, (error: any) => error?.name === 'TimeoutError');
+    const timedOut = debuggerProcess.evaluate("2", undefined, {
+      timeoutMs: 20,
+    });
+    await assert.rejects(
+      timedOut,
+      (error: any) => error?.name === "TimeoutError",
+    );
 
     await wait(250);
-    assert.equal(((debuggerProcess as any).pendingRequests as Map<number, unknown>).size, 0);
+    assert.equal(
+      ((debuggerProcess as any).pendingRequests as Map<number, unknown>).size,
+      0,
+    );
     await debuggerProcess.ping();
 
     await debuggerProcess.stop();
     await mockServer.close();
-    console.log('Cancellation tests passed');
+    console.log("Cancellation tests passed");
   }
 
   const emittedFiles = [
-    path.join(extensionRoot, 'dist', 'extension.js'),
-    path.join(extensionRoot, 'dist', 'debugAdapter.js'),
-    path.join(extensionRoot, 'dist', 'cli', 'debuggerProcess.js')
+    path.join(extensionRoot, "dist", "extension.js"),
+    path.join(extensionRoot, "dist", "debugAdapter.js"),
+    path.join(extensionRoot, "dist", "cli", "debuggerProcess.js"),
   ];
 
   for (const file of emittedFiles) {
@@ -236,100 +341,153 @@ async function main(): Promise<void> {
   }
 
   const preflightBinaryPath = emittedFiles[0];
-  const contractPath = path.join(repoRoot, 'tests', 'fixtures', 'wasm', 'echo.wasm');
-  assert.ok(fs.existsSync(contractPath), `Missing fixture WASM: ${contractPath}`);
-  const snapshotPath = path.join(repoRoot, 'extensions', 'vscode', 'package.json');
+  const contractPath = path.join(
+    repoRoot,
+    "tests",
+    "fixtures",
+    "wasm",
+    "echo.wasm",
+  );
+  assert.ok(
+    fs.existsSync(contractPath),
+    `Missing fixture WASM: ${contractPath}`,
+  );
+  const snapshotPath = path.join(
+    repoRoot,
+    "extensions",
+    "vscode",
+    "package.json",
+  );
 
   const goodPreflight = await validateLaunchConfig({
     binaryPath: preflightBinaryPath,
     contractPath,
     snapshotPath,
-    entrypoint: 'echo',
-    args: ['7'],
-    token: 'debug-token'
+    entrypoint: "echo",
+    args: ["7"],
+    token: "debug-token",
   });
-  assert.equal(goodPreflight.ok, true, 'Expected valid launch configuration to pass preflight');
+  assert.equal(
+    goodPreflight.ok,
+    true,
+    "Expected valid launch configuration to pass preflight",
+  );
 
   const missingContract = await validateLaunchConfig({
     binaryPath: preflightBinaryPath,
-    contractPath: path.join(repoRoot, 'missing-contract.wasm'),
-    entrypoint: 'echo',
-    args: []
+    contractPath: path.join(repoRoot, "missing-contract.wasm"),
+    entrypoint: "echo",
+    args: [],
   });
-  assert.equal(missingContract.ok, false, 'Expected missing contract path to fail preflight');
-  assert.equal(missingContract.issues[0].field, 'contractPath');
+  assert.equal(
+    missingContract.ok,
+    false,
+    "Expected missing contract path to fail preflight",
+  );
+  assert.equal(missingContract.issues[0].field, "contractPath");
   assert.match(missingContract.issues[0].message, /contractPath/);
 
   const badArgs = await validateLaunchConfig({
     binaryPath: preflightBinaryPath,
     contractPath,
-    entrypoint: 'echo',
-    args: [{ nested: undefined }]
+    entrypoint: "echo",
+    args: [{ nested: undefined }],
   });
-  assert.equal(badArgs.ok, false, 'Expected non-serializable args to fail preflight');
-  assert.equal(badArgs.issues[0].field, 'args');
+  assert.equal(
+    badArgs.ok,
+    false,
+    "Expected non-serializable args to fail preflight",
+  );
+  assert.equal(badArgs.issues[0].field, "args");
   assert.match(badArgs.issues[0].message, /\$\[0\]\.nested/);
 
   const badPort = await validateLaunchConfig({
     binaryPath: preflightBinaryPath,
     contractPath,
-    entrypoint: 'echo',
+    entrypoint: "echo",
     args: [],
-    port: 70000
+    port: 70000,
   });
-  assert.equal(badPort.ok, false, 'Expected out-of-range port to fail preflight');
-  assert.equal(badPort.issues[0].field, 'port');
+  assert.equal(
+    badPort.ok,
+    false,
+    "Expected out-of-range port to fail preflight",
+  );
+  assert.equal(badPort.issues[0].field, "port");
 
   const badToken = await validateLaunchConfig({
     binaryPath: preflightBinaryPath,
     contractPath,
-    entrypoint: 'echo',
+    entrypoint: "echo",
     args: [],
-    token: '   '
+    token: "   ",
   });
-  assert.equal(badToken.ok, false, 'Expected blank token to fail preflight');
-  assert.equal(badToken.issues[0].field, 'token');
+  assert.equal(badToken.ok, false, "Expected blank token to fail preflight");
+  assert.equal(badToken.issues[0].field, "token");
 
   {
     const candidates = collectSorobanLaunchConfigs([
       {
-        folder: { name: 'workspace-a' },
+        folder: { name: "workspace-a" },
         configurations: [
-          { name: 'Soroban: First', type: 'soroban', request: 'launch', contractPath: contractPath },
-          { name: 'Ignored', type: 'node', request: 'launch' }
-        ]
+          {
+            name: "Soroban: First",
+            type: "soroban",
+            request: "launch",
+            contractPath: contractPath,
+          },
+          { name: "Ignored", type: "node", request: "launch" },
+        ],
       },
       {
-        folder: { name: 'workspace-b' },
+        folder: { name: "workspace-b" },
         configurations: [
-          { name: 'Soroban: Second', type: 'soroban', request: 'launch', contractPath: 'contract-b.wasm' }
-        ]
-      }
+          {
+            name: "Soroban: Second",
+            type: "soroban",
+            request: "launch",
+            contractPath: "contract-b.wasm",
+          },
+        ],
+      },
     ]);
 
-    assert.equal(candidates.length, 2, 'Expected only Soroban launch configs to be collected');
-    assert.equal(candidates[0].description, 'workspace-a');
-    assert.equal(candidates[1].description, 'workspace-b');
+    assert.equal(
+      candidates.length,
+      2,
+      "Expected only Soroban launch configs to be collected",
+    );
+    assert.equal(candidates[0].description, "workspace-a");
+    assert.equal(candidates[1].description, "workspace-b");
   }
 
   {
     const applyQuickFixCalls: string[] = [];
-    let infoMessage = '';
+    let infoMessage = "";
 
     const outcome = await runLaunchPreflightCommand({
-      launchConfigSources: [{
-        folder: { name: 'workspace-a' },
-        configurations: [
-          { name: 'Soroban: Happy Path', type: 'soroban', request: 'launch', contractPath }
-        ]
-      }],
+      launchConfigSources: [
+        {
+          folder: { name: "workspace-a" },
+          configurations: [
+            {
+              name: "Soroban: Happy Path",
+              type: "soroban",
+              request: "launch",
+              contractPath,
+            },
+          ],
+        },
+      ],
       selectLaunchConfig: async () => {
-        throw new Error('Did not expect configuration picker for a single config');
+        throw new Error(
+          "Did not expect configuration picker for a single config",
+        );
       },
       validateLaunchConfig: async () => ({
         ok: true,
         issues: [],
-        resolvedBinaryPath: preflightBinaryPath
+        resolvedBinaryPath: preflightBinaryPath,
       }),
       showInformationMessage: async (message: string) => {
         infoMessage = message;
@@ -339,195 +497,306 @@ async function main(): Promise<void> {
       showErrorMessage: async () => undefined,
       applyQuickFix: async (quickFix) => {
         applyQuickFixCalls.push(quickFix);
-      }
+      },
     });
 
-    assert.equal(outcome, 'passed');
+    assert.equal(outcome, "passed");
     assert.match(infoMessage, /backend was not started/i);
     assert.deepEqual(applyQuickFixCalls, []);
   }
 
   {
     const applyQuickFixCalls: string[] = [];
-    let errorMessage = '';
+    let errorMessage = "";
 
     const outcome = await runLaunchPreflightCommand({
-      launchConfigSources: [{
-        folder: { name: 'workspace-a' },
-        configurations: [
-          { name: 'Soroban: Broken', type: 'soroban', request: 'launch', contractPath }
-        ]
-      }],
+      launchConfigSources: [
+        {
+          folder: { name: "workspace-a" },
+          configurations: [
+            {
+              name: "Soroban: Broken",
+              type: "soroban",
+              request: "launch",
+              contractPath,
+            },
+          ],
+        },
+      ],
       selectLaunchConfig: async () => {
-        throw new Error('Did not expect configuration picker for a single config');
+        throw new Error(
+          "Did not expect configuration picker for a single config",
+        );
       },
       validateLaunchConfig: async () => ({
         ok: false,
         issues: [
           {
-            field: 'contractPath',
-            message: "Launch config field 'contractPath' points to a missing file.",
-            expected: 'A readable .wasm file.',
-            quickFixes: ['pickContract', 'openLaunchConfig']
+            field: "contractPath",
+            message:
+              "Launch config field 'contractPath' points to a missing file.",
+            expected: "A readable .wasm file.",
+            quickFixes: ["pickContract", "openLaunchConfig"],
           },
           {
-            field: 'args',
+            field: "args",
             message: "Launch config field 'args' must be an array.",
-            expected: 'A JSON array.',
-            quickFixes: ['openLaunchConfig']
-          }
+            expected: "A JSON array.",
+            quickFixes: ["openLaunchConfig"],
+          },
         ],
-        resolvedBinaryPath: preflightBinaryPath
+        resolvedBinaryPath: preflightBinaryPath,
       }),
       showInformationMessage: async () => undefined,
       showWarningMessage: async () => undefined,
       showErrorMessage: async (message: string, ...actions: string[]) => {
         errorMessage = message;
-        assert.deepEqual(actions, ['Select Contract', 'Open launch.json']);
-        return 'Select Contract';
+        assert.deepEqual(actions, ["Select Contract", "Open launch.json"]);
+        return "Select Contract";
       },
       applyQuickFix: async (quickFix) => {
         applyQuickFixCalls.push(quickFix);
-      }
+      },
     });
 
-    assert.equal(outcome, 'failed');
+    assert.equal(outcome, "failed");
     assert.match(errorMessage, /found 2 issues/i);
-    assert.deepEqual(applyQuickFixCalls, ['pickContract']);
+    assert.deepEqual(applyQuickFixCalls, ["pickContract"]);
     assert.match(
       formatPreflightFailureMessage(
-        { label: 'Soroban: Broken', config: { contractPath } },
+        { label: "Soroban: Broken", config: { contractPath } },
         [
           {
-            field: 'contractPath',
-            message: 'missing',
-            expected: 'expected',
-            quickFixes: ['pickContract']
-          }
-        ]
+            field: "contractPath",
+            message: "missing",
+            expected: "expected",
+            quickFixes: ["pickContract"],
+          },
+        ],
       ),
-      /Soroban: Broken/
+      /Soroban: Broken/,
     );
   }
 
   {
     const applyQuickFixCalls: string[] = [];
-    let warningMessage = '';
+    let warningMessage = "";
 
     const outcome = await runLaunchPreflightCommand({
-      launchConfigSources: [{
-        folder: { name: 'workspace-a' },
-        configurations: []
-      }],
+      launchConfigSources: [
+        {
+          folder: { name: "workspace-a" },
+          configurations: [],
+        },
+      ],
       selectLaunchConfig: async () => undefined,
       validateLaunchConfig: async () => {
-        throw new Error('Did not expect validation with no launch config');
+        throw new Error("Did not expect validation with no launch config");
       },
       showInformationMessage: async () => undefined,
       showWarningMessage: async (message: string, ...actions: string[]) => {
         warningMessage = message;
-        assert.deepEqual(actions, ['Generate Launch Config', 'Open launch.json']);
-        return 'Generate Launch Config';
+        assert.deepEqual(actions, [
+          "Generate Launch Config",
+          "Open launch.json",
+        ]);
+        return "Generate Launch Config";
       },
       showErrorMessage: async () => undefined,
       applyQuickFix: async (quickFix) => {
         applyQuickFixCalls.push(quickFix);
-      }
+      },
     });
 
-    assert.equal(outcome, 'no-config');
+    assert.equal(outcome, "no-config");
     assert.match(warningMessage, /No Soroban launch configurations were found/);
-    assert.deepEqual(applyQuickFixCalls, ['generateLaunchConfig']);
+    assert.deepEqual(applyQuickFixCalls, ["generateLaunchConfig"]);
   }
 
-  const binaryPath = process.env.SOROBAN_DEBUG_BIN
-    || path.join(repoRoot, 'target', 'debug', process.platform === 'win32' ? 'soroban-debug.exe' : 'soroban-debug');
+  const binaryPath =
+    process.env.SOROBAN_DEBUG_BIN ||
+    path.join(
+      repoRoot,
+      "target",
+      "debug",
+      process.platform === "win32" ? "soroban-debug.exe" : "soroban-debug",
+    );
 
   if (!fs.existsSync(binaryPath)) {
-    console.log(`Skipping debugger smoke test because the CLI binary was not found at ${binaryPath}`);
+    console.log(
+      `Skipping debugger smoke test because the CLI binary was not found at ${binaryPath}`,
+    );
     return;
   }
 
   const debuggerProcess = new DebuggerProcess({
     binaryPath,
     contractPath,
-    entrypoint: 'echo',
-    args: ['7']
+    entrypoint: "echo",
+    args: ["7"],
   });
 
   await debuggerProcess.start();
   await debuggerProcess.ping();
+  const sessionInfo = debuggerProcess.getSessionInfo();
+  assert.ok(
+    sessionInfo.backendVersion.length > 0,
+    "Expected backend version to be populated",
+  );
+  assert.ok(
+    sessionInfo.protocolVersion.length > 0,
+    "Expected protocol version to be populated",
+  );
 
-  const sourcePath = path.join(repoRoot, 'tests', 'fixtures', 'contracts', 'echo', 'src', 'lib.rs');
+  const fallbackInfo = extractSessionInfoFromPong({
+    backend_version: undefined,
+    protocol_version: undefined,
+  });
+  assert.equal(
+    fallbackInfo.backendVersion,
+    "unknown",
+    "Expected missing backend version to fallback to unknown",
+  );
+  assert.equal(
+    fallbackInfo.protocolVersion,
+    "unknown",
+    "Expected missing protocol version to fallback to unknown",
+  );
+
+  const sourcePath = path.join(
+    repoRoot,
+    "tests",
+    "fixtures",
+    "contracts",
+    "echo",
+    "src",
+    "lib.rs",
+  );
   assert.ok(fs.existsSync(sourcePath), `Missing fixture source: ${sourcePath}`);
   const exportedFunctions = await debuggerProcess.getContractFunctions();
-  const resolvedBreakpoints = resolveSourceBreakpoints(sourcePath, [10], exportedFunctions);
-  assert.equal(resolvedBreakpoints[0].verified, false, 'Expected heuristic source mapping to be unverified');
-  assert.equal(resolvedBreakpoints[0].functionName, 'echo');
-  assert.equal(resolvedBreakpoints[0].setBreakpoint, true, 'Expected heuristic mapping to still set a function breakpoint');
+  const resolvedBreakpoints = resolveSourceBreakpoints(
+    sourcePath,
+    [10],
+    exportedFunctions,
+  );
+  assert.equal(
+    resolvedBreakpoints[0].verified,
+    false,
+    "Expected heuristic source mapping to be unverified",
+  );
+  assert.equal(resolvedBreakpoints[0].functionName, "echo");
+  assert.equal(
+    resolvedBreakpoints[0].setBreakpoint,
+    true,
+    "Expected heuristic mapping to still set a function breakpoint",
+  );
 
   await debuggerProcess.setBreakpoint({
-    id: 'echo',
-    functionName: 'echo'
+    id: "echo",
+    functionName: "echo",
   });
   const paused = await debuggerProcess.execute();
-  assert.equal(paused.paused, true, 'Expected breakpoint to pause before execution');
+  assert.equal(
+    paused.paused,
+    true,
+    "Expected breakpoint to pause before execution",
+  );
 
   const pausedInspection = await debuggerProcess.inspect();
-  assert.match(pausedInspection.args || '', /7/, 'Expected paused inspection to include call args');
+  assert.match(
+    pausedInspection.args || "",
+    /7/,
+    "Expected paused inspection to include call args",
+  );
 
   const resumed = await debuggerProcess.continueExecution();
-  assert.match(resumed.output || '', /7/, 'Expected continue() to finish echo()');
-  await debuggerProcess.clearBreakpoint('echo');
+  assert.match(
+    resumed.output || "",
+    /7/,
+    "Expected continue() to finish echo()",
+  );
+  await debuggerProcess.clearBreakpoint("echo");
 
   const result = await debuggerProcess.execute();
-  assert.match(result.output, /7/, 'Expected second echo() to return the input');
+  assert.match(
+    result.output,
+    /7/,
+    "Expected second echo() to return the input",
+  );
 
   const inspection = await debuggerProcess.inspect();
-  assert.ok(Array.isArray(inspection.callStack), 'Expected call stack array from inspection');
-  assert.match(inspection.args || '', /7/, 'Expected inspection to include args');
+  assert.ok(
+    Array.isArray(inspection.callStack),
+    "Expected call stack array from inspection",
+  );
+  assert.match(
+    inspection.args || "",
+    /7/,
+    "Expected inspection to include args",
+  );
 
   const storage = await debuggerProcess.getStorage();
-  assert.ok(typeof storage === 'object' && storage !== null, 'Expected storage snapshot object');
+  assert.ok(
+    typeof storage === "object" && storage !== null,
+    "Expected storage snapshot object",
+  );
 
   await debuggerProcess.stop();
-  console.log('VS Code extension smoke tests passed');
+  console.log("VS Code extension smoke tests passed");
 
   // DAP end-to-end tests (adapter <-> backend).
-  const debugAdapterPath = path.join(extensionRoot, 'dist', 'debugAdapter.js');
-  assert.ok(fs.existsSync(debugAdapterPath), `Missing debug adapter entrypoint: ${debugAdapterPath}`);
+  const debugAdapterPath = path.join(extensionRoot, "dist", "debugAdapter.js");
+  assert.ok(
+    fs.existsSync(debugAdapterPath),
+    `Missing debug adapter entrypoint: ${debugAdapterPath}`,
+  );
 
   await runDapHappyPathE2E(debugAdapterPath, {
     contractPath,
     sourcePath,
-    binaryPath
+    binaryPath,
   });
   await runDapLaunchErrorE2E(debugAdapterPath, {
-    contractPath: path.join(repoRoot, 'tests', 'fixtures', 'wasm', 'does-not-exist.wasm'),
+    contractPath: path.join(
+      repoRoot,
+      "tests",
+      "fixtures",
+      "wasm",
+      "does-not-exist.wasm",
+    ),
     sourcePath,
-    binaryPath
+    binaryPath,
   });
 
-  console.log('VS Code DAP end-to-end tests passed');
+  console.log("VS Code DAP end-to-end tests passed");
 }
 
 async function assertPerRequestTimeoutBehavior(): Promise<void> {
   const dp = new DebuggerProcess({
-    contractPath: 'placeholder.wasm',
-    entrypoint: 'main',
+    contractPath: "placeholder.wasm",
+    entrypoint: "main",
     args: [],
-    requestTimeoutMs: 5
+    requestTimeoutMs: 5,
   });
 
   (dp as any).socket = { write: () => undefined, destroyed: false };
 
-  const sendRequest = (dp as any).sendRequest.bind(dp) as (req: any, opts?: any) => Promise<any>;
+  const sendRequest = (dp as any).sendRequest.bind(dp) as (
+    req: any,
+    opts?: any,
+  ) => Promise<any>;
 
   for (const req of [
-    { type: 'Handshake', client_name: 'test', client_version: '0.0.0', protocol_min: 1, protocol_max: 1 },
-    { type: 'Inspect' },
-    { type: 'GetStorage' },
-    { type: 'Continue' }
+    {
+      type: "Handshake",
+      client_name: "test",
+      client_version: "0.0.0",
+      protocol_min: 1,
+      protocol_max: 1,
+    },
+    { type: "Inspect" },
+    { type: "GetStorage" },
+    { type: "Continue" },
   ]) {
     let threwTimeout = false;
     try {
@@ -536,113 +805,194 @@ async function assertPerRequestTimeoutBehavior(): Promise<void> {
       threwTimeout = error instanceof DebuggerTimeoutError;
     }
 
-    assert.equal(threwTimeout, true, `Expected ${req.type} to time out deterministically`);
-    assert.equal((dp as any).pendingRequests.size, 0, 'Expected pending request map to be cleared after timeout');
+    assert.equal(
+      threwTimeout,
+      true,
+      `Expected ${req.type} to time out deterministically`,
+    );
+    assert.equal(
+      (dp as any).pendingRequests.size,
+      0,
+      "Expected pending request map to be cleared after timeout",
+    );
   }
 }
 
 async function runDapHappyPathE2E(
   debugAdapterPath: string,
-  fixtures: { contractPath: string; sourcePath: string; binaryPath: string }
+  fixtures: { contractPath: string; sourcePath: string; binaryPath: string },
 ): Promise<void> {
   const proc = spawn(process.execPath, [debugAdapterPath], {
-    stdio: ['pipe', 'pipe', 'pipe']
+    stdio: ["pipe", "pipe", "pipe"],
   });
   const client = new DapClient(proc);
 
   try {
-    const init = await client.request('initialize', {
-      adapterID: 'soroban',
+    const init = await client.request("initialize", {
+      adapterID: "soroban",
       linesStartAt1: true,
       columnsStartAt1: true,
-      pathFormat: 'path'
+      pathFormat: "path",
     });
-    assert.equal(init.success, true, `initialize failed: ${init.message || ''}`);
-    await client.waitForEvent('initialized');
+    assert.equal(
+      init.success,
+      true,
+      `initialize failed: ${init.message || ""}`,
+    );
+    await client.waitForEvent("initialized");
 
-    const launch = await client.request('launch', {
-      type: 'soroban',
-      request: 'launch',
-      name: 'Soroban: E2E',
-      contractPath: fixtures.contractPath,
-      entrypoint: 'echo',
-      args: ['7'],
-      trace: false,
-      binaryPath: fixtures.binaryPath
-    }, 30_000);
-    assert.equal(launch.success, true, `launch failed: ${launch.message || ''}`);
+    const launch = await client.request(
+      "launch",
+      {
+        type: "soroban",
+        request: "launch",
+        name: "Soroban: E2E",
+        contractPath: fixtures.contractPath,
+        entrypoint: "echo",
+        args: ["7"],
+        trace: false,
+        binaryPath: fixtures.binaryPath,
+      },
+      30_000,
+    );
+    assert.equal(
+      launch.success,
+      true,
+      `launch failed: ${launch.message || ""}`,
+    );
 
-    const setBps = await client.request('setBreakpoints', {
+    const setBps = await client.request("setBreakpoints", {
       source: { path: fixtures.sourcePath },
-      breakpoints: [{ line: 10 }]
+      breakpoints: [{ line: 10 }],
     });
-    assert.equal(setBps.success, true, `setBreakpoints failed: ${setBps.message || ''}`);
-    assert.equal(setBps.body?.breakpoints?.[0]?.verified, true, 'Expected breakpoint to verify');
+    assert.equal(
+      setBps.success,
+      true,
+      `setBreakpoints failed: ${setBps.message || ""}`,
+    );
+    assert.equal(
+      setBps.body?.breakpoints?.[0]?.verified,
+      true,
+      "Expected breakpoint to verify",
+    );
 
-    const configDone = await client.request('configurationDone', {});
-    assert.equal(configDone.success, true, `configurationDone failed: ${configDone.message || ''}`);
+    const configDone = await client.request("configurationDone", {});
+    assert.equal(
+      configDone.success,
+      true,
+      `configurationDone failed: ${configDone.message || ""}`,
+    );
 
-    await client.waitForEvent('stopped', (e: any) => e.body?.reason === 'entry');
+    await client.waitForEvent(
+      "stopped",
+      (e: any) => e.body?.reason === "entry",
+    );
 
-    const cont = await client.request('continue', { threadId: 1 }, 30_000);
-    assert.equal(cont.success, true, `continue failed: ${cont.message || ''}`);
+    const cont = await client.request("continue", { threadId: 1 }, 30_000);
+    assert.equal(cont.success, true, `continue failed: ${cont.message || ""}`);
 
-    await client.waitForEvent('stopped', (e: any) => e.body?.reason === 'breakpoint', 30_000);
+    await client.waitForEvent(
+      "stopped",
+      (e: any) => e.body?.reason === "breakpoint",
+      30_000,
+    );
 
-    const threads = await client.request('threads', {});
+    const threads = await client.request("threads", {});
     assert.equal(threads.success, true);
-    assert.equal(Array.isArray(threads.body?.threads), true, 'Expected threads array');
+    assert.equal(
+      Array.isArray(threads.body?.threads),
+      true,
+      "Expected threads array",
+    );
 
-    const stack = await client.request('stackTrace', { threadId: 1 });
+    const stack = await client.request("stackTrace", { threadId: 1 });
     assert.equal(stack.success, true);
     const frameId = stack.body?.stackFrames?.[0]?.id;
-    assert.ok(frameId, 'Expected at least one stack frame');
+    assert.ok(frameId, "Expected at least one stack frame");
 
-    const scopes = await client.request('scopes', { frameId });
+    const scopes = await client.request("scopes", { frameId });
     assert.equal(scopes.success, true);
-    const argsScope = (scopes.body?.scopes || []).find((s: any) => s.name === 'Arguments');
-    assert.ok(argsScope?.variablesReference, 'Expected Arguments scope');
+    const argsScope = (scopes.body?.scopes || []).find(
+      (s: any) => s.name === "Arguments",
+    );
+    assert.ok(argsScope?.variablesReference, "Expected Arguments scope");
 
-    const argsVars = await client.request('variables', { variablesReference: argsScope.variablesReference });
+    const argsVars = await client.request("variables", {
+      variablesReference: argsScope.variablesReference,
+    });
     assert.equal(argsVars.success, true);
-    assert.match(JSON.stringify(argsVars.body?.variables || []), /7/, 'Expected argument variable to include the input');
+    assert.match(
+      JSON.stringify(argsVars.body?.variables || []),
+      /7/,
+      "Expected argument variable to include the input",
+    );
 
-    const evalArgs = await client.request('evaluate', { expression: 'args', frameId });
+    const evalArgs = await client.request("evaluate", {
+      expression: "args",
+      frameId,
+    });
     assert.equal(evalArgs.success, true);
-    assert.match(String(evalArgs.body?.result || ''), /7/, 'Expected evaluate(args) to include the input');
+    assert.match(
+      String(evalArgs.body?.result || ""),
+      /7/,
+      "Expected evaluate(args) to include the input",
+    );
 
-    const evalStorage = await client.request('evaluate', { expression: 'storage', frameId });
+    const evalStorage = await client.request("evaluate", {
+      expression: "storage",
+      frameId,
+    });
     assert.equal(evalStorage.success, true);
-    assert.match(String(evalStorage.body?.result || ''), /^\{/, 'Expected evaluate(storage) to return JSON');
+    assert.match(
+      String(evalStorage.body?.result || ""),
+      /^\{/,
+      "Expected evaluate(storage) to return JSON",
+    );
 
     // Exercise stepping commands (these may exit quickly depending on the contract).
-    const stepIn = await client.request('stepIn', { threadId: 1 }, 30_000);
+    const stepIn = await client.request("stepIn", { threadId: 1 }, 30_000);
     assert.equal(stepIn.success, true);
-    const afterStepIn = await client.waitForAnyEvent(['stopped', 'exited'], () => true, 30_000);
-    let executionExited = afterStepIn.event === 'exited';
+    const afterStepIn = await client.waitForAnyEvent(
+      ["stopped", "exited"],
+      () => true,
+      30_000,
+    );
+    let executionExited = afterStepIn.event === "exited";
 
     if (!executionExited) {
-      const next = await client.request('next', { threadId: 1 }, 30_000);
+      const next = await client.request("next", { threadId: 1 }, 30_000);
       assert.equal(next.success, true);
-      const afterNext = await client.waitForAnyEvent(['stopped', 'exited'], () => true, 30_000);
+      const afterNext = await client.waitForAnyEvent(
+        ["stopped", "exited"],
+        () => true,
+        30_000,
+      );
 
-      executionExited = afterNext.event === 'exited';
+      executionExited = afterNext.event === "exited";
 
       if (!executionExited) {
-        const stepOut = await client.request('stepOut', { threadId: 1 }, 30_000);
+        const stepOut = await client.request(
+          "stepOut",
+          { threadId: 1 },
+          30_000,
+        );
         assert.equal(stepOut.success, true);
-        const afterStepOut = await client.waitForAnyEvent(['stopped', 'exited'], () => true, 30_000);
-        executionExited = afterStepOut.event === 'exited';
+        const afterStepOut = await client.waitForAnyEvent(
+          ["stopped", "exited"],
+          () => true,
+          30_000,
+        );
+        executionExited = afterStepOut.event === "exited";
       }
     }
 
     if (!executionExited) {
-      const cont2 = await client.request('continue', { threadId: 1 }, 30_000);
+      const cont2 = await client.request("continue", { threadId: 1 }, 30_000);
       assert.equal(cont2.success, true);
-      await client.waitForEvent('exited', () => true, 30_000);
+      await client.waitForEvent("exited", () => true, 30_000);
     }
 
-    const disconnect = await client.request('disconnect', { restart: false });
+    const disconnect = await client.request("disconnect", { restart: false });
     assert.equal(disconnect.success, true);
   } finally {
     client.dispose();
@@ -651,36 +1001,44 @@ async function runDapHappyPathE2E(
 
 async function runDapLaunchErrorE2E(
   debugAdapterPath: string,
-  fixtures: { contractPath: string; sourcePath: string; binaryPath: string }
+  fixtures: { contractPath: string; sourcePath: string; binaryPath: string },
 ): Promise<void> {
   const proc = spawn(process.execPath, [debugAdapterPath], {
-    stdio: ['pipe', 'pipe', 'pipe']
+    stdio: ["pipe", "pipe", "pipe"],
   });
   const client = new DapClient(proc);
 
   try {
-    const init = await client.request('initialize', {
-      adapterID: 'soroban',
+    const init = await client.request("initialize", {
+      adapterID: "soroban",
       linesStartAt1: true,
       columnsStartAt1: true,
-      pathFormat: 'path'
+      pathFormat: "path",
     });
     assert.equal(init.success, true);
-    await client.waitForEvent('initialized');
+    await client.waitForEvent("initialized");
 
-    const launch = await client.request('launch', {
-      type: 'soroban',
-      request: 'launch',
-      name: 'Soroban: E2E (error)',
-      contractPath: fixtures.contractPath,
-      entrypoint: 'echo',
-      args: ['7'],
-      trace: false,
-      binaryPath: fixtures.binaryPath
-    }, 30_000);
-    assert.equal(launch.success, false, 'Expected launch to fail for missing contract fixture');
+    const launch = await client.request(
+      "launch",
+      {
+        type: "soroban",
+        request: "launch",
+        name: "Soroban: E2E (error)",
+        contractPath: fixtures.contractPath,
+        entrypoint: "echo",
+        args: ["7"],
+        trace: false,
+        binaryPath: fixtures.binaryPath,
+      },
+      30_000,
+    );
+    assert.equal(
+      launch.success,
+      false,
+      "Expected launch to fail for missing contract fixture",
+    );
 
-    const disconnect = await client.request('disconnect', { restart: false });
+    const disconnect = await client.request("disconnect", { restart: false });
     assert.equal(disconnect.success, true);
   } finally {
     client.dispose();

--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -432,7 +432,7 @@ impl RemoteClient {
             self.send_request_with_retry(DebugRequest::Ping, RequestClass::Ping, true)?;
 
         match response {
-            DebugResponse::Pong => {
+            DebugResponse::Pong { .. } => {
                 info!("Server responded to ping");
                 Ok(())
             }
@@ -723,7 +723,7 @@ mod tests {
 
     #[test]
     fn parse_response_line_rejects_mismatched_ids() {
-        let msg = DebugMessage::response(42, DebugResponse::Pong);
+        let msg = DebugMessage::response(42, DebugResponse::Pong { backend_version: None, protocol_version: None });
         let line = serde_json::to_string(&msg).unwrap();
         let err = parse_response_line(7, &line).unwrap_err();
         assert!(err.to_string().contains("Mismatched response id"));
@@ -731,10 +731,10 @@ mod tests {
 
     #[test]
     fn parse_response_line_accepts_matching_ids() {
-        let msg = DebugMessage::response(7, DebugResponse::Pong);
+        let msg = DebugMessage::response(7, DebugResponse::Pong { backend_version: None, protocol_version: None });
         let line = serde_json::to_string(&msg).unwrap();
         let resp = parse_response_line(7, &line).unwrap();
-        assert!(matches!(resp, DebugResponse::Pong));
+        assert!(matches!(resp, DebugResponse::Pong { .. }));
     }
 
     #[test]
@@ -800,7 +800,7 @@ mod tests {
 
                 let msg: DebugMessage = serde_json::from_str(line.trim_end()).unwrap();
                 let id = msg.id;
-                let response = DebugMessage::response(id, DebugResponse::Pong);
+                let response = DebugMessage::response(id, DebugResponse::Pong { backend_version: None, protocol_version: None });
                 let json = serde_json::to_string(&response).unwrap();
                 let _ = writeln!(stream, "{}", json);
                 let _ = stream.flush();

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -2,7 +2,7 @@ use crate::debugger::breakpoint::{BreakpointManager, BreakpointSpec};
 use crate::debugger::engine::{DebuggerEngine, StepOverResult};
 use crate::inspector::budget::BudgetInspector;
 use crate::server::protocol::{
-    negotiate_protocol_version, PROTOCOL_MAX_VERSION, PROTOCOL_MIN_VERSION,
+    negotiate_protocol_version, PROTOCOL_MAX_VERSION, PROTOCOL_MIN_VERSION, DEBUG_PROTOCOL_VERSION,
 };
 use crate::server::protocol::{
     BreakpointCapabilities, BreakpointDescriptor, DebugMessage, DebugRequest, DebugResponse,
@@ -148,7 +148,13 @@ impl DebugServer {
             info!("Received request: {}", summarize_request(&request));
 
             if matches!(request, DebugRequest::Ping) {
-                let response = DebugMessage::response(message.id, DebugResponse::Pong);
+                let response = DebugMessage::response(
+                    message.id,
+                    DebugResponse::Pong {
+                        backend_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                        protocol_version: Some(DEBUG_PROTOCOL_VERSION.to_string()),
+                    },
+                );
                 send_response(&mut writer, response).await?;
                 continue;
             }
@@ -808,7 +814,10 @@ impl DebugServer {
                             .to_string(),
                     },
                 },
-                DebugRequest::Ping => DebugResponse::Pong,
+                DebugRequest::Ping => DebugResponse::Pong {
+                    backend_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                    protocol_version: Some(DEBUG_PROTOCOL_VERSION.to_string()),
+                },
                 DebugRequest::Disconnect => DebugResponse::Disconnected,
                 DebugRequest::Unknown => DebugResponse::Error {
                     message: "Unknown request type".to_string(),

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -7,6 +7,8 @@ pub const PROTOCOL_VERSION: u32 = 1;
 pub const PROTOCOL_MIN_VERSION: u32 = 1;
 /// Maximum protocol version this backend can communicate with.
 pub const PROTOCOL_MAX_VERSION: u32 = 1;
+/// Debug protocol version for external clients (e.g., VS Code extension)
+pub const DEBUG_PROTOCOL_VERSION: &str = "1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProtocolNegotiationError {
@@ -345,7 +347,12 @@ pub enum DebugResponse {
     },
 
     /// Pong response
-    Pong,
+    Pong {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        backend_version: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        protocol_version: Option<String>,
+    },
 
     /// Disconnected
     Disconnected,


### PR DESCRIPTION
Summary
Expose backend and protocol version details in the VS Code UI during active debug sessions.

Changes
Extend Pong response with optional backend_version and protocol_version
Capture session info in DebuggerProcess with fallback to unknown
Display version info in the VS Code status bar during debug sessions
Reset status bar on session end
Add minimal tests and README update
Before
Version details were not visible during a debug session.

After
Status bar shows:
Soroban: v<backendVersion> | protocol <protocolVersion>

Compatibility
Backward compatible (missing fields fall back to unknown)

Closes https://github.com/Timi16/soroban-debugger/issues/534