### PR TITLE
Fixture pipeline: add a manifest describing expected exports, hashes,…

### DIFF
--- a/tests/command_feature_tests.rs
+++ b/tests/command_feature_tests.rs
@@ -3,12 +3,11 @@ use predicates::prelude::*;
 use std::fs;
 use tempfile::NamedTempFile;
 
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
 fn fixture_wasm(name: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("wasm")
-        .join(format!("{name}.wasm"))
+    fixtures::get_fixture_path(name)
 }
 
 fn base_cmd() -> Command {

--- a/tests/fixture_manifest_tests.rs
+++ b/tests/fixture_manifest_tests.rs
@@ -1,0 +1,64 @@
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+use sha2::{Digest, Sha256};
+use soroban_debugger::utils::wasm;
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[test]
+fn fixture_manifest_matches_checked_in_artifacts() {
+    let manifest = fixtures::load_manifest();
+    assert_eq!(manifest.version, 1, "unexpected fixture manifest version");
+    assert!(
+        !manifest.fixtures.is_empty(),
+        "fixture manifest should describe at least one fixture"
+    );
+
+    for fixture in manifest.fixtures {
+        assert!(
+            fixtures::contract_dir(&fixture.name).exists(),
+            "missing contract dir for {}",
+            fixture.name
+        );
+        assert!(
+            fixtures::source_path(&fixture.name).exists(),
+            "missing lib.rs source path for {}",
+            fixture.name
+        );
+
+        let release = fixture
+            .artifacts
+            .get("release")
+            .expect("every fixture must define a release artifact");
+        let release_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(&release.path);
+        assert!(
+            release_path.exists(),
+            "missing release artifact for {} at {}",
+            fixture.name,
+            release_path.display()
+        );
+
+        let bytes = std::fs::read(&release_path).expect("release artifact should be readable");
+        assert_eq!(
+            sha256_hex(&bytes),
+            release.sha256,
+            "sha256 mismatch for {}",
+            fixture.name
+        );
+
+        let mut exports = wasm::parse_functions(&bytes).expect("fixture exports should parse");
+        exports.sort();
+
+        let mut expected_exports = fixture.exports.clone();
+        expected_exports.sort();
+
+        assert_eq!(
+            exports, expected_exports,
+            "export list mismatch for {}",
+            fixture.name
+        );
+    }
+}

--- a/tests/fixture_tests.rs
+++ b/tests/fixture_tests.rs
@@ -1,21 +1,14 @@
 //! Tests that demonstrate usage of test fixture contracts
 
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
 use soroban_debugger::utils::wasm;
 use std::fs;
 
-/// Helper to get fixture path - mirrors the mod.rs helper but for integration tests
-fn get_fixture_path(name: &str) -> std::path::PathBuf {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    std::path::PathBuf::from(manifest_dir)
-        .join("tests")
-        .join("fixtures")
-        .join("wasm")
-        .join(format!("{}.wasm", name))
-}
-
 #[test]
 fn test_fixture_counter_parsing() {
-    let fixture_path = get_fixture_path("counter");
+    let fixture_path = fixtures::get_fixture_path(fixtures::names::COUNTER);
 
     // Skip test if fixture doesn't exist (needs to be built first)
     if !fixture_path.exists() {
@@ -31,12 +24,9 @@ fn test_fixture_counter_parsing() {
     // Test that we can parse functions from the counter contract
     let functions = wasm::parse_functions(&wasm_bytes).expect("Failed to parse functions");
 
-    // Counter contract should have increment, decrement, get, and init functions
+    // Counter contract should have the release exports recorded in the fixture manifest.
     assert!(
-        functions.contains(&"increment".to_string())
-            || functions.contains(&"decrement".to_string())
-            || functions.contains(&"get".to_string())
-            || functions.contains(&"init".to_string()),
+        functions.contains(&"increment".to_string()) && functions.contains(&"get".to_string()),
         "Counter fixture should contain expected functions. Found: {:?}",
         functions
     );
@@ -51,7 +41,7 @@ fn test_fixture_counter_parsing() {
 
 #[test]
 fn test_fixture_echo_parsing() {
-    let fixture_path = get_fixture_path("echo");
+    let fixture_path = fixtures::get_fixture_path(fixtures::names::ECHO);
 
     if !fixture_path.exists() {
         eprintln!(
@@ -77,10 +67,14 @@ fn test_fixture_echo_parsing() {
 #[test]
 fn test_fixture_metadata_extraction() {
     // Test metadata extraction on fixtures (if they have metadata)
-    let fixtures = ["counter", "echo", "budget_heavy"];
+    let fixture_names = [
+        fixtures::names::COUNTER,
+        fixtures::names::ECHO,
+        fixtures::names::BUDGET_HEAVY,
+    ];
 
-    for fixture_name in fixtures {
-        let fixture_path = get_fixture_path(fixture_name);
+    for fixture_name in fixture_names {
+        let fixture_path = fixtures::get_fixture_path(fixture_name);
 
         if !fixture_path.exists() {
             continue; // Skip if not built
@@ -106,7 +100,7 @@ fn test_fixture_metadata_extraction() {
 fn test_fixture_inspect_command() {
     use assert_cmd::Command;
 
-    let fixture_path = get_fixture_path("counter");
+    let fixture_path = fixtures::get_fixture_path(fixtures::names::COUNTER);
 
     if !fixture_path.exists() {
         eprintln!(
@@ -133,7 +127,7 @@ fn test_fixture_inspect_command() {
 fn test_fixture_registration_and_invocation() {
     use soroban_sdk::{Env, Symbol};
 
-    let fixture_path = get_fixture_path("counter");
+    let fixture_path = fixtures::get_fixture_path(fixtures::names::COUNTER);
     if !fixture_path.exists() {
         return;
     }

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,73 +1,69 @@
 # Test Fixture Contracts
 
-This directory contains pre-compiled WASM test fixture contracts for use across all test suites.
+This directory contains Soroban contract fixtures used by the test suite.
+`manifest.json` is the checked-in source of truth for fixture exports, hashes, source paths, and artifact locations.
 
 ## Contracts
 
-- **counter** - Simple counter contract with increment, decrement, and get functions
-- **echo** - Echo contract that returns its input unchanged
-- **panic** - Contract that always panics, useful for error testing
-- **budget_heavy** - Contract with budget-intensive operations for budget testing
-- **cross_contract** - Contract that calls other contracts, for cross-contract call testing
+- `counter` - Simple counter contract with `increment` and `get`
+- `echo` - Echo contract that returns its input unchanged
+- `always_panic` - Contract that always panics, useful for error testing
+- `budget_heavy` - Contract with budget-intensive operations for budget testing
+- `cross_contract` - Contract that calls other contracts for cross-contract call testing
+- `same_return` - Contract with divergent branches that intentionally return the same value
 
 ## Building
 
-To rebuild all WASM files from source:
+To rebuild all fixture artifacts and refresh the manifest:
 
-### Linux/macOS:
+Linux/macOS:
 ```bash
 ./build.sh
 ```
 
-### Windows:
+Windows:
 ```powershell
 .\build.ps1
 ```
 
-Or manually:
-```bash
-cd contracts/counter && cargo build --release --target wasm32-unknown-unknown
-# Copy the resulting .wasm file to wasm/counter.wasm
-```
+Both scripts build release and `release-debug` WASM artifacts under `tests/fixtures/wasm/` and then rewrite `tests/fixtures/manifest.json` with the expected exports, source paths, and SHA-256 hashes for every generated artifact.
 
 ## Usage in Tests
 
 ```rust
-use std::path::PathBuf;
-
-fn get_fixture_path(name: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("wasm")
-        .join(format!("{}.wasm", name))
-}
+#[path = "fixtures/mod.rs"]
+mod fixtures;
 
 #[test]
 fn test_with_counter() {
-    let wasm_path = get_fixture_path("counter");
+    let wasm_path = fixtures::get_fixture_path(fixtures::names::COUNTER);
     let wasm_bytes = std::fs::read(&wasm_path).unwrap();
-    // Use wasm_bytes in your test...
+    let source_path = fixtures::source_path(fixtures::names::COUNTER);
+
+    assert!(source_path.exists());
+    assert!(!wasm_bytes.is_empty());
 }
 ```
 
+Use `fixtures::artifact_path(name, "debug")` when a test needs the debug-info-preserving fixture.
+
+## Manifest Shape
+
+The manifest is JSON and includes, for each fixture:
+
+- the exported contract functions
+- the source contract directory and `src/lib.rs` path
+- the release artifact path and SHA-256 hash
+- the debug artifact path and SHA-256 hash when debug fixtures have been generated
+
 ## Structure
 
-```
+```text
 tests/fixtures/
-├── contracts/          # Source code for contracts
-│   ├── counter/
-│   ├── echo/
-│   ├── panic/
-│   ├── budget_heavy/
-│   └── cross_contract/
-├── wasm/               # Pre-compiled WASM files
-│   ├── counter.wasm
-│   ├── echo.wasm
-│   ├── panic.wasm
-│   ├── budget_heavy.wasm
-│   └── cross_contract.wasm
-├── build.sh            # Build script (Linux/macOS)
-├── build.ps1           # Build script (Windows)
-└── README.md           # This file
+|-- contracts/
+|-- manifest.json
+|-- wasm/
+|-- build.sh
+|-- build.ps1
+`-- README.md
 ```

--- a/tests/fixtures/build.ps1
+++ b/tests/fixtures/build.ps1
@@ -1,22 +1,33 @@
-# PowerShell build script to compile all test fixture contracts to WASM
-#
-# Usage: .\build.ps1
-#
-# Prerequisites:
-#   - Rust toolchain installed
-#   - wasm32-unknown-unknown target: rustup target add wasm32-unknown-unknown
-#
-# This script builds all contracts in tests/fixtures/contracts/ and
-# places the compiled WASM files in tests/fixtures/wasm/
+# PowerShell build script to compile all test fixture contracts to WASM and refresh manifest.json.
 
 $ErrorActionPreference = "Stop"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ContractsDir = Join-Path $ScriptDir "contracts"
 $WasmDir = Join-Path $ScriptDir "wasm"
-$WorkspaceTargetDir = Join-Path $ContractsDir "target\wasm32-unknown-unknown\release"
+$ManifestPath = Join-Path $ScriptDir "manifest.json"
+$ReleaseTargetDir = Join-Path $ContractsDir "target\wasm32-unknown-unknown\release"
+$DebugTargetDir = Join-Path $ContractsDir "target\wasm32-unknown-unknown\release-debug"
 
-# Check if wasm32 target is installed
+function Get-FixtureExports {
+    param([string]$Name)
+
+    switch ($Name) {
+        "always_panic" { return @("panic") }
+        "budget_heavy" { return @("heavy") }
+        "counter" { return @("get", "increment") }
+        "cross_contract" { return @("call") }
+        "echo" { return @("echo") }
+        "same_return" { return @("same") }
+        default { throw "Unknown fixture export set for '$Name'" }
+    }
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+    (Get-FileHash -Path $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
 $InstalledTargets = rustup target list --installed
 if ($InstalledTargets -notcontains "wasm32-unknown-unknown") {
     Write-Host "Error: wasm32-unknown-unknown target not installed." -ForegroundColor Red
@@ -24,46 +35,83 @@ if ($InstalledTargets -notcontains "wasm32-unknown-unknown") {
     exit 1
 }
 
-# Create wasm output directory
 New-Item -ItemType Directory -Force -Path $WasmDir | Out-Null
 
 Write-Host "Building test fixture contracts..." -ForegroundColor Cyan
 
-# Build each contract
-Get-ChildItem -Path $ContractsDir -Directory | ForEach-Object {
+$ManifestFixtures = @()
+
+Get-ChildItem -Path $ContractsDir -Directory | Sort-Object Name | ForEach-Object {
     $ContractDir = $_.FullName
     $ContractName = $_.Name
     $CargoToml = Join-Path $ContractDir "Cargo.toml"
-    
-    if (Test-Path $CargoToml) {
-        Write-Host "  Building $ContractName..." -ForegroundColor Yellow
-        
-        Push-Location $ContractDir
-        try {
-            cargo build --release --target wasm32-unknown-unknown
-            
-            $PackageName = Select-String -Path $CargoToml -Pattern '^name = "(.*)"$' | ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1
-            if (-not $PackageName) {
-                Write-Host "    ✗ Failed to determine package name for $ContractName" -ForegroundColor Red
-                exit 1
-            }
 
-            $WasmFileName = $PackageName -replace "-", "_"
-            $WasmFile = Join-Path $WorkspaceTargetDir "${WasmFileName}.wasm"
-            
-            if (Test-Path $WasmFile) {
-                Copy-Item $WasmFile (Join-Path $WasmDir "${ContractName}.wasm")
-                Write-Host "    ✓ Built ${ContractName}.wasm" -ForegroundColor Green
-            } else {
-                Write-Host "    ✗ Failed to find WASM output for $ContractName" -ForegroundColor Red
-                exit 1
+    if (-not (Test-Path $CargoToml)) {
+        return
+    }
+
+    Write-Host "  Building $ContractName..." -ForegroundColor Yellow
+
+    Push-Location $ContractDir
+    try {
+        cargo build --release --target wasm32-unknown-unknown
+        cargo build --profile release-debug --target wasm32-unknown-unknown
+    } finally {
+        Pop-Location
+    }
+
+    $PackageName = Select-String -Path $CargoToml -Pattern '^name = "(.*)"$' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value } |
+        Select-Object -First 1
+
+    if (-not $PackageName) {
+        throw "Failed to determine package name for $ContractName"
+    }
+
+    $WasmFileName = $PackageName -replace "-", "_"
+    $ReleaseSource = Join-Path $ReleaseTargetDir "${WasmFileName}.wasm"
+    $DebugSource = Join-Path $DebugTargetDir "${WasmFileName}.wasm"
+    $ReleaseDest = Join-Path $WasmDir "${ContractName}.wasm"
+    $DebugDest = Join-Path $WasmDir "${ContractName}_debug.wasm"
+
+    if (-not (Test-Path $ReleaseSource)) {
+        throw "Failed to find release WASM output for $ContractName"
+    }
+    if (-not (Test-Path $DebugSource)) {
+        throw "Failed to find debug WASM output for $ContractName"
+    }
+
+    Copy-Item $ReleaseSource $ReleaseDest -Force
+    Copy-Item $DebugSource $DebugDest -Force
+
+    $ManifestFixtures += [ordered]@{
+        name = $ContractName
+        exports = (Get-FixtureExports -Name $ContractName)
+        source = [ordered]@{
+            contract_dir = "tests/fixtures/contracts/$ContractName"
+            lib_rs = "tests/fixtures/contracts/$ContractName/src/lib.rs"
+        }
+        artifacts = [ordered]@{
+            release = [ordered]@{
+                path = "tests/fixtures/wasm/$ContractName.wasm"
+                sha256 = Get-Sha256 -Path $ReleaseDest
             }
-        } finally {
-            Pop-Location
+            debug = [ordered]@{
+                path = "tests/fixtures/wasm/${ContractName}_debug.wasm"
+                sha256 = Get-Sha256 -Path $DebugDest
+            }
         }
     }
 }
 
+$Manifest = [ordered]@{
+    version = 1
+    fixtures = $ManifestFixtures
+}
+
+$Manifest | ConvertTo-Json -Depth 6 | Set-Content -Path $ManifestPath
+
 Write-Host ""
-Write-Host "All contracts built successfully!" -ForegroundColor Green
+Write-Host "All contracts built successfully." -ForegroundColor Green
 Write-Host "WASM files are in: $WasmDir" -ForegroundColor Cyan
+Write-Host "Manifest refreshed at: $ManifestPath" -ForegroundColor Cyan

--- a/tests/fixtures/build.sh
+++ b/tests/fixtures/build.sh
@@ -1,77 +1,134 @@
 #!/bin/bash
-# Build script to compile all test fixture contracts to WASM
-#
-# Usage: ./build.sh
-#
-# Prerequisites:
-#   - Rust toolchain installed
-#   - wasm32-unknown-unknown target: rustup target add wasm32-unknown-unknown
-#
-# This script builds all contracts in tests/fixtures/contracts/ and
-# places the compiled WASM files in tests/fixtures/wasm/
+# Build script to compile all test fixture contracts to WASM and refresh manifest.json.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTRACTS_DIR="${SCRIPT_DIR}/contracts"
 WASM_DIR="${SCRIPT_DIR}/wasm"
+MANIFEST_PATH="${SCRIPT_DIR}/manifest.json"
 RELEASE_TARGET_DIR="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release"
 DEBUG_TARGET_DIR="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release-debug"
 
-# Check if wasm32 target is installed
+fixture_exports_json() {
+    case "$1" in
+        always_panic) printf '["panic"]' ;;
+        budget_heavy) printf '["heavy"]' ;;
+        counter) printf '["get","increment"]' ;;
+        cross_contract) printf '["call"]' ;;
+        echo) printf '["echo"]' ;;
+        same_return) printf '["same"]' ;;
+        *)
+            echo "Unknown fixture export set for '$1'" >&2
+            exit 1
+            ;;
+    esac
+}
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        echo "Could not find sha256sum or shasum" >&2
+        exit 1
+    fi
+}
+
+append_manifest_entry() {
+    local contract_name="$1"
+    local release_hash="$2"
+    local debug_hash="$3"
+    local exports_json
+    exports_json="$(fixture_exports_json "${contract_name}")"
+
+    if [ "${FIRST_ENTRY}" = false ]; then
+        printf ',\n' >> "${MANIFEST_PATH}"
+    fi
+    FIRST_ENTRY=false
+
+    cat >> "${MANIFEST_PATH}" <<EOF
+    {
+      "name": "${contract_name}",
+      "exports": ${exports_json},
+      "source": {
+        "contract_dir": "tests/fixtures/contracts/${contract_name}",
+        "lib_rs": "tests/fixtures/contracts/${contract_name}/src/lib.rs"
+      },
+      "artifacts": {
+        "release": {
+          "path": "tests/fixtures/wasm/${contract_name}.wasm",
+          "sha256": "${release_hash}"
+        },
+        "debug": {
+          "path": "tests/fixtures/wasm/${contract_name}_debug.wasm",
+          "sha256": "${debug_hash}"
+        }
+      }
+    }
+EOF
+}
+
 if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
     echo "Error: wasm32-unknown-unknown target not installed."
     echo "Install it with: rustup target add wasm32-unknown-unknown"
     exit 1
 fi
 
-# Create wasm output directory
 mkdir -p "${WASM_DIR}"
 
 echo "Building test fixture contracts..."
 
-# Build each contract
+printf '{\n  "version": 1,\n  "fixtures": [\n' > "${MANIFEST_PATH}"
+FIRST_ENTRY=true
+
 for contract_dir in "${CONTRACTS_DIR}"/*/; do
-    if [ -f "${contract_dir}Cargo.toml" ]; then
-        contract_name=$(basename "${contract_dir}")
-        echo "  Building ${contract_name}..."
-        
-        (
-            cd "${contract_dir}"
-            cargo build --release --target wasm32-unknown-unknown
-            
-            package_name=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
-            if [ -z "${package_name}" ]; then
-                echo "    ✗ Failed to determine package name for ${contract_name}"
-                exit 1
-            fi
-
-            wasm_file="${RELEASE_TARGET_DIR}/${package_name//-/_}.wasm"
-            
-            if [ -f "${wasm_file}" ]; then
-                cp "${wasm_file}" "${WASM_DIR}/${contract_name}.wasm"
-                echo "    ✓ Built ${contract_name}.wasm"
-            else
-                echo "    ✗ Failed to find WASM output for ${contract_name}"
-                exit 1
-            fi
-
-            echo "  Building ${contract_name} (debug info)..."
-            cargo build --profile release-debug --target wasm32-unknown-unknown
-
-            debug_wasm_file="${DEBUG_TARGET_DIR}/${package_name//-/_}.wasm"
-
-            if [ -f "${debug_wasm_file}" ]; then
-                cp "${debug_wasm_file}" "${WASM_DIR}/${contract_name}_debug.wasm"
-                echo "    Built ${contract_name}_debug.wasm"
-            else
-                echo "    Failed to find debug WASM output for ${contract_name}"
-                exit 1
-            fi
-        )
+    if [ ! -f "${contract_dir}Cargo.toml" ]; then
+        continue
     fi
+
+    contract_name="$(basename "${contract_dir}")"
+    echo "  Building ${contract_name}..."
+
+    (
+        cd "${contract_dir}"
+        cargo build --release --target wasm32-unknown-unknown
+        cargo build --profile release-debug --target wasm32-unknown-unknown
+    )
+
+    package_name="$(sed -n 's/^name = "\(.*\)"/\1/p' "${contract_dir}Cargo.toml" | head -n 1)"
+    if [ -z "${package_name}" ]; then
+        echo "Failed to determine package name for ${contract_name}" >&2
+        exit 1
+    fi
+
+    release_src="${RELEASE_TARGET_DIR}/${package_name//-/_}.wasm"
+    debug_src="${DEBUG_TARGET_DIR}/${package_name//-/_}.wasm"
+    release_dest="${WASM_DIR}/${contract_name}.wasm"
+    debug_dest="${WASM_DIR}/${contract_name}_debug.wasm"
+
+    if [ ! -f "${release_src}" ]; then
+        echo "Failed to find release WASM output for ${contract_name}" >&2
+        exit 1
+    fi
+    if [ ! -f "${debug_src}" ]; then
+        echo "Failed to find debug WASM output for ${contract_name}" >&2
+        exit 1
+    fi
+
+    cp "${release_src}" "${release_dest}"
+    cp "${debug_src}" "${debug_dest}"
+
+    append_manifest_entry \
+        "${contract_name}" \
+        "$(sha256_file "${release_dest}")" \
+        "$(sha256_file "${debug_dest}")"
 done
 
+printf '\n  ]\n}\n' >> "${MANIFEST_PATH}"
+
 echo ""
-echo "All contracts built successfully!"
+echo "All contracts built successfully."
 echo "WASM files are in: ${WASM_DIR}"
+echo "Manifest refreshed at: ${MANIFEST_PATH}"

--- a/tests/fixtures/manifest.json
+++ b/tests/fixtures/manifest.json
@@ -1,0 +1,75 @@
+{
+  "version": 1,
+  "fixtures": [
+    {
+      "name": "always_panic",
+      "exports": ["panic"],
+      "source": {
+        "contract_dir": "tests/fixtures/contracts/always_panic",
+        "lib_rs": "tests/fixtures/contracts/always_panic/src/lib.rs"
+      },
+      "artifacts": {
+        "release": {
+          "path": "tests/fixtures/wasm/always_panic.wasm",
+          "sha256": "b866531c02861bc749b0bcfb39ee801c0f5b59a703980e764b8b515510c524a2"
+        }
+      }
+    },
+    {
+      "name": "budget_heavy",
+      "exports": ["heavy"],
+      "source": {
+        "contract_dir": "tests/fixtures/contracts/budget_heavy",
+        "lib_rs": "tests/fixtures/contracts/budget_heavy/src/lib.rs"
+      },
+      "artifacts": {
+        "release": {
+          "path": "tests/fixtures/wasm/budget_heavy.wasm",
+          "sha256": "32e6adefbe95e83aebb1d7007f4533a5b59bb6be029bb1ec4a2d64382648960c"
+        }
+      }
+    },
+    {
+      "name": "counter",
+      "exports": ["get", "increment"],
+      "source": {
+        "contract_dir": "tests/fixtures/contracts/counter",
+        "lib_rs": "tests/fixtures/contracts/counter/src/lib.rs"
+      },
+      "artifacts": {
+        "release": {
+          "path": "tests/fixtures/wasm/counter.wasm",
+          "sha256": "5be3612b8625f8a0bd7cdd12736995be4bba6726aa03ce55f33aa87f4bfd4eef"
+        }
+      }
+    },
+    {
+      "name": "cross_contract",
+      "exports": ["call"],
+      "source": {
+        "contract_dir": "tests/fixtures/contracts/cross_contract",
+        "lib_rs": "tests/fixtures/contracts/cross_contract/src/lib.rs"
+      },
+      "artifacts": {
+        "release": {
+          "path": "tests/fixtures/wasm/cross_contract.wasm",
+          "sha256": "ca15b9b508f9683a93a12046013f21ea66911b3a19094c085d9a42ae14a561e2"
+        }
+      }
+    },
+    {
+      "name": "echo",
+      "exports": ["echo"],
+      "source": {
+        "contract_dir": "tests/fixtures/contracts/echo",
+        "lib_rs": "tests/fixtures/contracts/echo/src/lib.rs"
+      },
+      "artifacts": {
+        "release": {
+          "path": "tests/fixtures/wasm/echo.wasm",
+          "sha256": "314f3b1bb7e2000b026a602d84ff2e0c74c147b8327561364d89f009196aa8b4"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -1,65 +1,96 @@
-//! Test fixture utilities for loading pre-compiled WASM contracts
-//!
-//! This module provides helpers to load test fixture WASM files for use in tests.
+//! Test fixture utilities for loading pre-compiled WASM contracts.
 
-use std::path::PathBuf;
+use serde::Deserialize;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
-/// Get the path to a test fixture WASM file
-///
-/// # Arguments
-/// * `name` - Name of the fixture contract (without .wasm extension)
-///
-/// # Returns
-/// PathBuf pointing to the fixture WASM file
-///
-/// # Panics
-/// Panics if the fixture file doesn't exist. Use `fixture_exists()` to check first.
-pub fn get_fixture_path(name: &str) -> PathBuf {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let path = PathBuf::from(manifest_dir)
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureManifest {
+    pub version: u32,
+    pub fixtures: Vec<FixtureContract>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureContract {
+    pub name: String,
+    pub exports: Vec<String>,
+    pub source: FixtureSource,
+    pub artifacts: BTreeMap<String, FixtureArtifact>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureSource {
+    pub contract_dir: String,
+    pub lib_rs: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureArtifact {
+    pub path: String,
+    pub sha256: String,
+}
+
+pub fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
-        .join("wasm")
-        .join(format!("{}.wasm", name));
-    
-    if !path.exists() {
+}
+
+pub fn manifest_path() -> PathBuf {
+    fixtures_root().join("manifest.json")
+}
+
+pub fn load_manifest() -> FixtureManifest {
+    let path = manifest_path();
+    let contents = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read fixture manifest from {}: {}", path.display(), e));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|e| panic!("Failed to parse fixture manifest from {}: {}", path.display(), e))
+}
+
+pub fn fixture(name: &str) -> FixtureContract {
+    load_manifest()
+        .fixtures
+        .into_iter()
+        .find(|fixture| fixture.name == name)
+        .unwrap_or_else(|| panic!("Fixture '{}' not found in {}", name, manifest_path().display()))
+}
+
+pub fn artifact_path(name: &str, profile: &str) -> PathBuf {
+    try_artifact_path(name, profile).unwrap_or_else(|| {
         panic!(
-            "Fixture '{}' not found at {}. Run tests/fixtures/build.sh to build fixtures.",
+            "Fixture '{}' does not define a '{}' artifact in {}",
             name,
-            path.display()
-        );
-    }
-    
-    path
+            profile,
+            manifest_path().display()
+        )
+    })
 }
 
-/// Check if a fixture WASM file exists
-///
-/// # Arguments
-/// * `name` - Name of the fixture contract (without .wasm extension)
-///
-/// # Returns
-/// `true` if the fixture exists, `false` otherwise
+pub fn try_artifact_path(name: &str, profile: &str) -> Option<PathBuf> {
+    let fixture = fixture(name);
+    fixture
+        .artifacts
+        .get(profile)
+        .map(|artifact| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(&artifact.path))
+}
+
+pub fn get_fixture_path(name: &str) -> PathBuf {
+    artifact_path(name, "release")
+}
+
 pub fn fixture_exists(name: &str) -> bool {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest_dir)
-        .join("tests")
-        .join("fixtures")
-        .join("wasm")
-        .join(format!("{}.wasm", name))
-        .exists()
+    get_fixture_path(name).exists()
 }
 
-/// Load a test fixture WASM file as bytes
-///
-/// # Arguments
-/// * `name` - Name of the fixture contract (without .wasm extension)
-///
-/// # Returns
-/// Vec<u8> containing the WASM bytes
-///
-/// # Panics
-/// Panics if the fixture file doesn't exist or can't be read
+pub fn artifact_exists(name: &str, profile: &str) -> bool {
+    try_artifact_path(name, profile)
+        .map(|path| path.exists())
+        .unwrap_or(false)
+}
+
 pub fn load_fixture(name: &str) -> Vec<u8> {
     let path = get_fixture_path(name);
     std::fs::read(&path).unwrap_or_else(|e| {
@@ -67,11 +98,30 @@ pub fn load_fixture(name: &str) -> Vec<u8> {
     })
 }
 
-/// Available fixture contracts
+pub fn source_path(name: &str) -> PathBuf {
+    let fixture = fixture(name);
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(fixture.source.lib_rs)
+}
+
+pub fn contract_dir(name: &str) -> PathBuf {
+    let fixture = fixture(name);
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(fixture.source.contract_dir)
+}
+
+pub fn relative_to_repo(path: &Path) -> String {
+    path.strip_prefix(env!("CARGO_MANIFEST_DIR"))
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Available fixture contracts.
 pub mod names {
     pub const COUNTER: &str = "counter";
     pub const ECHO: &str = "echo";
-    pub const PANIC: &str = "panic";
+    pub const ALWAYS_PANIC: &str = "always_panic";
+    pub const PANIC: &str = ALWAYS_PANIC;
     pub const BUDGET_HEAVY: &str = "budget_heavy";
     pub const CROSS_CONTRACT: &str = "cross_contract";
+    pub const SAME_RETURN: &str = "same_return";
 }

--- a/tests/source_map_integration_tests.rs
+++ b/tests/source_map_integration_tests.rs
@@ -1,16 +1,11 @@
-use soroban_debugger::debugger::source_map::SourceMap;
+#[path = "fixtures/mod.rs"]
+mod fixtures;
 
-fn fixture_wasm(name: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("wasm")
-        .join(format!("{name}.wasm"))
-}
+use soroban_debugger::debugger::source_map::SourceMap;
 
 #[test]
 fn source_map_missing_debug_info_is_graceful() {
-    let wasm = fixture_wasm("counter");
+    let wasm = fixtures::get_fixture_path(fixtures::names::COUNTER);
     if !wasm.exists() {
         eprintln!(
             "Skipping test: fixture not found at {}. Run tests/fixtures/build.sh to build fixtures.",
@@ -30,7 +25,14 @@ fn source_map_missing_debug_info_is_graceful() {
 
 #[test]
 fn source_map_debug_fixture_resolves_locations() {
-    let wasm = fixture_wasm("counter_debug");
+    let Some(wasm) = fixtures::try_artifact_path(fixtures::names::COUNTER, "debug") else {
+        eprintln!(
+            "Skipping test: debug artifact missing from {}. Run tests/fixtures/build.sh to generate debug fixtures.",
+            fixtures::manifest_path().display()
+        );
+        return;
+    };
+
     if !wasm.exists() {
         eprintln!(
             "Skipping test: debug fixture not found at {}. Run tests/fixtures/build.sh to generate *_debug.wasm fixtures.",
@@ -51,6 +53,5 @@ fn source_map_debug_fixture_resolves_locations() {
     let looked_up = sm.lookup(first_offset).expect("lookup should succeed");
     assert_eq!(&looked_up, first_loc);
 
-    // Range lookup should return the same location for nearby offsets.
     assert!(sm.lookup(first_offset.saturating_add(1)).is_some());
 }


### PR DESCRIPTION
Close: #542

Added a checked-in fixture manifest at [tests/fixtures/manifest.json] and rewired the fixture helpers in [tests/fixtures/mod.rs] so tests can resolve fixture artifacts, source paths, and optional debug artifacts from one machine-readable source of truth instead of hardcoded paths. I also updated [tests/fixture_tests.rs] , [tests/command_feature_tests.rs], and [tests/source_map_integration_tests.rs] to consume those helpers, and added a new manifest validation test in [tests/fixture_manifest_tests.rs]

The fixture tooling and docs now reflect the manifest too: [tests/fixtures/build.sh] and [tests/fixtures/build.ps1] now rebuild fixtures and regenerate manifest metadata, and [tests/fixtures/README.md] documents the new flow.

Verification: I directly validated every checked-in manifest entry’s source paths and release SHA-256 hash against the committed WASM files. Full cargo test runs for the touched tests timed out locally, and an attempted fixture rebuild hit a disk-space issue on C: while compiling, so I couldn’t complete end-to-end Rust test execution on this machine.