### PR TITLE
Fix DWARF code-section offsets

### DIFF
--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,4 +17,16 @@ Shell to generate completion script for
 .br
 
 .br
-[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+bash
+.IP \(bu 2
+elvish
+.IP \(bu 2
+fish
+.IP \(bu 2
+powershell
+.IP \(bu 2
+zsh
+.RE

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -23,7 +23,13 @@ Output format: pretty (default) or json
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-source\-map\-diagnostics\fR
 Print source map diagnostics including resolved mappings, missing DWARF sections, and fallback behavior
@@ -39,7 +45,13 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-[\fIpossible values: \fRdot, mermaid]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+dot
+.IP \(bu 2
+mermaid
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-profile.1
+++ b/man/man1/soroban-debug-profile.1
@@ -29,7 +29,15 @@ Export format for profiler output (report|folded\-stack|json)
 .br
 
 .br
-[\fIpossible values: \fRreport, folded\-stack, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+report
+.IP \(bu 2
+folded\-stack
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -56,7 +56,13 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/man/man1/soroban-debug-symbolic.1
+++ b/man/man1/soroban-debug-symbolic.1
@@ -23,7 +23,15 @@ Preset symbolic exploration budget profile
 .br
 
 .br
-[\fIpossible values: \fRfast, balanced, deep]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+fast
+.IP \(bu 2
+balanced
+.IP \(bu 2
+deep
+.RE
 .TP
 \fB\-\-input\-combination\-cap\fR \fI<N>\fR
 Maximum number of input combinations to generate deterministically
@@ -51,7 +59,13 @@ Output format for the report (pretty/text or json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/debugger/source_map.rs
+++ b/src/debugger/source_map.rs
@@ -230,22 +230,23 @@ impl SourceMap {
                     if let Some(file_path) =
                         self.get_file_path(&dwarf, &unit, header, row.file_index())
                     {
-                        let offset =
-                            self.normalize_wasm_offset(row.address() as usize, wasm_bytes.len());
+                        let (offset, alt_offset) =
+                            self.normalize_wasm_offsets(row.address() as usize, wasm_bytes.len());
                         let line = row.line().map(|l| l.get() as u32).unwrap_or(0);
                         let column = match row.column() {
                             gimli::ColumnType::LeftEdge => None,
                             gimli::ColumnType::Column(column) => Some(column.get() as u32),
                         };
+                        let location = SourceLocation {
+                            file: file_path,
+                            line,
+                            column,
+                        };
 
-                        self.offsets.insert(
-                            offset,
-                            SourceLocation {
-                                file: file_path,
-                                line,
-                                column,
-                            },
-                        );
+                        self.offsets.insert(offset, location.clone());
+                        if let Some(alt_offset) = alt_offset {
+                            self.offsets.entry(alt_offset).or_insert(location);
+                        }
                     }
                 }
             } else {
@@ -337,18 +338,17 @@ impl SourceMap {
                 // load() failed partway through: any mappings collected are
                 // partial. Downgrade "source" → "partial-source" so the mode
                 // accurately reflects that the parse did not complete.
-                let (fallback_mode, fallback_message) = if mappings_count > 0
-                    && fallback_mode == "source"
-                {
-                    (
-                        "partial-source".to_string(),
-                        "DWARF parse failed after collecting some mappings; \
+                let (fallback_mode, fallback_message) =
+                    if mappings_count > 0 && fallback_mode == "source" {
+                        (
+                            "partial-source".to_string(),
+                            "DWARF parse failed after collecting some mappings; \
                          results may be incomplete."
-                            .to_string(),
-                    )
-                } else {
-                    (fallback_mode, fallback_message)
-                };
+                                .to_string(),
+                        )
+                    } else {
+                        (fallback_mode, fallback_message)
+                    };
 
                 Ok(SourceMapInspectionReport {
                     mappings_count,
@@ -377,26 +377,45 @@ impl SourceMap {
         self.offsets.iter().map(|(o, l)| (*o, l))
     }
 
-    fn normalize_wasm_offset(&self, dwarf_address: usize, wasm_len: usize) -> usize {
+    fn normalize_wasm_offsets(
+        &self,
+        dwarf_address: usize,
+        wasm_len: usize,
+    ) -> (usize, Option<usize>) {
         let Some(code_range) = &self.code_section_range else {
-            return dwarf_address;
+            return (dwarf_address, None);
         };
 
-        // Common case: DWARF line-program addresses are offsets into the code-section payload.
         let code_start = code_range.start;
+        let code_end = code_range.end;
         let code_len = code_range.end.saturating_sub(code_range.start);
+        let module_candidate = dwarf_address;
 
-        // If the address already looks like a module/file offset, keep it.
-        if dwarf_address >= code_start && dwarf_address < wasm_len {
-            return dwarf_address;
+        let relative_candidate = dwarf_address
+            .checked_add(code_start)
+            .filter(|candidate| *candidate < wasm_len);
+        let module_in_code = module_candidate >= code_start
+            && module_candidate < code_end
+            && module_candidate < wasm_len;
+        let relative_in_code = dwarf_address < code_len
+            && relative_candidate
+                .map(|candidate| candidate >= code_start && candidate < code_end)
+                .unwrap_or(false);
+
+        match (module_in_code, relative_in_code) {
+            (true, true) => (module_candidate, relative_candidate),
+            (true, false) => (module_candidate, None),
+            (false, true) => (relative_candidate.unwrap_or(module_candidate), None),
+            (false, false) => {
+                if module_candidate < wasm_len {
+                    (module_candidate, None)
+                } else if let Some(relative_candidate) = relative_candidate {
+                    (relative_candidate, None)
+                } else {
+                    (dwarf_address, None)
+                }
+            }
         }
-
-        // Otherwise, treat addresses within the code-section payload length as relative.
-        if dwarf_address < code_len {
-            return code_start.saturating_add(dwarf_address);
-        }
-
-        dwarf_address
     }
 
     fn get_file_path(
@@ -1000,6 +1019,41 @@ mod tests {
         push_section(&mut bytes, 0x0a, &code_section);
 
         bytes
+    }
+
+    #[test]
+    fn normalize_wasm_offsets_keeps_alternate_for_ambiguous_addresses() {
+        let sm = SourceMap {
+            code_section_range: Some(100..400),
+            ..SourceMap::new()
+        };
+
+        let (primary, alternate) = sm.normalize_wasm_offsets(150, 500);
+
+        assert_eq!(primary, 150);
+        assert_eq!(alternate, Some(250));
+    }
+
+    #[test]
+    fn ambiguous_addresses_resolve_for_both_coordinate_spaces() {
+        let mut sm = SourceMap {
+            code_section_range: Some(100..400),
+            ..SourceMap::new()
+        };
+        let location = SourceLocation {
+            file: PathBuf::from("lib.rs"),
+            line: 9,
+            column: Some(1),
+        };
+
+        let (primary, alternate) = sm.normalize_wasm_offsets(150, 500);
+        sm.offsets.insert(primary, location.clone());
+        if let Some(alternate) = alternate {
+            sm.offsets.entry(alternate).or_insert(location.clone());
+        }
+
+        assert_eq!(sm.lookup(150), Some(location.clone()));
+        assert_eq!(sm.lookup(250), Some(location));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes DWARF offset normalization for source mapping when line-program addresses are emitted relative to the WASM code-section payload (seen with `wasm-pack` + `opt-level = z`).

### What changed
- Replaced single-offset normalization with dual-candidate normalization in `src/debugger/source_map.rs`:
  - `normalize_wasm_offset` -> `normalize_wasm_offsets` returning `(primary, alternate)`.
  - When an address is ambiguous (valid as both module-relative and code-section-relative), both offsets are mapped.
- Updated DWARF row ingestion to insert the primary mapping and preserve the alternate mapping without overriding existing entries.
- Added regression tests for:
  - ambiguous address normalization producing both offsets
  - successful lookup in both coordinate spaces

### Motivation
Previously, the heuristic could normalize some valid DWARF addresses outside the intended module/lookup coordinate space, causing `lookup()` to return `None` for instructions that should resolve to source lines.

## Related Issue

Closes #734

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [x] Test / CI improvement

---

## CI/Test Behavior Changes

**What changed in CI or test behavior?**

N/A — no CI/test behavior changes

**Migration notes**

N/A

---

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)  
  (blocked by pre-existing unrelated compile error in `src/plugin/api.rs`: unclosed delimiter)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR description mentions the related issue(s)
- [x] CI/test behavior changes documented above (or marked N/A)
- [x] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed