### PR TITLE
Fix error_db status table codes

### DIFF
--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,4 +17,16 @@ Shell to generate completion script for
 .br
 
 .br
-[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+bash
+.IP \(bu 2
+elvish
+.IP \(bu 2
+fish
+.IP \(bu 2
+powershell
+.IP \(bu 2
+zsh
+.RE

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -23,7 +23,13 @@ Output format: pretty (default) or json
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-source\-map\-diagnostics\fR
 Print source map diagnostics including resolved mappings, missing DWARF sections, and fallback behavior
@@ -39,7 +45,13 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-[\fIpossible values: \fRdot, mermaid]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+dot
+.IP \(bu 2
+mermaid
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-profile.1
+++ b/man/man1/soroban-debug-profile.1
@@ -29,7 +29,15 @@ Export format for profiler output (report|folded\-stack|json)
 .br
 
 .br
-[\fIpossible values: \fRreport, folded\-stack, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+report
+.IP \(bu 2
+folded\-stack
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -56,7 +56,13 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/man/man1/soroban-debug-symbolic.1
+++ b/man/man1/soroban-debug-symbolic.1
@@ -23,7 +23,15 @@ Preset symbolic exploration budget profile
 .br
 
 .br
-[\fIpossible values: \fRfast, balanced, deep]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+fast
+.IP \(bu 2
+balanced
+.IP \(bu 2
+deep
+.RE
 .TP
 \fB\-\-input\-combination\-cap\fR \fI<N>\fR
 Maximum number of input combinations to generate deterministically
@@ -51,7 +59,13 @@ Output format for the report (pretty/text or json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/debugger/source_map.rs
+++ b/src/debugger/source_map.rs
@@ -337,18 +337,17 @@ impl SourceMap {
                 // load() failed partway through: any mappings collected are
                 // partial. Downgrade "source" → "partial-source" so the mode
                 // accurately reflects that the parse did not complete.
-                let (fallback_mode, fallback_message) = if mappings_count > 0
-                    && fallback_mode == "source"
-                {
-                    (
-                        "partial-source".to_string(),
-                        "DWARF parse failed after collecting some mappings; \
+                let (fallback_mode, fallback_message) =
+                    if mappings_count > 0 && fallback_mode == "source" {
+                        (
+                            "partial-source".to_string(),
+                            "DWARF parse failed after collecting some mappings; \
                          results may be incomplete."
-                            .to_string(),
-                    )
-                } else {
-                    (fallback_mode, fallback_message)
-                };
+                                .to_string(),
+                        )
+                    } else {
+                        (fallback_mode, fallback_message)
+                    };
 
                 Ok(SourceMapInspectionReport {
                     mappings_count,
@@ -553,6 +552,12 @@ impl SourceMap {
         };
 
         let requested_norm = normalize_path_for_match(source_path);
+        let filename_ambiguous = is_filename_ambiguous(
+            self.offsets
+                .values()
+                .map(|loc| normalize_path_for_match(&loc.file)),
+            &requested_norm,
+        );
         let mut line_to_offsets: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
         let mut file_match_count = 0usize;
 
@@ -562,7 +567,11 @@ impl SourceMap {
                 continue;
             }
 
-            if !paths_match_normalized(&normalize_path_for_match(&loc.file), &requested_norm) {
+            if !paths_match_normalized(
+                &normalize_path_for_match(&loc.file),
+                &requested_norm,
+                filename_ambiguous,
+            ) {
                 continue;
             }
 
@@ -881,7 +890,7 @@ fn normalize_path_for_match(path: &Path) -> String {
         .to_ascii_lowercase()
 }
 
-fn paths_match_normalized(a: &str, b: &str) -> bool {
+fn paths_match_normalized(a: &str, b: &str, filename_ambiguous: bool) -> bool {
     if a == b {
         return true;
     }
@@ -892,7 +901,45 @@ fn paths_match_normalized(a: &str, b: &str) -> bool {
 
     let a_file = a.rsplit('/').next().unwrap_or(a);
     let b_file = b.rsplit('/').next().unwrap_or(b);
-    a_file == b_file
+    if a_file != b_file {
+        return false;
+    }
+
+    if !filename_ambiguous {
+        return true;
+    }
+
+    suffix_components_match(a, b, 2)
+}
+
+fn suffix_components_match(a: &str, b: &str, components: usize) -> bool {
+    let a_parts: Vec<&str> = a.split('/').filter(|part| !part.is_empty()).collect();
+    let b_parts: Vec<&str> = b.split('/').filter(|part| !part.is_empty()).collect();
+    if a_parts.len() < components || b_parts.len() < components {
+        return false;
+    }
+
+    a_parts[a_parts.len() - components..] == b_parts[b_parts.len() - components..]
+}
+
+fn is_filename_ambiguous<I>(paths: I, requested: &str) -> bool
+where
+    I: Iterator<Item = String>,
+{
+    let requested_file = requested.rsplit('/').next().unwrap_or(requested);
+    let mut matching_paths: HashSet<String> = HashSet::new();
+
+    for path in paths {
+        let file = path.rsplit('/').next().unwrap_or(&path);
+        if file == requested_file {
+            matching_paths.insert(path);
+            if matching_paths.len() > 1 {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -1211,5 +1258,41 @@ mod tests {
         assert!(resolved[0].message.contains("[AMBIGUOUS]"));
         assert!(resolved[0].message.contains("alpha"));
         assert!(resolved[0].message.contains("beta"));
+    }
+
+    #[test]
+    fn resolve_source_breakpoints_disambiguates_same_filename_by_parent_directory() {
+        let wasm = wasm_with_functions_and_exports(&[("alpha", 0), ("beta", 1)], 2);
+        let index = WasmIndex::parse(&wasm).unwrap();
+        let alpha_offset = index.function_bodies[0].0.start;
+        let beta_offset = index.function_bodies[1].0.start;
+
+        let mut sm = SourceMap::new();
+        sm.add_mapping(
+            alpha_offset,
+            SourceLocation {
+                file: PathBuf::from("/workspace/crate_a/src/lib.rs"),
+                line: 10,
+                column: None,
+            },
+        );
+        sm.add_mapping(
+            beta_offset,
+            SourceLocation {
+                file: PathBuf::from("/workspace/crate_b/src/lib.rs"),
+                line: 10,
+                column: None,
+            },
+        );
+
+        let exported_functions = HashSet::from([String::from("alpha"), String::from("beta")]);
+        let requested_path = PathBuf::from("crate_a/src/lib.rs");
+        let resolved =
+            sm.resolve_source_breakpoints(&wasm, &requested_path, &[10], &exported_functions);
+
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].verified);
+        assert_eq!(resolved[0].reason_code, "OK");
+        assert_eq!(resolved[0].function.as_deref(), Some("alpha"));
     }
 }


### PR DESCRIPTION
## Description

Fixes source-map path matching false positives when multiple crates contain the same short filename (for example multiple `src/lib.rs` paths in DWARF).

### What changed
- Updated `paths_match_normalized` logic to avoid matching by filename alone when that filename is ambiguous across DWARF paths.
- Added ambiguity detection for the requested filename across known source-map paths.
- When ambiguous, fallback matching now requires at least `parent/filename` suffix match (instead of just `filename`).
- Added regression test covering two crates with `src/lib.rs`, ensuring source breakpoints resolve to the correct crate/function.

### Motivation
The previous filename-only fallback could incorrectly match unrelated crates that shared the same stem, causing wrong breakpoint resolutions.

## Related Issue

Closes #735

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [x] Test / CI improvement

---

## CI/Test Behavior Changes

**What changed in CI or test behavior?**

N/A — no CI/test behavior changes

**Migration notes**

N/A

---

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)  
  (blocked by unrelated pre-existing compile error in `/Users/Tola/soroban-debugger/src/plugin/api.rs:242`, unclosed delimiter)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR description mentions the related issue(s)
- [x] CI/test behavior changes documented above (or marked N/A)
- [x] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed