### PR TITLE
test: add regression tests for remote mode argument validation

### DIFF
--- a/tests/cli/run_tests.rs
+++ b/tests/cli/run_tests.rs
@@ -32,6 +32,88 @@ fn test_run_command_requires_function_arg() {
         );
 }
 
+//
+// Regression tests for --remote and --server modes:
+// These modes should NOT require --contract or --function arguments.
+// See: https://github.com/.../issues/661
+//
+
+#[test]
+fn test_run_server_mode_does_not_require_contract_or_function() {
+    // Server mode should parse successfully without contract/function
+    // (the server will start and run until killed)
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--server", "--port", "9229"])
+        .timeout(std::time::Duration::from_secs(2))
+        .assert()
+        // Server starts successfully (we kill it after timeout)
+        .stderr(predicate::str::contains("Debug server listening"));
+}
+
+#[test]
+fn test_run_remote_mode_does_not_require_contract_or_function() {
+    // Remote mode (ping) should parse without contract/function
+    // Connection will fail if no server is running, but that's expected
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--remote", "127.0.0.1:9229"])
+        .assert()
+        // Should fail with connection error, not argument parsing error
+        .failure()
+        .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_run_remote_mode_accepts_optional_contract_function() {
+    // Remote mode should accept optional contract/function for full execution
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let contract_file = temp_dir.path().join("contract.wasm");
+    std::fs::write(&contract_file, b"dummy").expect("Failed to write temp file");
+
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args([
+        "run",
+        "--remote",
+        "127.0.0.1:9229",
+        "--contract",
+        contract_file.to_str().unwrap(),
+        "--function",
+        "test",
+    ])
+    .assert()
+    // Should parse successfully (connection may fail, but that's expected)
+    .stderr(predicate::str::contains("Connection").or(predicate::str::contains("127.0.0.1")));
+}
+
+#[test]
+fn test_run_local_mode_requires_both_contract_and_function() {
+    // Local mode (no --server, no --remote) requires both contract and function
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let contract_file = temp_dir.path().join("contract.wasm");
+    std::fs::write(&contract_file, b"dummy").expect("Failed to write temp file");
+
+    // Missing function should fail
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--contract", contract_file.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("function")
+                .or(predicate::str::contains("required"))
+                .or(predicate::str::contains("missing")),
+        );
+
+    // Missing contract should fail
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--function", "test"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("contract")
+                .or(predicate::str::contains("required"))
+                .or(predicate::str::contains("missing")),
+        );
+}
+
 #[test]
 fn test_run_with_missing_contract_file() {
     let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");

--- a/tests/remote_run_tests.rs
+++ b/tests/remote_run_tests.rs
@@ -4,6 +4,118 @@ use std::path::PathBuf;
 use std::process::Command as StdCommand;
 use std::time::Duration;
 
+//
+// Regression tests for remote mode argument validation
+// See: https://github.com/.../issues/661
+//
+
+#[test]
+fn test_remote_ping_without_contract_or_function() {
+    // Remote mode should allow ping without contract/function
+    // Connection will fail if no server is running, but argument parsing should succeed
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--remote", "127.0.0.1:9229"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_with_token_without_contract_or_function() {
+    // Remote mode with auth token should parse without contract/function
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--remote", "127.0.0.1:9229", "--token", "secret"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_rejects_invalid_address_format() {
+    // Invalid remote address format should fail at argument parsing
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--remote", "invalid-address"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_remote_with_only_contract_no_function() {
+    // Remote mode with only contract (no function) should still parse
+    // (connection may fail, but argument validation should pass)
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let contract_file = temp_dir.path().join("contract.wasm");
+    std::fs::write(&contract_file, b"dummy").expect("Failed to write temp file");
+
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args([
+        "run",
+        "--remote",
+        "127.0.0.1:9229",
+        "--contract",
+        contract_file.to_str().unwrap(),
+    ])
+    .assert()
+    // Should parse successfully (connection may fail, but that's expected)
+    .stderr(predicate::str::contains("Connection").or(predicate::str::contains("127.0.0.1")));
+}
+
+#[test]
+fn test_remote_with_only_function_no_contract() {
+    // Remote mode with only function (no contract) should still parse
+    // (connection may fail, but argument validation should pass)
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["run", "--remote", "127.0.0.1:9229", "--function", "test"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_with_args_but_no_contract_or_function() {
+    // Remote mode with args but no contract/function should parse
+    // (the remote server handles validation)
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args([
+        "run",
+        "--remote",
+        "127.0.0.1:9229",
+        "--args",
+        "[\"arg1\", \"arg2\"]",
+    ])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_full_execution_args_matrix() {
+    // Test remote mode with full set of optional arguments
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let contract_file = temp_dir.path().join("contract.wasm");
+    std::fs::write(&contract_file, b"dummy").expect("Failed to write temp file");
+
+    let mut cmd = Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args([
+        "run",
+        "--remote",
+        "127.0.0.1:9229",
+        "--token",
+        "secret",
+        "--contract",
+        contract_file.to_str().unwrap(),
+        "--function",
+        "increment",
+        "--args",
+        "[1]",
+        "--output",
+        "json",
+    ])
+    .assert()
+    // Should parse successfully (connection may fail, but that's expected)
+    .stderr(predicate::str::contains("Connection").or(predicate::str::contains("127.0.0.1")));
+}
+
 #[test]
 fn test_remote_run_execution() {
     fn fixture_wasm_path(name: &str) -> PathBuf {


### PR DESCRIPTION
This PR adds regression tests for remote mode argument validation.

Closes #661