### PR TITLE
tooling: add CI guard for README/CLI/manpage option drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Check man pages are up to date
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Verify check_manpages isolation behavior
+        shell: bash
+        run: bash scripts/test_manpage_tmpdir.sh
+      - name: Check man pages and README options are up to date
         run: make check-man
 
   coverage:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Options:
   -b, --breakpoint <NAME>   Set breakpoint at function name
       --storage-filter <PATTERN>  Filter storage by key pattern (repeatable)
   --batch-args <FILE>   Path to JSON file with array of argument sets for batch execution
-  --watch               Watch the WASM file for changes and automatically re-run
   --server              Start a remote debug server instead of executing locally
 ```
 
@@ -181,20 +180,6 @@ Generated tests are self-contained and use the Soroban test SDK.
 Options:
   --generate-test <FILE>  Write generated test to the specified file
   --overwrite             Overwrite the test file if it already exists (default: append)
-
-### Watch Mode
-
-Automatically reload and re-run when the WASM file changes:
-
-```bash
-soroban-debug run \
-  --contract target/wasm32-unknown-unknown/release/my_contract.wasm \
-  --function transfer \
-  --args '["user1", "user2", 100]' \
-  --watch
-```
-
-Perfect for development - edit your contract, rebuild, and see results immediately. See [docs/watch-mode.md](https://github.com/Timi16/soroban-debugger/blob/main/docs/watch-mode.md) for details.
 
 ### Batch Execution
 
@@ -396,7 +381,7 @@ You can export a full record of the contract execution to a JSON file using the 
 
 ```bash
 soroban-debug run \
-  --wasm contract.wasm \
+  --contract contract.wasm \
   --function hello \
   --trace-output execution_trace.json
 ```

--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,16 +17,4 @@ Shell to generate completion script for
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-bash
-.IP \(bu 2
-elvish
-.IP \(bu 2
-fish
-.IP \(bu 2
-powershell
-.IP \(bu 2
-zsh
-.RE
+[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -23,13 +23,7 @@ Output format: pretty (default) or json
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-pretty
-.IP \(bu 2
-json
-.RE
+[\fIpossible values: \fRpretty, json]
 .TP
 \fB\-\-source\-map\-diagnostics\fR
 Print source map diagnostics including resolved mappings, missing DWARF sections, and fallback behavior
@@ -45,13 +39,7 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-dot
-.IP \(bu 2
-mermaid
-.RE
+[\fIpossible values: \fRdot, mermaid]
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-profile.1
+++ b/man/man1/soroban-debug-profile.1
@@ -29,15 +29,7 @@ Export format for profiler output (report|folded\-stack|json)
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-report
-.IP \(bu 2
-folded\-stack
-.IP \(bu 2
-json
-.RE
+[\fIpossible values: \fRreport, folded\-stack, json]
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match

--- a/man/man1/soroban-debug-remote.1
+++ b/man/man1/soroban-debug-remote.1
@@ -4,7 +4,7 @@
 .SH NAME
 remote \- Connect to remote debug server
 .SH SYNOPSIS
-\fBremote\fR <\fB\-r\fR|\fB\-\-remote\fR> [\fB\-t\fR|\fB\-\-token\fR] [\fB\-c\fR|\fB\-\-contract\fR] [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-\-tls\-cert\fR] [\fB\-\-tls\-key\fR] [\fB\-\-tls\-ca\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBremote\fR <\fB\-r\fR|\fB\-\-remote\fR> [\fB\-t\fR|\fB\-\-token\fR] [\fB\-c\fR|\fB\-\-contract\fR] [\fB\-f\fR|\fB\-\-function\fR] [\fB\-\-tls\-cert\fR] [\fB\-\-tls\-key\fR] [\fB\-\-tls\-ca\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Connect to remote debug server
 .SH OPTIONS
@@ -21,17 +21,17 @@ Path to the contract WASM file
 \fB\-f\fR, \fB\-\-function\fR \fI<FUNCTION>\fR
 Function name to execute
 .TP
-\fB\-a\fR, \fB\-\-args\fR \fI<ARGS>\fR
-Function arguments as JSON array
-.TP
 \fB\-\-tls\-cert\fR \fI<TLS_CERT>\fR
-Path to the client TLS certificate
+TLS certificate file path (optional)
 .TP
 \fB\-\-tls\-key\fR \fI<TLS_KEY>\fR
-Path to the client TLS private key
+TLS private key file path (optional)
 .TP
 \fB\-\-tls\-ca\fR \fI<TLS_CA>\fR
-Path to the CA certificate for server verification
+TLS CA certificate file path (optional, for self\-signed certs)
+.TP
+\fB\-a\fR, \fB\-\-args\fR \fI<ARGS>\fR
+Function arguments as JSON array
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -56,13 +56,7 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-pretty
-.IP \(bu 2
-json
-.RE
+[\fIpossible values: \fRpretty, json]
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/man/man1/soroban-debug-server.1
+++ b/man/man1/soroban-debug-server.1
@@ -4,7 +4,7 @@
 .SH NAME
 server \- Start debug server for remote connections
 .SH SYNOPSIS
-\fBserver\fR [\fB\-p\fR|\fB\-\-port\fR] [\fB\-t\fR|\fB\-\-token\fR] [\fB\-\-tls\-cert\fR] [\fB\-\-tls\-key\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBserver\fR [\fB\-p\fR|\fB\-\-port\fR] [\fB\-t\fR|\fB\-\-token\fR] [\fB\-\-tls\-cert\fR] [\fB\-\-tls\-key\fR] [\fB\-\-repeat\fR] [\fB\-\-storage\-filter\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Start debug server for remote connections
 .SH OPTIONS
@@ -20,6 +20,12 @@ TLS certificate file path (optional)
 .TP
 \fB\-\-tls\-key\fR \fI<TLS_KEY>\fR
 TLS private key file path (optional)
+.TP
+\fB\-\-repeat\fR \fI<N>\fR
+Repeat execution N times and show throughput/latency stats
+.TP
+\fB\-\-storage\-filter\fR \fI<PATTERN>\fR
+Filter storage view to only show keys matching pattern (repeatable)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-symbolic.1
+++ b/man/man1/soroban-debug-symbolic.1
@@ -23,15 +23,7 @@ Preset symbolic exploration budget profile
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-fast
-.IP \(bu 2
-balanced
-.IP \(bu 2
-deep
-.RE
+[\fIpossible values: \fRfast, balanced, deep]
 .TP
 \fB\-\-input\-combination\-cap\fR \fI<N>\fR
 Maximum number of input combinations to generate deterministically
@@ -59,13 +51,7 @@ Output format for the report (pretty/text or json)
 .br
 
 .br
-\fIPossible values:\fR
-.RS 14
-.IP \(bu 2
-pretty
-.IP \(bu 2
-json
-.RE
+[\fIpossible values: \fRpretty, json]
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/scripts/check_manpages.sh
+++ b/scripts/check_manpages.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Regenerates man pages into a temp directory and diffs against committed versions.
-# Exits non-zero with a clear diff output if drift is detected.
+# Two-phase doc consistency check:
+#   1. Regenerates man pages into a temp directory and diffs against committed
+#      versions.  Exits non-zero if the CLI source has drifted from the .1 files.
+#   2. Scans README.md for --option-name references in documentation blocks and
+#      verifies that each one exists in a committed man page.  Exits non-zero if
+#      README documents options that are not present in the CLI.
 #
 # Usage: bash scripts/check_manpages.sh
 #   or:  make check-man
@@ -113,7 +117,7 @@ diff_status=${diff_status:-0}
 
 if [ "$diff_status" -eq 0 ]; then
     echo "OK: Man pages are in sync."
-    exit 0
+    # Fall through to README option drift check below.
 elif [ "$diff_status" -eq 1 ]; then
     echo ""
     echo "ERROR: Drift detected between committed man pages and current CLI source."
@@ -127,3 +131,67 @@ else
     echo "$diff_output"
     exit 2
 fi
+
+# ── README option drift check ────────────────────────────────────────────────
+# Verifies that every --option-name documented in README.md also exists in a
+# committed man page.  Only lines with two or more leading spaces are scanned —
+# these are option-table entries ("  --opt  desc") and shell-continuation args
+# ("  --opt" in multi-line soroban-debug examples).  Lines starting at column 0
+# (cargo, docker, git invocations) are intentionally excluded.
+echo ""
+echo "Checking README.md option references against committed man pages..."
+
+README="$REPO_ROOT/README.md"
+
+if [ ! -f "$README" ]; then
+    echo "WARNING: README.md not found, skipping option drift check."
+    exit 0
+fi
+
+# Step 1: extract --option-name patterns from indented README lines.
+readme_opts=$(grep -E '^[[:space:]]{2,}' "$README" \
+    | grep -oE '\-\-[a-z][a-z0-9-]+' \
+    | sort -u) || true
+
+if [ -z "$readme_opts" ]; then
+    echo "OK: No --option references found in README.md documentation blocks."
+    exit 0
+fi
+
+# Step 2: extract --option-name patterns from committed man pages.
+# In roff, long options are encoded as \fB\-\-option\-name\fR where each
+# hyphen is escaped as \-.  The alternation ([a-z0-9]|\\-) matches letters,
+# digits, and escaped hyphens but stops cleanly before \fR/\fI/etc.
+man_opts=$(grep -hEo '\\-\\-([a-z0-9]|\\-)+' "$COMMITTED_DIR"/*.1 2>/dev/null \
+    | sed 's/\\-/-/g' \
+    | grep '^--' \
+    | sort -u) || true
+
+if [ -z "$man_opts" ]; then
+    echo "ERROR: No options extracted from committed man pages at $COMMITTED_DIR." >&2
+    echo "   Run 'make regen-man' to generate and commit man pages first." >&2
+    exit 2
+fi
+
+# Step 3: report any README options absent from every man page.
+unknown=()
+while IFS= read -r opt; do
+    if ! printf '%s\n' "$man_opts" | grep -qxF -- "$opt"; then
+        unknown+=("$opt")
+    fi
+done <<< "$readme_opts"
+
+if [ "${#unknown[@]}" -eq 0 ]; then
+    echo "OK: All README option references match the CLI man pages."
+    exit 0
+fi
+
+echo "" >&2
+echo "ERROR: README.md references options not found in any CLI man page:" >&2
+for opt in "${unknown[@]}"; do
+    echo "   $opt" >&2
+done
+echo "" >&2
+echo "Either remove the option from README.md or add it to the CLI source" >&2
+echo "and run 'make regen-man' to regenerate man pages." >&2
+exit 1

--- a/scripts/test_manpage_tmpdir.sh
+++ b/scripts/test_manpage_tmpdir.sh
@@ -1,129 +1,107 @@
 #!/usr/bin/env bash
-# Test script to validate check_manpages.sh portability across TMPDIR configurations.
+# Behavioral tests for scripts/check_manpages.sh.
 #
-# Usage: bash scripts/test_manpage_tmpdir.sh
+# Uses a temporary fake repo and a stub cargo binary to run check_manpages.sh
+# in full isolation.  Tests:
+#   1. Tmpdir is created inside the controlled $TMPDIR and cleaned up on exit.
+#   2. README option drift check passes when all documented options exist in
+#      the committed man pages.
+#   3. README option drift check exits non-zero when README documents an option
+#      absent from every man page.
 #
-# This script validates that check_manpages.sh:
-#   - Respects explicit TMPDIR environment variable
-#   - Falls back to standard locations when TMPDIR is unset
-#   - Reports clear errors when no temp directory is writable
-#   - Is portable across BSD/macOS and Linux platforms
+# Mirrors the isolation pattern used by scripts/test_benchmark_regressions.sh.
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$SCRIPT_DIR/.."
-RESULTS_FILE="/tmp/manpage_tmpdir_test_results_$RANDOM.txt"
+SOURCE_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check_manpages.sh"
+TEST_ROOT="$(mktemp -d)"
+REPO_ROOT="$TEST_ROOT/repo"
+BIN_DIR="$TEST_ROOT/bin"
+CUSTOM_TMPDIR="$TEST_ROOT/tmp"
 
-# Color codes for output
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
 
-test_count=0
-pass_count=0
-fail_count=0
+mkdir -p "$REPO_ROOT/scripts" "$REPO_ROOT/man/man1" "$BIN_DIR" "$CUSTOM_TMPDIR"
+cp "$SOURCE_SCRIPT" "$REPO_ROOT/scripts/check_manpages.sh"
+chmod +x "$REPO_ROOT/scripts/check_manpages.sh"
 
-print_result() {
-    local status="$1"
-    local message="$2"
-    test_count=$((test_count + 1))
-    
-    if [[ "$status" == "PASS" ]]; then
-        echo -e "${GREEN}✓ PASS${NC}: $message"
-        pass_count=$((pass_count + 1))
-    else
-        echo -e "${RED}✗ FAIL${NC}: $message"
-        fail_count=$((fail_count + 1))
-    fi
-}
+# Minimal roff man page with --contract and --function.
+# The \fB\-\-option\fR encoding mirrors what clap_mangen generates.
+cat > "$REPO_ROOT/man/man1/soroban-debug-run.1" <<'EOF'
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH run 1
+.SH OPTIONS
+.TP
+\fB\-c\fR, \fB\-\-contract\fR \fI<FILE>\fR
+Path to the contract WASM file
+.TP
+\fB\-f\fR, \fB\-\-function\fR \fI<FUNCTION>\fR
+Function name to execute
+EOF
 
-echo "Testing check_manpages.sh portability..."
-echo ""
-
-# Test 1: Run with default TMPDIR (unset)
-echo "Test 1: Running with default TMPDIR (unset)..."
-(
-    cd "$REPO_ROOT"
-    unset TMPDIR || true
-    if bash scripts/check_manpages.sh >/dev/null 2>&1; then
-        print_result "PASS" "check_manpages.sh run successfully with default TMPDIR"
-    else
-        exit_code=$?
-        if [[ $exit_code -eq 1 ]]; then
-            print_result "PASS" "check_manpages.sh correctly reported man page drift (exit code 1)"
-        else
-            print_result "FAIL" "check_manpages.sh exited with unexpected code $exit_code"
-        fi
-    fi
-)
-
-# Test 2: Run with explicit TMPDIR=/tmp
-echo ""
-echo "Test 2: Running with TMPDIR=/tmp..."
-(
-    cd "$REPO_ROOT"
-    if TMPDIR=/tmp bash scripts/check_manpages.sh >/dev/null 2>&1; then
-        print_result "PASS" "check_manpages.sh runs successfully with TMPDIR=/tmp"
-    else
-        exit_code=$?
-        if [[ $exit_code -eq 1 ]]; then
-            print_result "PASS" "check_manpages.sh correctly reported man page drift (exit code 1)"
-        else
-            print_result "FAIL" "check_manpages.sh exited with unexpected code $exit_code"
-        fi
-    fi
-)
-
-# Test 3: Run with DEBUG=1 to verify debug output works
-echo ""
-echo "Test 3: Running with DEBUG=1 to verify diagnostic output..."
-(
-    cd "$REPO_ROOT"
-    output=$(DEBUG=1 TMPDIR=/tmp bash scripts/check_manpages.sh 2>&1 || true)
-    if echo "$output" | grep -q "DEBUG"; then
-        print_result "PASS" "Debug output is produced when DEBUG=1"
-    else
-        print_result "FAIL" "Debug output not found when DEBUG=1"
-    fi
-)
-
-# Test 4: Verify Makefile target works with TMPDIR override
-echo ""
-echo "Test 4: Testing Makefile check-man target with TMPDIR=/tmp..."
-(
-    cd "$REPO_ROOT"
-    if TMPDIR=/tmp make check-man >/dev/null 2>&1; then
-        print_result "PASS" "make check-man runs successfully with TMPDIR=/tmp"
-    else
-        exit_code=$?
-        if [[ $exit_code -eq 1 ]]; then
-            print_result "PASS" "make check-man correctly reported man page drift"
-        else
-            print_result "FAIL" "make check-man exited with unexpected code $exit_code"
-        fi
-    fi
-)
-
-# Summary
-echo ""
-echo "======================================"
-echo "Test Results"
-echo "======================================"
-echo "Total:  $test_count"
-echo -e "${GREEN}Passed: $pass_count${NC}"
-if [[ $fail_count -gt 0 ]]; then
-    echo -e "${RED}Failed: $fail_count${NC}"
-else
-    echo -e "${GREEN}Failed: $fail_count${NC}"
+# Fake cargo: copies committed man pages into MAN_OUT_DIR, simulating a clean
+# build where man page content has not changed.
+cat > "$BIN_DIR/cargo" <<FAKECARGO
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "\${MAN_OUT_DIR:-}" ]; then
+    mkdir -p "\$MAN_OUT_DIR"
+    cp "$REPO_ROOT/man/man1/"*.1 "\$MAN_OUT_DIR/"
 fi
-echo ""
+FAKECARGO
+chmod +x "$BIN_DIR/cargo"
 
-if [[ $fail_count -eq 0 ]]; then
-    echo -e "${GREEN}✓ All portability tests passed!${NC}"
-    exit 0
-else
-    echo -e "${RED}✗ Some tests failed.${NC}"
+export PATH="$BIN_DIR:$PATH"
+export TMPDIR="$CUSTOM_TMPDIR"
+unset DEBUG 2>/dev/null || true
+
+# ── Test 1: tmpdir is created inside $TMPDIR and cleaned up after exit ───────
+
+cat > "$REPO_ROOT/README.md" <<'EOF'
+## Run Command
+
+Options:
+  -c, --contract <FILE>   Path to the WASM file
+  -f, --function <NAME>   Function name
+EOF
+
+bash "$REPO_ROOT/scripts/check_manpages.sh" > /dev/null
+
+leftover=$(find "$CUSTOM_TMPDIR" -mindepth 1 -maxdepth 1 -name 'check_manpages.*' 2>/dev/null \
+    | wc -l | tr -d ' ')
+if [ "$leftover" -ne 0 ]; then
+    echo "FAIL: check_manpages.sh did not clean up its tmpdir after a successful run" >&2
     exit 1
 fi
+
+echo "PASS: tmpdir is created in TMPDIR and cleaned up on exit"
+
+# ── Test 2: README with only known options passes ────────────────────────────
+# Reuse the README from test 1 — it only contains --contract and --function,
+# both of which are in the fake man page above.
+
+bash "$REPO_ROOT/scripts/check_manpages.sh" > /dev/null
+
+echo "PASS: README drift check passes when all options exist in man pages"
+
+# ── Test 3: README with an unknown option causes failure ─────────────────────
+
+cat > "$REPO_ROOT/README.md" <<'EOF'
+## Run Command
+
+Options:
+  -c, --contract <FILE>   Path to the WASM file
+  --watch               Watch the WASM file for changes
+EOF
+
+if bash "$REPO_ROOT/scripts/check_manpages.sh" > /dev/null 2>&1; then
+    echo "FAIL: expected check_manpages.sh to exit non-zero for --watch drift" >&2
+    exit 1
+fi
+
+echo "PASS: README drift check exits non-zero when README documents an unknown option"
+
+echo ""
+echo "All check_manpages.sh behavioral tests passed."


### PR DESCRIPTION
## What

Adds a second check phase to `scripts/check_manpages.sh` that scans README.md
for `--option-name` references in documentation blocks and verifies each one
exists in a committed man page. The existing man page diff phase runs first;
the README drift check runs only if that phase passes.

## Why

CLI docs drift (e.g. stale `--watch`) was not caught by CI. A previous man page
check validated that committed `.1` files matched the CLI source, but nothing
validated that README actually reflected the same CLI surface.

## Changes

**`scripts/check_manpages.sh`** — new phase 2:
- Extracts `--option-name` from lines with 2+ leading spaces (option tables and
  shell-continuation args in soroban-debug examples).
- Lines starting at column 0 (cargo, docker, git) are excluded.
- Compares against options extracted from committed man pages (roff `\fB\-\-opt\fR` format).
- Exits 1 with a clear list of unknown options if any are found.

**`scripts/test_manpage_tmpdir.sh`** — rewritten as isolated behavioral tests:
- Uses a fake repo + stub cargo binary to test without a real build.
- Test 1: tmpdir is created inside `$TMPDIR` and cleaned up on exit.
- Test 2: drift check passes when all README options exist in man pages.
- Test 3: drift check exits non-zero when README documents `--watch` (not in CLI).

**`.github/workflows/ci.yml`** — `check-manpages` job:
- Adds Rust cache step.
- Runs `bash scripts/test_manpage_tmpdir.sh` before `make check-man`.

**`README.md`**:
- Remove `--watch` from the Run Command options list.
- Remove the Watch Mode section (the flag does not exist in `RunArgs`).
- Replace deprecated `--wasm` alias with `--contract` in the trace-output example.

**`man/man1/*.1`** — regenerated to fix pre-existing clap_mangen format drift
(inline possible-values list, reordered remote/server options).

Closes #701