### PR TITLE
Added regression test for first-continue stop reason on pre-set break points

### DIFF
--- a/extensions/vscode/src/dap/adapter.ts
+++ b/extensions/vscode/src/dap/adapter.ts
@@ -59,6 +59,7 @@ function parseRuntimeError(error: unknown): StructuredRuntimeError {
 type LaunchRequestArgs = DebugProtocol.LaunchRequestArguments & DebuggerProcessConfig;
 
 export class SorobanDebugSession extends DebugSession {
+  private static readonly FIRST_CONTINUE_STOP_REASON: 'breakpoint' = 'breakpoint';
   private logManager: LogManager | undefined;
   private debuggerProcess: DebuggerProcess | null = null;
   private state: DebuggerState = {
@@ -446,7 +447,8 @@ export class SorobanDebugSession extends DebugSession {
       this.sendResponse(response);
 
       if (!this.hasExecuted) {
-        await this.runExecution('breakpoint');
+        // After the synthetic entry stop, the first continue should surface as a breakpoint stop.
+        await this.runExecution(SorobanDebugSession.FIRST_CONTINUE_STOP_REASON);
         return;
       }
 

--- a/extensions/vscode/src/test/runTest.ts
+++ b/extensions/vscode/src/test/runTest.ts
@@ -169,6 +169,7 @@ async function main(): Promise<void> {
   }
 
   await runSmokeSuite();
+  console.log('Running DAP E2E suite (includes first-continue stop-reason regression assertion)');
   await runDapE2ESuite();
   
   const compatibilityMessage = formatProtocolMismatchMessage({

--- a/extensions/vscode/src/test/suites.ts
+++ b/extensions/vscode/src/test/suites.ts
@@ -685,10 +685,20 @@ async function runDapHappyPathE2E(
     const cont = await client.request("continue", { threadId: 1 }, 30_000);
     assert.equal(cont.success, true, `continue failed: ${cont.message || ""}`);
 
-    await client.waitForEvent(
-      "stopped",
-      (e) => e.body?.reason === "breakpoint",
+    const firstEventAfterContinue = await client.waitForAnyEvent(
+      ["stopped", "exited"],
+      () => true,
       30_000,
+    );
+    assert.equal(
+      firstEventAfterContinue.event,
+      "stopped",
+      `Expected continue to pause at breakpoint before exit; got ${firstEventAfterContinue.event}`,
+    );
+    assert.equal(
+      firstEventAfterContinue.body?.reason,
+      "breakpoint",
+      `Expected first stop after continue to be 'breakpoint'; got '${String(firstEventAfterContinue.body?.reason)}'`,
     );
 
     const threads = await client.request("threads", {});


### PR DESCRIPTION
closes #647 

Implemented a minimal regression guard for first-continue stop reason and tightened the DAP e2e check so it fails on the exact bug mentioned