### PR TITLE
fix error db host status codes

### DIFF
--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,4 +17,16 @@ Shell to generate completion script for
 .br
 
 .br
-[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+bash
+.IP \(bu 2
+elvish
+.IP \(bu 2
+fish
+.IP \(bu 2
+powershell
+.IP \(bu 2
+zsh
+.RE

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -23,7 +23,13 @@ Output format: pretty (default) or json
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-source\-map\-diagnostics\fR
 Print source map diagnostics including resolved mappings, missing DWARF sections, and fallback behavior
@@ -39,7 +45,13 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-[\fIpossible values: \fRdot, mermaid]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+dot
+.IP \(bu 2
+mermaid
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-profile.1
+++ b/man/man1/soroban-debug-profile.1
@@ -29,7 +29,15 @@ Export format for profiler output (report|folded\-stack|json)
 .br
 
 .br
-[\fIpossible values: \fRreport, folded\-stack, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+report
+.IP \(bu 2
+folded\-stack
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -56,7 +56,13 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/man/man1/soroban-debug-symbolic.1
+++ b/man/man1/soroban-debug-symbolic.1
@@ -23,7 +23,15 @@ Preset symbolic exploration budget profile
 .br
 
 .br
-[\fIpossible values: \fRfast, balanced, deep]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+fast
+.IP \(bu 2
+balanced
+.IP \(bu 2
+deep
+.RE
 .TP
 \fB\-\-input\-combination\-cap\fR \fI<N>\fR
 Maximum number of input combinations to generate deterministically
@@ -51,7 +59,13 @@ Output format for the report (pretty/text or json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/debugger/error_db.rs
+++ b/src/debugger/error_db.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use soroban_env_common::xdr::ScErrorType;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,80 +27,10 @@ impl ErrorDatabase {
     }
 
     fn init_standard_errors(&mut self) {
-        let std_errs = [
-            (
-                1,
-                "UnknownError",
-                "An unknown error occurred during contract execution",
-                "Unhandled exception or unexpected state",
-                "Check contract logic for unhandled edge cases or add error handling",
-            ),
-            (
-                2,
-                "HostError",
-                "Error from the Soroban host environment",
-                "Host operation failed (e.g., storage, budget exceeded)",
-                "Check budget limits, storage access, or host resource constraints",
-            ),
-            (
-                3,
-                "ConversionError",
-                "Failed to convert between value types",
-                "Type mismatch or invalid value format",
-                "Verify argument types match function signature and value formats are correct",
-            ),
-            (
-                4,
-                "StorageError",
-                "Storage operation failed",
-                "Storage key not found, access denied, or storage limit exceeded",
-                "Check storage key existence, permissions, and storage budget limits",
-            ),
-            (
-                5,
-                "BudgetError",
-                "CPU or memory budget exceeded",
-                "Contract execution consumed too many CPU instructions or memory bytes",
-                "Optimize contract code, reduce loop iterations, or use more efficient algorithms",
-            ),
-            (
-                6,
-                "AuthError",
-                "Authorization check failed",
-                "Missing required authorization or insufficient permissions",
-                "Ensure proper authorization is provided before calling the function",
-            ),
-            (
-                7,
-                "MathError",
-                "Mathematical operation failed",
-                "Division by zero, overflow, or invalid mathematical operation",
-                "Add bounds checking, validate inputs, and handle edge cases in math operations",
-            ),
-            (
-                8,
-                "ArrayError",
-                "Array operation failed",
-                "Index out of bounds, invalid array access, or array size exceeded",
-                "Validate array indices before access and check array bounds",
-            ),
-            (
-                9,
-                "StringError",
-                "String operation failed",
-                "Invalid string encoding, length exceeded, or malformed string",
-                "Validate string encoding and length before operations",
-            ),
-            (
-                10,
-                "MapError",
-                "Map operation failed",
-                "Key not found, invalid key type, or map operation failed",
-                "Check if key exists before access and validate key types",
-            ),
-        ];
-
-        for (code, name, desc, cause, fix) in std_errs {
+        for error_type in ScErrorType::VARIANTS {
+            let (desc, cause, fix) = standard_error_metadata(error_type);
+            let code = error_type as u32;
+            let name = error_type.name();
             self.standard_errors.insert(
                 code,
                 ErrorExplanation {
@@ -193,6 +124,61 @@ impl Default for ErrorDatabase {
     }
 }
 
+fn standard_error_metadata(error_type: ScErrorType) -> (&'static str, &'static str, &'static str) {
+    match error_type {
+        ScErrorType::Contract => (
+            "Contract-defined error code returned from contract logic",
+            "The contract intentionally returned a user-defined error (e.g. `panic_with_error!`)",
+            "Inspect the contract's custom error enum/documentation and validate business rules",
+        ),
+        ScErrorType::WasmVm => (
+            "WASM VM trap or runtime validation error",
+            "Invalid WASM action, bounds violation, or VM/runtime trap",
+            "Check contract bytecode assumptions, index bounds, and runtime preconditions",
+        ),
+        ScErrorType::Context => (
+            "Host context operation failed",
+            "Invalid host context state or exceeded context limits",
+            "Verify call context assumptions and ensure host context limits are respected",
+        ),
+        ScErrorType::Storage => (
+            "Storage operation failed in the Soroban host",
+            "Missing key, invalid storage access pattern, or storage-layer constraint failure",
+            "Validate key existence/access paths and review storage durability and limits",
+        ),
+        ScErrorType::Object => (
+            "Host object operation failed",
+            "Invalid object handle/type or object lifecycle misuse",
+            "Ensure object values are valid for the operation and not stale or mismatched",
+        ),
+        ScErrorType::Crypto => (
+            "Cryptographic operation failed",
+            "Invalid signature/hash input, malformed key material, or unsupported crypto action",
+            "Validate key formats and inputs, then re-check signature/hash expectations",
+        ),
+        ScErrorType::Events => (
+            "Event emission failed",
+            "Invalid event payload/topic shape or host event constraints were violated",
+            "Verify event topic/data schema and ensure payload sizes/types are valid",
+        ),
+        ScErrorType::Budget => (
+            "Execution budget was exceeded",
+            "CPU instruction or memory budget limit reached during execution",
+            "Optimize execution path, reduce allocations/loops, or increase available budget",
+        ),
+        ScErrorType::Value => (
+            "Host value conversion/validation failed",
+            "Type mismatch, invalid SCVal shape, or unsupported value conversion",
+            "Validate argument and return-value types against the contract interface",
+        ),
+        ScErrorType::Auth => (
+            "Authorization subsystem rejected the operation",
+            "Missing/invalid authorization or failed authorization checks",
+            "Provide required auth entries and verify signer/permission expectations",
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,12 +186,33 @@ mod tests {
     #[test]
     fn test_standard_error_lookup() {
         let db = ErrorDatabase::new();
-        let auth_error = db.lookup(6).expect("Should find standard AuthError");
-        assert_eq!(auth_error.name, "AuthError");
-        assert_eq!(auth_error.code, 6);
+        let wasm_vm = db
+            .lookup(ScErrorType::WasmVm as u32)
+            .expect("Should find WasmVm");
+        assert_eq!(wasm_vm.name, "WasmVm");
+        assert_eq!(wasm_vm.code, ScErrorType::WasmVm as u32);
+
+        let context = db
+            .lookup(ScErrorType::Context as u32)
+            .expect("Should find Context");
+        assert_eq!(context.name, "Context");
 
         let missing = db.lookup(999);
         assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_standard_error_table_covers_all_sc_error_types() {
+        let db = ErrorDatabase::new();
+
+        for error_type in ScErrorType::VARIANTS {
+            let code = error_type as u32;
+            let explanation = db
+                .lookup(code)
+                .unwrap_or_else(|| panic!("Missing standard error entry for code {}", code));
+            assert_eq!(explanation.name, error_type.name());
+            assert_eq!(explanation.code, code);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Extends `error_db` standard host error coverage to include all Soroban host-defined error types from `soroban-env-common` instead of a partial hardcoded table.

### What changed
- Reworked `init_standard_errors` to build entries from `ScErrorType::VARIANTS` (canonical source).
- Added type-specific metadata (`description`, `common_cause`, `suggested_fix`) for each host error type.
- Updated tests to:
  - validate lookup by real Soroban host type codes/names (`WasmVm`, `Context`, etc.)
  - assert full coverage for every `ScErrorType` variant.

### Motivation
Previously, the table only covered fixed legacy codes and missed common host categories, causing “No explanation available for this error code” for valid Soroban host errors.

## Related Issue

Closes #743

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [x] Test / CI improvement

---

## CI/Test Behavior Changes

**What changed in CI or test behavior?**

N/A — no CI/test behavior changes

**Migration notes**

N/A

---

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)  
  (blocked by unrelated existing compile error in `/Users/Tola/soroban-debugger/src/plugin/api.rs:242`, unclosed delimiter)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR description mentions the related issue(s)
- [x] CI/test behavior changes documented above (or marked N/A)
- [x] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed