### PR TITLE
test: add parity guard for auth-before-handshake backward compat

### DIFF
--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -275,7 +275,12 @@ impl DebugServer {
                 }
             }
 
-            // Backward compatibility: allow Authenticate before handshake.
+            // BACKWARD COMPATIBILITY (intentional): Allow `Authenticate` to succeed before
+            // the protocol `Handshake` is completed. Older clients (pre-handshake protocol)
+            // send `Authenticate` as their first message. Removing or reordering this block
+            // would break those clients silently. Any change here MUST be accompanied by an
+            // update to the parity test `parity_dap_auth_before_handshake_is_accepted` in
+            // tests/parity_tests.rs and a version bump in src/server/protocol.rs.
             if let DebugRequest::Authenticate { token } = &request {
                 let success = self
                     .token

--- a/tests/parity_tests.rs
+++ b/tests/parity_tests.rs
@@ -428,6 +428,89 @@ fn parity_dap_server_rejects_invalid_token() {
     }
 }
 
+/// SURFACE: DAP (server path) — BACKWARD COMPATIBILITY GUARD
+///
+/// Older clients send `Authenticate` as their very first message, before any
+/// `Handshake` exchange. The server MUST accept and honour this ordering so
+/// that pre-handshake clients continue to work without modification.
+///
+/// This test is the dedicated regression guard for that behaviour. If it
+/// starts failing it means the auth-before-handshake path in
+/// `src/server/debug_server.rs` (`handle_single_connection`) was broken.
+/// Do NOT remove or weaken this test without a corresponding protocol version
+/// bump and a migration note in CONTRIBUTING.md.
+#[test]
+fn parity_dap_auth_before_handshake_is_accepted() {
+    if !network::can_bind_loopback() {
+        eprintln!(
+            "Skipping parity_dap_auth_before_handshake_is_accepted: loopback networking \
+             restricted (EPERM or equivalent) – see docs/remote-troubleshooting.md."
+        );
+        return;
+    }
+
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let port = 19_235u16;
+    let token = "compat-test-token";
+
+    let mut server = std::process::Command::new(env!("CARGO_BIN_EXE_soroban-debug"))
+        .args(["server", "--port", &port.to_string(), "--token", token])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("Failed to spawn soroban-debug server");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let result: Result<String, String> = (|| {
+        let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+            .map_err(|e| format!("connect failed: {}", e))?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(4)))
+            .map_err(|e| format!("set_read_timeout: {}", e))?;
+
+        // Send Authenticate WITHOUT a prior Handshake — this is the legacy ordering.
+        let auth_msg = format!(
+            "{{\"id\":1,\"request\":{{\"type\":\"Authenticate\",\"token\":\"{}\"}}}}\n",
+            token
+        );
+        stream
+            .write_all(auth_msg.as_bytes())
+            .map_err(|e| format!("write failed: {}", e))?;
+
+        let mut reader = BufReader::new(stream);
+        let mut response = String::new();
+        reader
+            .read_line(&mut response)
+            .map_err(|e| format!("read failed: {}", e))?;
+        Ok(response)
+    })();
+
+    let _ = server.kill();
+    let _ = server.wait();
+
+    match result {
+        Ok(response) => {
+            assert!(
+                response.contains("\"success\":true"),
+                "Server must accept Authenticate sent before Handshake (backward-compat). \
+                 Got: {}",
+                response
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "Skipping parity_dap_auth_before_handshake_is_accepted: {} – \
+                 see docs/remote-troubleshooting.md.",
+                e
+            );
+        }
+    }
+}
+
 // ── Non-support assertions ────────────────────────────────────────────────
 //
 // These tests confirm that features unsupported on BOTH surfaces remain

--- a/tests/security_import_name_tests.rs
+++ b/tests/security_import_name_tests.rs
@@ -1,4 +1,5 @@
 use soroban_debugger::analyzer::security::{AnalyzerFilter, SecurityAnalyzer};
+use soroban_debugger::server::protocol::{DynamicTraceEvent, DynamicTraceEventKind};
 
 fn uleb128(mut value: usize) -> Vec<u8> {
     let mut out = Vec::new();


### PR DESCRIPTION
Closes #658 

## Summary

This PR adds a dedicated regression guard for the auth-before-handshake backward-compatibility behavior in the debug server, and fixes a pre-existing compile error in an unrelated test file.

## Problem

The server's `handle_single_connection` logic intentionally allows older clients to send an `Authenticate` message before completing the `Handshake` exchange. This behavior was fixed at some point but had no test protecting it — meaning a future refactor could silently break older clients with no CI signal.

## Changes

### `src/server/debug_server.rs`
Replaced the terse `// Backward compatibility: allow Authenticate before handshake.` comment with a detailed block comment that explains:
- Why the ordering is intentional
- What breaks if the block is removed or reordered
- Where the corresponding regression test lives

### `tests/parity_tests.rs`
Added `parity_dap_auth_before_handshake_is_accepted` — a new parity test that:
- Spawns a real `soroban-debug server` instance with a token
- Sends `Authenticate` as the very first message, with no prior `Handshake`
- Asserts the server responds with `"success": true`

The test doc comment explicitly marks it as a backward-compat guard and warns contributors not to remove it without a protocol version bump.

### `tests/security_import_name_tests.rs`
Fixed a pre-existing compile error caused by missing `use` imports for `DynamicTraceEvent` and `DynamicTraceEventKind` from `soroban_debugger::server::protocol`.

## Testing

```bash
# Run the new parity guard
cargo test --test parity_tests parity_dap_auth_before_handshake_is_accepted

# Confirm the previously broken test file now compiles and passes
cargo test --test security_import_name_tests
