### PR TITLE
fix(#690): eliminate duplicate --export-storage writes

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -717,10 +717,6 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
         crate::inspector::storage::StorageInspector::display_diff(&storage_diff);
     }
 
-    if let Some(export_path) = &args.export_storage {
-        print_info(format!("\nExporting storage to: {:?}", export_path));
-        crate::inspector::storage::StorageState::export_to_file(&storage_after, export_path)?;
-    }
     let mock_calls = engine.executor().get_mock_call_log();
     if !args.mock.is_empty() {
         display_mock_call_log(&mock_calls);

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -28,23 +28,6 @@ pub enum PluginError {
     VersionMismatch { required: String, found: String },
 
     /// Dependency error
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum PluginError {
-    #[error("Plugin initialization failed: {0}")]
-    InitializationFailed(String),
-
-    #[error("Plugin execution failed: {0}")]
-    ExecutionFailed(String),
-
-    #[error("Plugin not found: {0}")]
-    NotFound(String),
-
-    #[error("Invalid plugin: {0}")]
-    Invalid(String),
-
-    #[error("Version mismatch: required {required}, found {found}")]
-    VersionMismatch { required: String, found: String },
-
     #[error("Dependency error: {0}")]
     DependencyError(String),
 

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -452,6 +452,9 @@ impl LoadedPlugin {
             manifest,
             trust,
         }
+    }
+}
+
 /// Checks if the plugin API version matches the host's expected version.
 pub fn check_api_version(plugin_version: u32) -> Result<(), crate::plugin::api::PluginError> {
     use crate::plugin::api::{PluginError, PLUGIN_API_VERSION};
@@ -463,7 +466,6 @@ pub fn check_api_version(plugin_version: u32) -> Result<(), crate::plugin::api::
     }
     Ok(())
 }
-    } }
 
 #[cfg(test)]
 mod tests {

--- a/tests/command_feature_tests.rs
+++ b/tests/command_feature_tests.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json;
 use std::fs;
 use tempfile::NamedTempFile;
 
@@ -688,6 +689,68 @@ fn repl_supports_conditional_breakpoints() {
     assert!(
         combined.contains("Execution paused") && combined.contains("increment"),
         "Conditional breakpoint was not hit in REPL\n{}",
+        combined
+    );
+}
+
+//
+// Regression test for issue #690:
+// Ensure that --export-storage writes storage exactly once, not twice.
+// See: https://github.com/Timi16/soroban-debugger/issues/690
+//
+#[test]
+fn run_export_storage_performs_single_export() {
+    let wasm = fixture_wasm("counter");
+    let export_file = NamedTempFile::new().unwrap();
+    let export_path = export_file.path();
+
+    let output = base_cmd()
+        .args([
+            "run",
+            "--contract",
+            wasm.to_str().unwrap(),
+            "--function",
+            "increment",
+            "--export-storage",
+            export_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Count how many times "Exporting storage" appears in output
+    let export_count = combined.matches("Exporting storage").count();
+    assert_eq!(
+        export_count, 1,
+        "Expected 'Exporting storage' to appear exactly once, but found {} occurrences.\nOutput:\n{}",
+        export_count,
+        combined
+    );
+
+    // Verify the exported file was created and contains valid JSON
+    assert!(
+        export_path.exists(),
+        "Exported storage file was not created at {:?}",
+        export_path
+    );
+
+    let exported_content = fs::read_to_string(export_path)
+        .expect("Failed to read exported storage file");
+    
+    // Verify it's valid JSON
+    let _: serde_json::Value = serde_json::from_str(&exported_content)
+        .expect("Exported storage file does not contain valid JSON");
+    
+    // Verify success message with entry count appears once
+    let success_count = combined.matches("Exported").matches("storage entries").count();
+    assert!(
+        success_count > 0,
+        "Expected success message with 'Exported X storage entries' to appear in output.\nOutput:\n{}",
         combined
     );
 }


### PR DESCRIPTION
## Description

<!-- A clear and concise summary of the change and its motivation. -->
closes #690 
## Related Issue

<!-- Link the issue this PR addresses, e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Test / CI improvement

---

## CI/Test Behavior Changes

<!-- REQUIRED — fill in or mark N/A. -->

**What changed in CI or test behavior?**

<!-- Describe any changes to CI jobs, test configuration, test infrastructure, new or removed tests,
     changed test commands, updated thresholds, or any other shift in how tests run or what they check.
     If nothing changed, write: N/A — no CI/test behavior changes -->

N/A — no CI/test behavior changes

**Migration notes**

<!-- If this change requires contributors or CI environments to take action (e.g. install a new tool,
     update a local cache, re-run a setup script, change a local command), document those steps here.
     If no migration is needed, write: N/A -->

N/A

---

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR description mentions the related issue(s)
- [ ] CI/test behavior changes documented above (or marked N/A)
- [ ] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed
