### PR TITLE
Improve DAP diagnostics, CI extension gate, TLS validation messaging, and run JSON envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,8 @@ jobs:
       - name: Check extension dist drift
         run: npm --prefix extensions/vscode run check:dist
 
-      - name: Run extension smoke tests
-        run: npm --prefix extensions/vscode run test:smoke
-
-      - name: Run extension DAP E2E tests
-        run: npm --prefix extensions/vscode run test:dap-e2e
+      - name: Run extension aggregate tests
+        run: npm --prefix extensions/vscode run test:all
 
   lint:
     name: Lint (Clippy & Format)

--- a/docs/remote-debugging.md
+++ b/docs/remote-debugging.md
@@ -129,6 +129,7 @@ The second form is easy to leak through shell history, process listings, shared 
 Use TLS whenever the server is reachable beyond a tightly controlled private boundary.
 Native TLS is enabled only when you provide both `--tls-cert` and `--tls-key`.
 Supplying only one of those flags is rejected during server startup.
+If startup fails with that validation error, either provide both flags together or remove both flags and keep transport private (for example, loopback + SSH tunnel).
 
 ```bash
 openssl req -x509 -newkey rsa:4096 \

--- a/extensions/vscode/src/test/dapClient.ts
+++ b/extensions/vscode/src/test/dapClient.ts
@@ -26,6 +26,15 @@ type DapEvent = {
 
 type DapMessage = DapResponse | DapEvent;
 
+type TranscriptEntry = {
+  timestampMs: number;
+  direction: 'send' | 'recv';
+  kind: 'request' | 'response' | 'event';
+  commandOrEvent: string;
+  success?: boolean;
+  message?: string;
+};
+
 export type TimestampedEvent = {
   timestampMs: number;
   event: string;
@@ -39,6 +48,8 @@ export class DapClient {
   private pending = new Map<number, { resolve: (r: DapResponse) => void; reject: (e: Error) => void }>();
   private events: DapEvent[] = [];
   private eventLog: TimestampedEvent[] = [];
+  private transcript: TranscriptEntry[] = [];
+  private readonly maxTranscriptEntries = 200;
 
   constructor(proc: ChildProcessWithoutNullStreams) {
     this.proc = proc;
@@ -67,7 +78,11 @@ export class DapClient {
     const responsePromise = new Promise<DapResponse>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(requestSeq);
-        reject(new Error(`Timed out waiting for DAP response to ${command}`));
+        reject(
+          new Error(
+            `Timed out waiting for DAP response to ${command}\n\nRecent DAP transcript:\n${this.formatRecentTranscript()}`,
+          ),
+        );
       }, timeoutMs);
 
       this.pending.set(requestSeq, {
@@ -83,6 +98,12 @@ export class DapClient {
     });
 
     this.proc.stdin.write(Buffer.concat([header, payload]));
+    this.recordTranscript({
+      timestampMs: Date.now(),
+      direction: 'send',
+      kind: 'request',
+      commandOrEvent: command,
+    });
     const response = await responsePromise;
     return response;
   }
@@ -102,7 +123,9 @@ export class DapClient {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
 
-    throw new Error(`Timed out waiting for DAP event: ${event}`);
+    throw new Error(
+      `Timed out waiting for DAP event: ${event}\n\nRecent DAP transcript:\n${this.formatRecentTranscript()}`,
+    );
   }
 
   async waitForAnyEvent(
@@ -120,12 +143,36 @@ export class DapClient {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
 
-    throw new Error(`Timed out waiting for DAP event(s): ${events.join(', ')}`);
+    throw new Error(
+      `Timed out waiting for DAP event(s): ${events.join(', ')}\n\nRecent DAP transcript:\n${this.formatRecentTranscript()}`,
+    );
   }
 
   /** Returns a copy of all events received, with millisecond timestamps. */
   getEventLog(): TimestampedEvent[] {
     return this.eventLog.slice();
+  }
+
+  formatRecentTranscript(limit = 30): string {
+    const recent = this.transcript.slice(Math.max(0, this.transcript.length - limit));
+    if (recent.length === 0) {
+      return '(no DAP messages captured)';
+    }
+
+    return recent
+      .map((entry) => {
+        const time = new Date(entry.timestampMs).toISOString();
+        const base = `[${time}] ${entry.direction.toUpperCase()} ${entry.kind.toUpperCase()} ${entry.commandOrEvent}`;
+        const parts: string[] = [];
+        if (typeof entry.success === 'boolean') {
+          parts.push(`success=${entry.success}`);
+        }
+        if (entry.message) {
+          parts.push(`message=${entry.message}`);
+        }
+        return parts.length > 0 ? `${base} (${parts.join(', ')})` : base;
+      })
+      .join('\n');
   }
 
   dispose(): void {
@@ -172,8 +219,23 @@ export class DapClient {
     if (message.type === 'event') {
       this.events.push(message);
       this.eventLog.push({ timestampMs: Date.now(), event: message.event, body: message.body });
+      this.recordTranscript({
+        timestampMs: Date.now(),
+        direction: 'recv',
+        kind: 'event',
+        commandOrEvent: message.event,
+      });
       return;
     }
+
+    this.recordTranscript({
+      timestampMs: Date.now(),
+      direction: 'recv',
+      kind: 'response',
+      commandOrEvent: message.command,
+      success: message.success,
+      message: message.message,
+    });
 
     const pending = this.pending.get(message.request_seq);
     if (!pending) {
@@ -182,5 +244,12 @@ export class DapClient {
 
     this.pending.delete(message.request_seq);
     pending.resolve(message);
+  }
+
+  private recordTranscript(entry: TranscriptEntry): void {
+    this.transcript.push(entry);
+    if (this.transcript.length > this.maxTranscriptEntries) {
+      this.transcript.splice(0, this.transcript.length - this.maxTranscriptEntries);
+    }
   }
 }

--- a/extensions/vscode/src/test/suites.ts
+++ b/extensions/vscode/src/test/suites.ts
@@ -1095,6 +1095,10 @@ async function runDapHappyPathE2E(
     const disconnect = await client.request("disconnect", { restart: false });
     assert.equal(disconnect.success, true);
   } finally {
+    if (stderrOutput.trim().length > 0) {
+      console.error("[dap-e2e][adapter-stderr]\n" + stderrOutput.trim());
+    }
+    console.error("[dap-e2e][last-protocol-messages]\n" + client.formatRecentTranscript(40));
     client.dispose();
   }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -929,32 +929,15 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
             result_obj["ledger_entries"] = ledger.to_json();
         }
 
-        let output = serde_json::json!({
-            "schema_version": "1.0",
-            "command": "run",
-            "status": "success",
-            "result": result_obj,
-            "sha256": wasm_hash,
-            "budget": {
-                "cpu_instructions": budget.cpu_instructions,
-                "memory_bytes": budget.memory_bytes,
-            },
-            "storage_diff": storage_diff,
-            "error": serde_json::Value::Null
-        });
+        let output = crate::output::VersionedOutput::success("run", result_obj);
 
         match serde_json::to_string_pretty(&output) {
             Ok(json) => println!("{}", json),
             Err(e) => {
-                let err_output = serde_json::json!({
-                    "schema_version": "1.0",
-                    "command": "run",
-                    "status": "error",
-                    "result": serde_json::Value::Null,
-                    "error": {
-                        "message": format!("Failed to serialize output: {}", e)
-                    }
-                });
+                let err_output = crate::output::VersionedOutput::<serde_json::Value>::error(
+                    "run",
+                    format!("Failed to serialize output: {}", e),
+                );
                 if let Ok(err_json) = serde_json::to_string_pretty(&err_output) {
                     println!("{}", err_json);
                 }

--- a/src/server/debug_server.rs
+++ b/src/server/debug_server.rs
@@ -52,7 +52,7 @@ impl DebugServer {
             (None, None) => None,
             _ => {
                 return Err(miette::miette!(
-                    "TLS requires both certificate and key paths (--tls-cert and --tls-key)"
+                    "TLS requires both certificate and key paths (--tls-cert and --tls-key). Provide both flags together, or remove both flags to run without native TLS."
                 ));
             }
         };

--- a/tests/schemas/execution_output.json
+++ b/tests/schemas/execution_output.json
@@ -2,13 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "RunCommandOutputEnvelope",
   "type": "object",
-  "required": ["schema_version", "status", "result", "sha256", "budget", "storage_diff"],
+  "required": ["schema_version", "command", "status", "result", "error"],
   "properties": {
     "schema_version": {
-      "type": "string",
-      "pattern": "^\\d+\\.\\d+$"
-    },
-    "status": {
       "type": "string",
       "const": "1.0.0"
     },


### PR DESCRIPTION
## Summary
- Improve VS Code DAP test diagnostics by capturing a bounded last-N protocol transcript and printing it on timeouts/finalization paths, making failures much easier to debug.
- Update CI to gate the VS Code extension through the aggregate `test:all` script so workflow coverage tracks contributor usage.
- Normalize `run --output json` to use the shared versioned envelope format and align the run schema with that envelope; also improve TLS partial-config remediation wording and docs.

## Notes
- Per request, no new tests were added.
- Two manpage files were modified by local tooling but intentionally left out of this commit.

Closes #655
Closes #660
Closes #659
Closes #645