### PR TITLE
feat: fix duplicate execution start banner emission

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -669,9 +669,9 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
     }
 
     // Execute locally with debugging
-    if !args.is_json_output() {
-        println!("\n--- Execution Start ---\n");
-    }
+    // if !args.is_json_output() {
+    //     println!("\n--- Execution Start ---\n");
+    // }
     if args.instruction_debug {
         print_info("Enabling instruction-level debugging...");
         engine.enable_instruction_debug(&wasm_bytes)?;
@@ -687,7 +687,7 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
             return Ok(());
         }
     }
-
+    
     print_info("\n--- Execution Start ---\n");
     output_writer.write("\n--- Execution Start ---\n")?;
     let storage_before = engine.executor().get_storage_snapshot()?;

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -463,6 +463,7 @@ pub fn check_api_version(plugin_version: u32) -> Result<(), crate::plugin::api::
     }
     Ok(())
 }
+    } }
 
 #[cfg(test)]
 mod tests {
@@ -522,6 +523,7 @@ mod version_tests {
     fn test_api_version_check() {
         let result = check_api_version(999);
         assert!(matches!(result, Err(PluginError::VersionMismatch { .. })));
+    }
 
     #[test]
     fn test_loader_creation() {
@@ -663,3 +665,6 @@ mod version_tests {
         );
         let result_ok = check_api_version(PLUGIN_API_VERSION);
         assert!(result_ok.is_ok());
+    }
+}
+}


### PR DESCRIPTION
## Description
This PR fix duplicate execution start banner emission in src/cli/command.rs

## Related Issue
Closes #696 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ x] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Test / CI improvement

---

## CI/Test Behavior Changes
This PR does not modify any existing tests. However, some syntax error in were fixed in src/plugin/loader.rs to resolve build issues.

**What changed in CI or test behavior?**
N/A — no CI/test behavior changes

**Migration notes**


N/A

---

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x ] PR description mentions the related issue(s)
- [ ] CI/test behavior changes documented above (or marked N/A)
- [ ] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed
