### PR TITLE
feat: extend remote CLI with inspect, storage, evaluate

### DIFF
--- a/man/man1/soroban-debug-remote.1
+++ b/man/man1/soroban-debug-remote.1
@@ -4,9 +4,23 @@
 .SH NAME
 remote \- Connect to remote debug server
 .SH SYNOPSIS
-\fBremote\fR <\fB\-r\fR|\fB\-\-remote\fR> [\fB\-t\fR|\fB\-\-token\fR] [\fB\-c\fR|\fB\-\-contract\fR] [\fB\-f\fR|\fB\-\-function\fR] [\fB\-\-tls\-cert\fR] [\fB\-\-tls\-key\fR] [\fB\-\-tls\-ca\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBremote\fR <\fB\-r\fR|\fB\-\-remote\fR> [\fB\-t\fR|\fB\-\-token\fR] [\fB\-c\fR|\fB\-\-contract\fR] [\fB\-f\fR|\fB\-\-function\fR] [\fB\-\-tls\-cert\fR] [\fB\-\-tls\-key\fR] [\fB\-\-tls\-ca\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIsubcommand\fR]
 .SH DESCRIPTION
-Connect to remote debug server
+Connect to remote debug server. Without a subcommand, executes a function (if
+\fB\-\-function\fR is given) or pings the server. Subcommands provide richer
+operations on an active debug session.
+.SH SUBCOMMANDS
+.TP
+\fBinspect\fR
+Inspect current execution state: function name, step count, paused flag, and
+call stack.
+.TP
+\fBstorage\fR
+Retrieve the contract storage state as JSON.
+.TP
+\fBevaluate\fR \fB\-\-expression\fR \fI<EXPR>\fR [\fB\-\-frame\-id\fR \fI<ID>\fR]
+Evaluate an expression in the current debug context. Optionally specify a
+stack frame ID for evaluation scope.
 .SH OPTIONS
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1090,6 +1090,33 @@ pub struct RemoteArgs {
     /// Function arguments as JSON array
     #[arg(short, long)]
     pub args: Option<String>,
+
+    /// Remote operation to perform (default: execute or ping)
+    #[command(subcommand)]
+    pub action: Option<RemoteAction>,
+}
+
+#[derive(Subcommand)]
+pub enum RemoteAction {
+    /// Inspect current execution state (function, step count, call stack)
+    Inspect,
+
+    /// Get contract storage state as JSON
+    Storage,
+
+    /// Evaluate an expression in the current debug context
+    Evaluate(RemoteEvaluateArgs),
+}
+
+#[derive(Parser)]
+pub struct RemoteEvaluateArgs {
+    /// Expression to evaluate
+    #[arg(short, long)]
+    pub expression: String,
+
+    /// Stack frame ID for evaluation context (optional)
+    #[arg(long)]
+    pub frame_id: Option<u64>,
 }
 
 #[derive(Parser)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -3,8 +3,8 @@ use crate::analyzer::upgrade::{CompatibilityReport, ExecutionDiff, UpgradeAnalyz
 use crate::analyzer::{security::SecurityAnalyzer, symbolic::SymbolicAnalyzer};
 use crate::cli::args::{
     AnalyzeArgs, CompareArgs, HistoryPruneArgs, InspectArgs, InteractiveArgs, OptimizeArgs,
-    OutputFormat, ProfileArgs, RemoteArgs, ReplArgs, ReplayArgs, RunArgs, ScenarioArgs, ServerArgs,
-    SymbolicArgs, SymbolicProfile, TuiArgs, UpgradeCheckArgs, Verbosity,
+    OutputFormat, ProfileArgs, RemoteAction, RemoteArgs, ReplArgs, ReplayArgs, RunArgs,
+    ScenarioArgs, ServerArgs, SymbolicArgs, SymbolicProfile, TuiArgs, UpgradeCheckArgs, Verbosity,
 };
 use crate::debugger::engine::DebuggerEngine;
 use crate::debugger::instruction_pointer::StepMode;
@@ -1865,6 +1865,39 @@ pub fn remote(args: RemoteArgs, _verbosity: Verbosity) -> Result<()> {
         print_info(format!("Loading contract: {:?}", contract));
         let size = client.load_contract(&contract.to_string_lossy())?;
         print_success(format!("Contract loaded: {} bytes", size));
+    }
+
+    if let Some(action) = &args.action {
+        return match action {
+            RemoteAction::Inspect => {
+                let (function, step_count, paused, call_stack) = client.inspect()?;
+                println!("Function: {}", function.as_deref().unwrap_or("<none>"));
+                println!("Step count: {}", step_count);
+                println!("Paused: {}", paused);
+                if !call_stack.is_empty() {
+                    println!("Call stack:");
+                    for frame in &call_stack {
+                        println!("  {}", frame);
+                    }
+                }
+                Ok(())
+            }
+            RemoteAction::Storage => {
+                let storage_json = client.get_storage()?;
+                println!("{}", storage_json);
+                Ok(())
+            }
+            RemoteAction::Evaluate(eval_args) => {
+                let (result, result_type) =
+                    client.evaluate(&eval_args.expression, eval_args.frame_id)?;
+                if let Some(rtype) = &result_type {
+                    println!("[{}] {}", rtype, result);
+                } else {
+                    println!("{}", result);
+                }
+                Ok(())
+            }
+        };
     }
 
     if let Some(function) = &args.function {

--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -576,6 +576,30 @@ impl RemoteClient {
         }
     }
 
+    /// Evaluate an expression in the current debug context
+    pub fn evaluate(&mut self, expression: &str, frame_id: Option<u64>) -> Result<(String, Option<String>)> {
+        let response = self.send_request_with_retry(
+            DebugRequest::Evaluate {
+                expression: expression.to_string(),
+                frame_id,
+            },
+            RequestClass::Default,
+            true,
+        )?;
+
+        match response {
+            DebugResponse::EvaluateResult {
+                result,
+                result_type,
+                ..
+            } => Ok((result, result_type)),
+            DebugResponse::Error { message } => Err(DebuggerError::ExecutionError(message).into()),
+            _ => Err(
+                DebuggerError::ExecutionError("Unexpected response to Evaluate".to_string()).into(),
+            ),
+        }
+    }
+
     /// Ping the server
     pub fn ping(&mut self) -> Result<()> {
         let response =

--- a/tests/cli/run_tests.rs
+++ b/tests/cli/run_tests.rs
@@ -167,3 +167,55 @@ fn test_run_accepts_dry_run_flag() {
         ])
         .output();
 }
+
+#[test]
+fn test_remote_inspect_subcommand_accepted() {
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["remote", "--remote", "127.0.0.1:9229", "inspect"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_storage_subcommand_accepted() {
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args(["remote", "--remote", "127.0.0.1:9229", "storage"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_evaluate_subcommand_accepted() {
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args([
+        "remote",
+        "--remote",
+        "127.0.0.1:9229",
+        "evaluate",
+        "--expression",
+        "1 + 1",
+    ])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}
+
+#[test]
+fn test_remote_evaluate_with_frame_id() {
+    let mut cmd = assert_cmd::Command::cargo_bin("soroban-debug").expect("Failed to find binary");
+    cmd.args([
+        "remote",
+        "--remote",
+        "127.0.0.1:9229",
+        "evaluate",
+        "--expression",
+        "x",
+        "--frame-id",
+        "0",
+    ])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("Connection").or(predicate::str::contains("connect")));
+}


### PR DESCRIPTION
## Summary
- Add `inspect`, `storage`, and `evaluate` subcommands to the `remote` CLI command
- `remote inspect` — query execution state (function, step count, paused, call stack)
- `remote storage` — retrieve contract storage as JSON
- `remote evaluate --expression <EXPR>` — evaluate expressions with optional `--frame-id`
- Implement `evaluate()` method on `RemoteClient` wrapping `DebugRequest::Evaluate`
- Update man page with new subcommand documentation

## Test plan
- [x] CLI parser tests for each new subcommand in `tests/cli/run_tests.rs`
- [x] Evaluate subcommand accepts `--expression` and optional `--frame-id`
- [x] Existing remote command behavior (execute/ping) unchanged when no subcommand given

Closes #706