### PR TITLE
feat: vscode batch-args launch support

### DIFF
--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -90,7 +90,7 @@ Legend:
 
 | Feature | CLI flag / command | VS Code Extension | Notes |
 |---|---|---|---|
-| Batch arguments from file | `--batch-args <file.json>` | NO | No `batchArgs` field in `launch.json`. |
+| Batch arguments from file | `--batch-args <file.json>` | YES — `"batchArgs"` in `launch.json` | Each argument set is executed separately; results and summary shown in Debug Console. |
 | Repeat execution N times | `--repeat <n>` | YES — `"repeat"` in `launch.json` | Execution runs N times; aggregate stats shown in Debug Console. |
 
 ---
@@ -133,7 +133,7 @@ For VS Code users, this table maps CLI flags to their `launch.json` equivalents.
 | `--instruction-debug` | (none) | NO |
 | `--step-instructions` | (none) | NO |
 | `--step-mode` | (none) | NO |
-| `--batch-args` | (none) | NO |
+| `--batch-args` | `batchArgs` | YES |
 | `--repeat` | `repeat` | YES |
 | `--tls-cert` / `--tls-key` | Passed via CLI arguments | YES |
 | `--import-storage` | Use `snapshotPath` instead | PARTIAL |

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -154,6 +154,11 @@ Create a `snapshot.json` file with the initial state for your debugger session. 
 - **connectTimeoutMs** (number): Timeout to wait for the backend server to accept connections on startup
   - Default: `10000`
 
+- **batchArgs** (string): Path to a JSON file containing an array of argument sets for batch execution. Each entry runs as a separate invocation. Results and a pass/fail summary are printed to the Debug Console.
+  - Example: `"${workspaceFolder}/tests/batch_inputs.json"`
+  - The JSON file should be an array of arrays, e.g. `[["arg1"], ["arg2", 42], []]`
+  - Known limits: batch mode skips breakpoints and stepping; use single-run mode to debug individual failing cases.
+
 ### Environment Overrides (Advanced)
 
 If you can’t (or don’t want to) set timeouts in `launch.json`, you can also use:
@@ -237,7 +242,7 @@ The following features are **not available** in the extension.
 | Instruction-level stepping  | `--instruction-debug`, `--step-instructions`, `--step-mode [block]`                            | Use `soroban-debug interactive --instruction-debug` in a terminal      |
 | Storage key filtering       | `--storage-filter <pattern>`                                                                   | All storage is shown unfiltered in the Variables panel; filter via CLI |
 | Auth tree display           | `--show-auth`                                                                                  | Use `soroban-debug run --show-auth` in a terminal                      |
-| Batch execution             | `--batch-args <file>`, `--repeat N`                                                            | Use `soroban-debug run --batch-args` in a terminal                     |
+| Batch execution             | `--batch-args <file>`, `--repeat N`                                                            | Set `"batchArgs"` in `launch.json` (see below)                         |
 | TLS configuration           | `--tls-cert`, `--tls-key`                                                                      | Use CLI server/remote commands directly                                |
 | Storage export              | `--export-storage <file>`                                                                      | Use `soroban-debug run --export-storage` in a terminal                 |
 | Storage import              | `--import-storage <file>`                                                                      | Use `snapshotPath` in `launch.json` for initial state                  |

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -125,6 +125,10 @@
                 "description": "Repeat execution N times and show throughput/latency stats in the Debug Console.",
                 "minimum": 1,
                 "default": 1
+              },
+              "batchArgs": {
+                "type": "string",
+                "description": "Path to a JSON file containing an array of argument sets for batch execution. Each entry is executed as a separate run with its own args."
               }
             }
           },

--- a/extensions/vscode/src/cli/debuggerProcess.ts
+++ b/extensions/vscode/src/cli/debuggerProcess.ts
@@ -35,6 +35,11 @@ export interface DebuggerProcessConfig {
   spawnServer?: boolean;
   storageFilter?: string[];
   repeat?: number;
+  /**
+   * Path to a JSON file containing an array of argument sets for batch
+   * execution.  Each entry is passed as `args` to a separate Execute request.
+   */
+  batchArgs?: string;
 }
 
 export interface DebuggerExecutionResult {
@@ -104,7 +109,8 @@ export interface LaunchPreflightIssue {
     | "args"
     | "port"
     | "host"
-    | "token";
+    | "token"
+    | "batchArgs";
   message: string;
   expected: string;
   quickFixes: LaunchPreflightQuickFix[];
@@ -521,6 +527,42 @@ export class DebuggerProcess {
       paused: response.paused,
       completed: response.completed,
     };
+  }
+
+  async executeBatch(
+    batchItems: unknown[][]
+  ): Promise<{ index: number; args: unknown[]; output: string; success: boolean; error?: string }[]> {
+    const results: { index: number; args: unknown[]; output: string; success: boolean; error?: string }[] = [];
+    const entrypoint = this.config.entrypoint || "main";
+
+    for (let i = 0; i < batchItems.length; i++) {
+      const args = batchItems[i];
+      try {
+        const response = await this.sendRequest({
+          type: "Execute",
+          function: entrypoint,
+          args: args.length > 0 ? JSON.stringify(args) : undefined,
+        });
+        this.expectResponse(response, "ExecutionResult");
+        results.push({
+          index: i,
+          args,
+          output: response.output || "",
+          success: response.success !== false,
+          error: response.error,
+        });
+      } catch (err) {
+        results.push({
+          index: i,
+          args,
+          output: "",
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return results;
   }
 
   async stepIn(): Promise<{
@@ -1213,6 +1255,24 @@ export async function validateLaunchConfig(
         message:
           "Launch config field 'token' must be a single-line non-empty string.",
         expected: "A non-empty authentication token without line breaks.",
+        quickFixes: ["openLaunchConfig"],
+      });
+    }
+  }
+
+  if (config.batchArgs !== undefined) {
+    if (typeof config.batchArgs !== "string" || config.batchArgs.trim().length === 0) {
+      issues.push({
+        field: "batchArgs",
+        message: "Launch config field 'batchArgs' must be a path to a readable JSON file.",
+        expected: "A readable JSON file containing an array of argument sets.",
+        quickFixes: ["openLaunchConfig"],
+      });
+    } else if (!looksLikeVariableReference(config.batchArgs) && !fs.existsSync(config.batchArgs)) {
+      issues.push({
+        field: "batchArgs",
+        message: `Launch config field 'batchArgs' points to '${config.batchArgs}', which does not exist.`,
+        expected: "A readable JSON file containing an array of argument sets.",
         quickFixes: ["openLaunchConfig"],
       });
     }

--- a/extensions/vscode/src/dap/adapter.ts
+++ b/extensions/vscode/src/dap/adapter.ts
@@ -5,6 +5,7 @@ import {
   ExitedEvent
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
+import * as fs from 'fs';
 import * as readline from 'readline';
 import {
   DebuggerProcess,
@@ -107,6 +108,7 @@ export class SorobanDebugSession extends DebugSession {
   private refreshAbortController: AbortController | null = null;
   private refreshGeneration = 0;
   private launchLifecycleReporter?: (event: LaunchLifecycleEvent) => void;
+  private batchArgsPath?: string;
 
   constructor(
     logManagerOrLinesStartAt1?: LogManager | boolean,
@@ -167,10 +169,12 @@ export class SorobanDebugSession extends DebugSession {
         requestTimeoutMs: args.requestTimeoutMs,
         connectTimeoutMs: args.connectTimeoutMs,
         storageFilter: args.storageFilter,
-        repeat: args.repeat
+        repeat: args.repeat,
+        batchArgs: args.batchArgs
       }, this.logManager, this.launchLifecycleReporter);
 
       await this.debuggerProcess.start();
+      this.batchArgsPath = args.batchArgs;
       this.state.isRunning = true;
       this.state.isPaused = false;
       this.hasExecuted = false;
@@ -753,6 +757,11 @@ export class SorobanDebugSession extends DebugSession {
       throw new Error('Debugger process is not running');
     }
 
+    if (this.batchArgsPath) {
+      await this.runBatchExecution();
+      return;
+    }
+
     const result = await this.debuggerProcess.execute();
     this.hasExecuted = true;
     await this.refreshState();
@@ -768,6 +777,54 @@ export class SorobanDebugSession extends DebugSession {
 
     this.state.isPaused = false;
     this.sendEvent(new ExitedEvent(0));
+    await this.stop();
+  }
+
+  private async runBatchExecution(): Promise<void> {
+    if (!this.debuggerProcess || !this.batchArgsPath) {
+      throw new Error('Batch execution requires a debugger process and batch-args path');
+    }
+
+    const raw = fs.readFileSync(this.batchArgsPath, 'utf-8');
+    const batchItems: unknown[][] = JSON.parse(raw);
+
+    if (!Array.isArray(batchItems)) {
+      throw new Error('batch-args file must contain a JSON array of argument sets');
+    }
+
+    this.sendEvent(new LogOutputEvent(
+      `\n=== Batch Execution: ${batchItems.length} test case(s) ===\n\n`,
+      LogLevel.Log
+    ));
+
+    const results = await this.debuggerProcess.executeBatch(batchItems);
+    this.hasExecuted = true;
+
+    let passed = 0;
+    let failed = 0;
+    for (const r of results) {
+      const status = r.success ? 'PASS' : 'FAIL';
+      if (r.success) { passed++; } else { failed++; }
+      const argsStr = JSON.stringify(r.args);
+      this.sendEvent(new LogOutputEvent(
+        `[${r.index + 1}/${batchItems.length}] ${status} args=${argsStr}`,
+        r.success ? LogLevel.Log : LogLevel.Error
+      ));
+      if (r.output) {
+        this.sendEvent(new LogOutputEvent(`  Result: ${r.output}\n`, LogLevel.Log));
+      }
+      if (r.error) {
+        this.sendEvent(new LogOutputEvent(`  Error: ${r.error}\n`, LogLevel.Error));
+      }
+    }
+
+    this.sendEvent(new LogOutputEvent(
+      `\n=== Batch Summary: ${passed} passed, ${failed} failed, ${batchItems.length} total ===\n`,
+      LogLevel.Log
+    ));
+
+    this.state.isPaused = false;
+    this.sendEvent(new ExitedEvent(failed > 0 ? 1 : 0));
     await this.stop();
   }
 


### PR DESCRIPTION
## Summary
- Add `batchArgs` field to VS Code launch.json configuration for batch execution
- Extension reads the JSON file, executes each argument set sequentially via wire protocol
- Per-case pass/fail results and summary rendered in the Debug Console
- Preflight validation ensures the batch-args file exists before launch
- Update README with batch-args docs and known limits (no breakpoints/stepping in batch mode)
- Update feature-matrix.md to reflect new support

## Test plan
- [x] `batchArgs` field accepted in launch.json schema
- [x] Preflight rejects missing/empty batch-args paths
- [x] Batch execution outputs per-case results to Debug Console
- [x] Non-batch launches unaffected (existing behavior preserved)
- [x] Feature matrix and README updated

Closes #713