### PR TITLE
feat: add symbolic replay bundle export

### DIFF
--- a/src/analyzer/symbolic.rs
+++ b/src/analyzer/symbolic.rs
@@ -1,3 +1,4 @@
+use crate::output::*;
 use crate::runtime::executor::ContractExecutor;
 use crate::utils::wasm::{parse_function_signatures, ContractFunctionSignature};
 use crate::{DebuggerError, Result};
@@ -86,6 +87,46 @@ impl SymbolicConfig {
             seed: None,
             storage_seed: None,
         }
+    }
+}
+
+pub fn build_replay_bundle(
+    config: &SymbolicConfig,
+    report: &SymbolicReport,
+    contract_sha256: String,
+    contract_path: Option<String>,
+) -> SymbolicReplayBundle {
+    SymbolicReplayBundle {
+        schema_version: 1,
+        command: "symbolic".to_string(),
+
+        contract: ContractInfo {
+            sha256: contract_sha256,
+            path_hint: contract_path,
+        },
+
+        invocation: InvocationInfo {
+            function: report.function.clone(),
+        },
+
+        config: ReplayConfig {
+            seed: config.seed,
+            max_paths: Some(config.max_paths),
+            max_input_combinations: Some(config.max_input_combinations),
+            max_breadth: Some(config.max_breadth),
+            max_depth: Some(config.max_depth),
+            timeout_secs: Some(config.timeout_secs),
+        },
+
+        storage_seed: config.storage_seed.as_ref().map(|s| StorageSeed {
+            format: "json".to_string(),
+            data: s.clone(),
+        }),
+
+        metadata: Some(ReplayMetadata {
+            paths_explored: report.paths_explored,
+            panics_found: report.panics_found,
+        }),
     }
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -970,6 +970,10 @@ pub struct SymbolicArgs {
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 
+    /// Export a symbolic replay bundle to JSON
+    #[arg(long, value_name = "FILE")]
+    pub export_replay_bundle: Option<PathBuf>,
+
     /// Preset symbolic exploration budget profile
     #[arg(long, value_enum, default_value_t = SymbolicProfile::Balanced)]
     pub profile: SymbolicProfile,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,9 @@
 use crate::analyzer::symbolic::SymbolicConfig;
 use crate::analyzer::upgrade::{CompatibilityReport, ExecutionDiff, UpgradeAnalyzer};
-use crate::analyzer::{security::SecurityAnalyzer, symbolic::SymbolicAnalyzer};
+use crate::analyzer::{
+    security::SecurityAnalyzer,
+    symbolic::{build_replay_bundle, SymbolicAnalyzer},
+};
 use crate::cli::args::{
     AnalyzeArgs, CompareArgs, HistoryPruneArgs, InspectArgs, InteractiveArgs, OptimizeArgs,
     OutputFormat, ProfileArgs, RemoteAction, RemoteArgs, ReplArgs, ReplayArgs, RunArgs,
@@ -2194,6 +2197,25 @@ pub fn symbolic(args: SymbolicArgs, _verbosity: Verbosity) -> Result<()> {
             ))
         })?;
         print_success(format!("Scenario TOML written to: {:?}", output_path));
+    }
+
+    if let Some(bundle_path) = &args.export_replay_bundle {
+        let bundle = build_replay_bundle(
+            &config,
+            &report,
+            wasm_file.sha256_hash.clone(),
+            Some(args.contract.to_string_lossy().to_string()),
+        );
+        let serialized = serde_json::to_string_pretty(&bundle).map_err(|e| {
+            DebuggerError::FileError(format!("Failed to serialize replay bundle to JSON: {}", e))
+        })?;
+        fs::write(bundle_path, serialized).map_err(|e| {
+            DebuggerError::FileError(format!(
+                "Failed to write replay bundle to {:?}: {}",
+                bundle_path, e
+            ))
+        })?;
+        print_success(format!("Replay bundle written to: {:?}", bundle_path));
     }
 
     Ok(())

--- a/src/debugger/instruction_pointer.rs
+++ b/src/debugger/instruction_pointer.rs
@@ -129,10 +129,8 @@ impl InstructionPointer {
             | wasmparser::Operator::If { .. } => {
                 self.block_depth += 1;
             }
-            wasmparser::Operator::End => {
-                if self.block_depth > 0 {
-                    self.block_depth -= 1;
-                }
+            wasmparser::Operator::End if self.block_depth > 0 => {
+                self.block_depth -= 1;
             }
             _ => {}
         }

--- a/src/inspector/budget.rs
+++ b/src/inspector/budget.rs
@@ -416,7 +416,7 @@ impl MemoryTracker {
 
     pub fn get_top_allocations(&self, count: usize) -> Vec<MemoryAllocation> {
         let mut sorted: Vec<MemoryAllocation> = self.allocations.iter().cloned().collect();
-        sorted.sort_by(|a, b| b.size.cmp(&a.size));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.size));
         sorted.into_iter().take(count).collect()
     }
 

--- a/src/inspector/instructions.rs
+++ b/src/inspector/instructions.rs
@@ -53,7 +53,7 @@ impl InstructionCounter {
     pub fn get_counts(&self) -> Vec<FunctionInstructionCount> {
         let mut counts: Vec<FunctionInstructionCount> =
             self.function_counts.values().cloned().collect();
-        counts.sort_by(|a, b| b.instruction_count.cmp(&a.instruction_count));
+        counts.sort_by_key(|b| std::cmp::Reverse(b.instruction_count));
         counts
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,7 +2,7 @@
 //!
 //! Supports `NO_COLOR` (disable ANSI colors) and `--no-unicode` (ASCII-only output).
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static NO_UNICODE: AtomicBool = AtomicBool::new(false);
@@ -58,6 +58,52 @@ where
             }),
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SymbolicReplayBundle {
+    pub schema_version: u8,
+    pub command: String,
+
+    pub contract: ContractInfo,
+    pub invocation: InvocationInfo,
+    pub config: ReplayConfig,
+
+    pub storage_seed: Option<StorageSeed>,
+    pub metadata: Option<ReplayMetadata>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ContractInfo {
+    pub sha256: String,
+    pub path_hint: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct InvocationInfo {
+    pub function: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ReplayConfig {
+    pub seed: Option<u64>,
+    pub max_paths: Option<usize>,
+    pub max_input_combinations: Option<usize>,
+    pub max_breadth: Option<usize>,
+    pub max_depth: Option<usize>,
+    pub timeout_secs: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StorageSeed {
+    pub format: String,
+    pub data: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ReplayMetadata {
+    pub paths_explored: usize,
+    pub panics_found: usize,
 }
 
 /// Global output/accessibility configuration.
@@ -211,5 +257,75 @@ impl OutputWriter {
                 .map_err(|e| miette::miette!("Failed to write to output file: {}", e))?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_replay_bundle_serializes() {
+        let bundle = SymbolicReplayBundle {
+            schema_version: 1,
+            command: "symbolic".to_string(),
+            contract: ContractInfo {
+                sha256: "abc".to_string(),
+                path_hint: None,
+            },
+            invocation: InvocationInfo {
+                function: "test".to_string(),
+            },
+            config: ReplayConfig {
+                seed: Some(1),
+                max_paths: None,
+                max_input_combinations: None,
+                max_breadth: None,
+                max_depth: None,
+                timeout_secs: None,
+            },
+            storage_seed: None,
+            metadata: None,
+        };
+
+        let json = serde_json::to_string(&bundle).unwrap();
+        assert!(json.contains("schema_version"));
+        assert!(json.contains("symbolic"));
+    }
+
+    #[test]
+    fn test_replay_bundle_optional_fields_serialization() {
+        let bundle = SymbolicReplayBundle {
+            schema_version: 1,
+            command: "symbolic".to_string(),
+            contract: ContractInfo {
+                sha256: "abc".to_string(),
+                path_hint: Some("contract.wasm".to_string()),
+            },
+            invocation: InvocationInfo {
+                function: "test".to_string(),
+            },
+            config: ReplayConfig {
+                seed: None,
+                max_paths: Some(10),
+                max_input_combinations: Some(20),
+                max_breadth: Some(2),
+                max_depth: Some(3),
+                timeout_secs: Some(30),
+            },
+            storage_seed: Some(StorageSeed {
+                format: "json".to_string(),
+                data: "{}".to_string(),
+            }),
+            metadata: Some(ReplayMetadata {
+                paths_explored: 5,
+                panics_found: 1,
+            }),
+        };
+
+        let json = serde_json::to_string(&bundle).unwrap();
+        assert!(json.contains("storage_seed"));
+        assert!(json.contains("metadata"));
+        assert!(json.contains("contract.wasm"));
     }
 }

--- a/src/profiler/analyzer.rs
+++ b/src/profiler/analyzer.rs
@@ -474,7 +474,7 @@ impl GasOptimizer {
         }
 
         // Sort by cost descending
-        trees.sort_by(|a, b| b.cpu_cost.cmp(&a.cpu_cost));
+        trees.sort_by_key(|b| std::cmp::Reverse(b.cpu_cost));
         trees
     }
 } // ✅ end impl GasOptimizer (IMPORTANT)

--- a/src/repl/executor.rs
+++ b/src/repl/executor.rs
@@ -218,7 +218,7 @@ impl ReplExecutor {
         crate::logging::log_display("", crate::logging::LogLevel::Info);
 
         let mut items: Vec<_> = entries.iter().collect();
-        items.sort_by(|(ka, _), (kb, _)| ka.cmp(kb));
+        items.sort_by_key(|(ka, _)| *ka);
 
         for (key, value) in items {
             crate::logging::log_display(

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -438,7 +438,7 @@ impl ContractExecutor {
             .iter()
             .map(|(name, &cpu)| (name.clone(), cpu))
             .collect();
-        function_counts.sort_by(|a, b| b.1.cmp(&a.1));
+        function_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
         let total = function_counts.iter().map(|(_, c)| c).sum();
         Ok(InstructionCounts {
             function_counts,

--- a/src/runtime/instrumentation.rs
+++ b/src/runtime/instrumentation.rs
@@ -56,7 +56,7 @@ impl InstructionCounter {
             .ok()
             .map(|c| c.iter().map(|(k, v)| (k.clone(), *v)).collect::<Vec<_>>())
             .unwrap_or_default();
-        counts.sort_by(|a, b| b.1.cmp(&a.1));
+        counts.sort_by_key(|b| std::cmp::Reverse(b.1));
         counts
     }
 

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -264,7 +264,7 @@ impl DebuggerUI {
         crate::logging::log_display("", crate::logging::LogLevel::Info);
 
         let mut items: Vec<_> = entries.iter().collect();
-        items.sort_by(|(ka, _), (kb, _)| ka.cmp(kb));
+        items.sort_by_key(|(ka, _)| *ka);
 
         for (key, value) in items {
             crate::logging::log_display(


### PR DESCRIPTION
## Description

Adds support for exporting a symbolic replay bundle as a single JSON artifact.

This enables symbolic findings to be shared and reproduced without manually reconstructing CLI arguments, seed values, or storage state.

---

## Related Issue

Closes #828

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code cleanup

---

## CI/Test Behavior Changes

**What changed in CI or test behavior?**  
N/A — no CI/test behavior changes

**Migration notes**  
N/A

---

## Checklist

- [x] All tests pass locally (`cargo test --workspace --all-features`)
- [x] Code is formatted (`cargo fmt --all -- --check`)
- [x] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Commit message follows Conventional Commits
- [x] PR description mentions the related issue(s)
- [x] CI/test behavior changes documented above (or marked N/A)