### PR TITLE
fix: remove stale debug comment in run()

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -658,10 +658,6 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
 
     let mut engine = DebuggerEngine::new(executor, args.breakpoint.clone());
 
-    // Execute locally with debugging
-    // if !args.is_json_output() {
-    //     println!("\n--- Execution Start ---\n");
-    // }
     if args.instruction_debug {
         print_info("Enabling instruction-level debugging...");
         engine.enable_instruction_debug(&wasm_bytes)?;


### PR DESCRIPTION
## Summary
- Remove dead commented-out `println` block (~line 661) in `run()` that was left over from an earlier refactor

## Test plan
- [x] No functional change — only dead code removal
- [x] Existing tests unaffected

Closes #705