### PR TITLE
feat: add repeat-mode flaky detector for VS Code DAP e2e (#671)

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -159,7 +159,8 @@
     "ci": "npm run build && npm run test",
     "test:all": "node ./dist/test/runTest.js",
     "test:smoke": "node ./dist/test/runSmokeTest.js",
-    "test:dap-e2e": "node ./dist/test/runDapE2E.js"
+    "test:dap-e2e": "node ./dist/test/runDapE2E.js",
+    "test:dap-e2e:repeat": "node ./dist/test/runDapE2E.js --repeat 10"
   },
   "devDependencies": {
     "@types/node": "^20.19.37",

--- a/extensions/vscode/src/test/dapClient.ts
+++ b/extensions/vscode/src/test/dapClient.ts
@@ -26,12 +26,19 @@ type DapEvent = {
 
 type DapMessage = DapResponse | DapEvent;
 
+export type TimestampedEvent = {
+  timestampMs: number;
+  event: string;
+  body?: any;
+};
+
 export class DapClient {
   private proc: ChildProcessWithoutNullStreams;
   private seq = 0;
   private stdoutBuffer: Buffer = Buffer.alloc(0);
   private pending = new Map<number, { resolve: (r: DapResponse) => void; reject: (e: Error) => void }>();
   private events: DapEvent[] = [];
+  private eventLog: TimestampedEvent[] = [];
 
   constructor(proc: ChildProcessWithoutNullStreams) {
     this.proc = proc;
@@ -116,6 +123,11 @@ export class DapClient {
     throw new Error(`Timed out waiting for DAP event(s): ${events.join(', ')}`);
   }
 
+  /** Returns a copy of all events received, with millisecond timestamps. */
+  getEventLog(): TimestampedEvent[] {
+    return this.eventLog.slice();
+  }
+
   dispose(): void {
     this.proc.kill();
   }
@@ -159,6 +171,7 @@ export class DapClient {
   private handleMessage(message: DapMessage): void {
     if (message.type === 'event') {
       this.events.push(message);
+      this.eventLog.push({ timestampMs: Date.now(), event: message.event, body: message.body });
       return;
     }
 

--- a/extensions/vscode/src/test/runDapE2E.ts
+++ b/extensions/vscode/src/test/runDapE2E.ts
@@ -1,6 +1,75 @@
 import { runDapE2ESuite } from './suites';
 
-runDapE2ESuite().catch((error) => {
+type IterationResult =
+  | { iteration: number; status: 'pass' }
+  | { iteration: number; status: 'fail'; error: unknown };
+
+function parseRepeatCount(): number {
+  const argIndex = process.argv.indexOf('--repeat');
+  if (argIndex !== -1 && process.argv[argIndex + 1]) {
+    const n = parseInt(process.argv[argIndex + 1], 10);
+    if (!isNaN(n) && n >= 1) {
+      return n;
+    }
+  }
+  const envVal = process.env.DAP_E2E_REPEAT;
+  if (envVal) {
+    const n = parseInt(envVal, 10);
+    if (!isNaN(n) && n >= 1) {
+      return n;
+    }
+  }
+  return 1;
+}
+
+async function runRepeat(repeat: number): Promise<void> {
+  console.log(`[repeat-mode] Running DAP e2e suite ${repeat} times to detect flakiness...`);
+
+  const results: IterationResult[] = [];
+
+  for (let i = 1; i <= repeat; i++) {
+    try {
+      await runDapE2ESuite();
+      results.push({ iteration: i, status: 'pass' });
+      console.log(`[repeat-mode] Iteration ${i}/${repeat}: PASS`);
+    } catch (error) {
+      results.push({ iteration: i, status: 'fail', error });
+      console.log(`[repeat-mode] Iteration ${i}/${repeat}: FAIL`);
+    }
+  }
+
+  const passed = results.filter((r) => r.status === 'pass').length;
+  const failed = results.filter((r) => r.status === 'fail').length;
+  const firstFailure = results.find((r): r is Extract<IterationResult, { status: 'fail' }> => r.status === 'fail');
+
+  console.log('');
+  console.log('=== DAP e2e repeat-mode summary ===');
+  console.log(`  Iterations: ${repeat}`);
+  console.log(`  Passed:     ${passed}`);
+  console.log(`  Failed:     ${failed}`);
+
+  if (firstFailure) {
+    console.log(`  First failure: iteration ${firstFailure.iteration}`);
+    console.log('  First failure context:');
+    console.error(firstFailure.error);
+    process.exit(1);
+  }
+
+  console.log('  Result: all iterations passed.');
+}
+
+async function main(): Promise<void> {
+  const repeat = parseRepeatCount();
+
+  if (repeat === 1) {
+    await runDapE2ESuite();
+    return;
+  }
+
+  await runRepeat(repeat);
+}
+
+main().catch((error) => {
   console.error(error);
   process.exit(1);
 });


### PR DESCRIPTION
closes #671 

Introduces --repeat N / DAP_E2E_REPEAT env-var support in runDapE2E.ts so contributors can run the DAP e2e suite N times and get a summarised pass/fail report with first-failure context for diagnosing intermittent protocol timing issues.

- runDapE2E.ts: parseRepeatCount() reads --repeat arg or DAP_E2E_REPEAT env var; runRepeat() loops N times, collects results, prints summary (Iterations / Passed / Failed) and first-failure error on exit code 1; single-run path (repeat=1) is fully backward-compatible
- dapClient.ts: added TimestampedEvent type and getEventLog() method so callers can surface per-event timing in failure diagnostics
- package.json: added test:dap-e2e:repeat script (--repeat 10)