### PR TITLE
Feat/plugin command namespaces

### DIFF
--- a/docs/plugin-command-namespaces.md
+++ b/docs/plugin-command-namespaces.md
@@ -1,0 +1,48 @@
+# Plugin Command Namespace Policy
+
+## Problem
+
+Plugins can provide custom CLI commands and output formatters, but name collisions between plugins make behavior unpredictable.
+
+## Solution
+
+Plugin command and formatter names are now resolved deterministically.
+
+### Precedence order
+
+1. Core commands always win.
+2. Plugin names are sorted deterministically by manifest name.
+3. If the manifest name is missing or empty, the plugin file name is used as a fallback.
+
+### Normalization rules
+
+- Plugin command names are normalized by trimming whitespace and lowercasing.
+- Formatter names are normalized the same way.
+
+### Conflict behavior
+
+- The first plugin in deterministic order wins for execution.
+- All providers are recorded in a conflict map so collisions are visible.
+- Warnings are emitted once during plugin loading or registry initialization, not during every command execution.
+
+### Example warning
+
+```
+Plugin command collision: 'foo' winner: plugin_a ignored: plugin_b, plugin_c
+```
+
+## Best practice
+
+Use a namespaced command style where practical:
+
+```text
+plugin_name:command_name
+```
+
+This reduces collision risk and makes it easier to understand where a command comes from.
+
+## Notes
+
+- No new plugin API is required for this behavior.
+- Existing plugin commands continue to work.
+- The registry exposes conflicts via `command_conflicts()` and `formatter_conflicts()`.

--- a/man/man1/soroban-debug-completions.1
+++ b/man/man1/soroban-debug-completions.1
@@ -17,4 +17,16 @@ Shell to generate completion script for
 .br
 
 .br
-[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+bash
+.IP \(bu 2
+elvish
+.IP \(bu 2
+fish
+.IP \(bu 2
+powershell
+.IP \(bu 2
+zsh
+.RE

--- a/man/man1/soroban-debug-inspect.1
+++ b/man/man1/soroban-debug-inspect.1
@@ -23,7 +23,13 @@ Output format: pretty (default) or json
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-source\-map\-diagnostics\fR
 Print source map diagnostics including resolved mappings, missing DWARF sections, and fallback behavior
@@ -39,7 +45,13 @@ Show cross\-contract dependency graph in specified format
 .br
 
 .br
-[\fIpossible values: \fRdot, mermaid]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+dot
+.IP \(bu 2
+mermaid
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/man/man1/soroban-debug-profile.1
+++ b/man/man1/soroban-debug-profile.1
@@ -29,7 +29,15 @@ Export format for profiler output (report|folded\-stack|json)
 .br
 
 .br
-[\fIpossible values: \fRreport, folded\-stack, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+report
+.IP \(bu 2
+folded\-stack
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match

--- a/man/man1/soroban-debug-run.1
+++ b/man/man1/soroban-debug-run.1
@@ -59,7 +59,13 @@ Output mode for command result rendering (pretty, json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-\-show\-events\fR
 Show contract events emitted during execution

--- a/man/man1/soroban-debug-symbolic.1
+++ b/man/man1/soroban-debug-symbolic.1
@@ -4,7 +4,7 @@
 .SH NAME
 symbolic \- Run symbolic execution to explore contract input space
 .SH SYNOPSIS
-\fBsymbolic\fR <\fB\-c\fR|\fB\-\-contract\fR> <\fB\-f\fR|\fB\-\-function\fR> [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-profile\fR] [\fB\-\-input\-combination\-cap\fR] [\fB\-\-path\-cap\fR] [\fB\-\-max\-breadth\fR] [\fB\-\-timeout\fR] [\fB\-\-seed\fR] [\fB\-\-replay\fR] [\fB\-\-storage\-seed\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBsymbolic\fR <\fB\-c\fR|\fB\-\-contract\fR> <\fB\-f\fR|\fB\-\-function\fR> [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-export\-replay\-bundle\fR] [\fB\-\-profile\fR] [\fB\-\-input\-combination\-cap\fR] [\fB\-\-path\-cap\fR] [\fB\-\-max\-breadth\fR] [\fB\-\-timeout\fR] [\fB\-\-seed\fR] [\fB\-\-replay\fR] [\fB\-\-storage\-seed\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Run symbolic execution to explore contract input space
 .SH OPTIONS
@@ -18,12 +18,23 @@ Function name to execute
 \fB\-o\fR, \fB\-\-output\fR \fI<OUTPUT>\fR
 Output file for the scenario TOML
 .TP
+\fB\-\-export\-replay\-bundle\fR \fI<FILE>\fR
+Export a symbolic replay bundle to JSON
+.TP
 \fB\-\-profile\fR \fI<PROFILE>\fR [default: balanced]
 Preset symbolic exploration budget profile
 .br
 
 .br
-[\fIpossible values: \fRfast, balanced, deep]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+fast
+.IP \(bu 2
+balanced
+.IP \(bu 2
+deep
+.RE
 .TP
 \fB\-\-input\-combination\-cap\fR \fI<N>\fR
 Maximum number of input combinations to generate deterministically
@@ -51,7 +62,13 @@ Output format for the report (pretty/text or json)
 .br
 
 .br
-[\fIpossible values: \fRpretty, json]
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,42 @@ fn main() -> miette::Result<()> {
                             message.push_str(&format!("  - {}\n", fmt.name));
                         }
                     }
+
+                    let command_conflicts =
+                        soroban_debugger::plugin::registry::global_command_conflicts();
+                    if !command_conflicts.is_empty() {
+                        let mut conflict_entries: Vec<_> = command_conflicts.iter().collect();
+                        conflict_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                        message.push_str("\nPlugin command collisions detected:\n");
+                        for (cmd, providers) in conflict_entries {
+                            if providers.len() > 1 {
+                                message.push_str(&format!(
+                                    "  - {}: winner {} ignored {}\n",
+                                    cmd,
+                                    providers[0],
+                                    providers[1..].join(", ")
+                                ));
+                            }
+                        }
+                    }
+
+                    let formatter_conflicts =
+                        soroban_debugger::plugin::registry::global_formatter_conflicts();
+                    if !formatter_conflicts.is_empty() {
+                        let mut conflict_entries: Vec<_> = formatter_conflicts.iter().collect();
+                        conflict_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                        message.push_str("\nPlugin formatter collisions detected:\n");
+                        for (formatter, providers) in conflict_entries {
+                            if providers.len() > 1 {
+                                message.push_str(&format!(
+                                    "  - {}: winner {} ignored {}\n",
+                                    formatter,
+                                    providers[0],
+                                    providers[1..].join(", ")
+                                ));
+                            }
+                        }
+                    }
                     Err(soroban_debugger::DebuggerError::ExecutionError(message).into())
                 }
                 Err(e) => {

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -44,7 +44,12 @@ pub enum PluginError {
     CircuitOpen(String),
 }
 
-/// Custom CLI command that a plugin can provide
+/// Custom CLI command that a plugin can provide.
+///
+/// Plugin command names are matched case-insensitively and normalized by
+/// trimming whitespace. Conflicts between plugins are resolved deterministically
+/// by plugin name precedence, and collisions are exposed through the plugin
+/// registry.
 #[derive(Debug, Clone)]
 pub struct PluginCommand {
     /// Command name
@@ -57,7 +62,11 @@ pub struct PluginCommand {
     pub arguments: Vec<(String, String, bool)>,
 }
 
-/// Custom output formatter that a plugin can provide
+/// Custom output formatter that a plugin can provide.
+///
+/// Formatter names are matched case-insensitively and normalized by trimming
+/// whitespace. If multiple plugins provide the same formatter, a deterministic
+/// winner is chosen and the conflict is recorded.
 #[derive(Debug, Clone)]
 pub struct OutputFormatter {
     /// Formatter name

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -106,6 +106,28 @@ pub fn format_global_output(formatter: &str, data: &str) -> PluginResult<Option<
     registry.format_output(formatter, data)
 }
 
+pub fn global_command_conflicts() -> HashMap<String, Vec<String>> {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return HashMap::new();
+    };
+
+    registry
+        .read()
+        .map(|r| r.command_conflicts().clone())
+        .unwrap_or_default()
+}
+
+pub fn global_formatter_conflicts() -> HashMap<String, Vec<String>> {
+    let Some(registry) = GLOBAL_PLUGIN_REGISTRY.get() else {
+        return HashMap::new();
+    };
+
+    registry
+        .read()
+        .map(|r| r.formatter_conflicts().clone())
+        .unwrap_or_default()
+}
+
 // ---------------------------------------------------------------------------
 // Plugin Snapshot and Reload Diff
 // ---------------------------------------------------------------------------
@@ -445,6 +467,18 @@ pub struct PluginRegistry {
 
     /// Per-plugin health state used for containment and telemetry
     health: RwLock<HashMap<String, PluginHealth>>,
+
+    /// Resolved plugin command winners, keyed by normalized command name
+    command_winners: HashMap<String, String>,
+
+    /// Resolved formatter winners, keyed by normalized formatter name
+    formatter_winners: HashMap<String, String>,
+
+    /// All providers for each normalized command name, winner first
+    command_conflicts: HashMap<String, Vec<String>>,
+
+    /// All providers for each normalized formatter name, winner first
+    formatter_conflicts: HashMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -532,6 +566,10 @@ impl PluginRegistry {
             hot_reload_enabled: false,
             policy,
             health: RwLock::new(HashMap::new()),
+            command_winners: HashMap::new(),
+            formatter_winners: HashMap::new(),
+            command_conflicts: HashMap::new(),
+            formatter_conflicts: HashMap::new(),
         })
     }
 
@@ -586,7 +624,7 @@ impl PluginRegistry {
 
         // ── Phase 3: register in dependency order ──────────────────────────
         for plugin in sorted_plugins {
-            let name = plugin.manifest().name.clone();
+            let name = Self::plugin_registration_key(&plugin);
             match self.register_plugin(plugin) {
                 Ok(_) => {
                     info!("Successfully registered plugin: {}", name);
@@ -605,7 +643,7 @@ impl PluginRegistry {
 
     /// Register a loaded plugin
     fn register_plugin(&mut self, plugin: LoadedPlugin) -> PluginResult<()> {
-        let name = plugin.manifest().name.clone();
+        let name = Self::plugin_registration_key(&plugin);
 
         // Check for duplicates
         if self.plugins.contains_key(&name) {
@@ -635,6 +673,7 @@ impl PluginRegistry {
                 PluginError::ExecutionFailed("Failed to update plugin health".to_string())
             })?
             .insert(name, PluginHealth::default());
+        self.rebuild_command_and_formatter_maps();
         Ok(())
     }
 
@@ -643,9 +682,105 @@ impl PluginRegistry {
         self.plugins.get(name).cloned()
     }
 
+    /// Normalize a command or formatter name for conflict detection and lookup.
+    fn normalize_plugin_item_name(name: &str) -> String {
+        name.trim().to_lowercase()
+    }
+
+    /// Compute a stable plugin registration key, using manifest name when available.
+    fn plugin_registration_key(plugin: &LoadedPlugin) -> String {
+        let manifest_name = plugin.manifest().name.trim();
+        if !manifest_name.is_empty() {
+            manifest_name.to_string()
+        } else if let Some(stem) = plugin.path().file_stem() {
+            stem.to_string_lossy().to_string()
+        } else {
+            plugin.path().to_string_lossy().to_string()
+        }
+    }
+
+    /// Compute a stable precedence key for plugin sorting.
+    fn plugin_precedence_key(plugin: &LoadedPlugin) -> (String, String) {
+        let registration_key = Self::plugin_registration_key(plugin);
+        let path_key = plugin.path().to_string_lossy().to_string();
+        (registration_key.to_lowercase(), path_key)
+    }
+
     /// Get all plugin names
     pub fn plugin_names(&self) -> Vec<String> {
         self.plugins.keys().cloned().collect()
+    }
+
+    /// Rebuild command and formatter conflict maps after plugin registration changes.
+    fn rebuild_command_and_formatter_maps(&mut self) {
+        self.command_winners.clear();
+        self.formatter_winners.clear();
+        self.command_conflicts.clear();
+        self.formatter_conflicts.clear();
+
+        let mut plugins: Vec<_> = self.plugins.values().cloned().collect();
+        plugins.sort_by(|a, b| {
+            let a = a.read();
+            let b = b.read();
+            match (a, b) {
+                (Ok(a), Ok(b)) => {
+                    Self::plugin_precedence_key(&a).cmp(&Self::plugin_precedence_key(&b))
+                }
+                _ => std::cmp::Ordering::Equal,
+            }
+        });
+
+        for plugin_arc in plugins {
+            if let Ok(plugin) = plugin_arc.read() {
+                let plugin_key = Self::plugin_registration_key(&plugin);
+
+                if plugin.manifest().capabilities.provides_commands {
+                    for command in plugin.plugin().commands() {
+                        let key = Self::normalize_plugin_item_name(&command.name);
+                        self.command_conflicts
+                            .entry(key.clone())
+                            .or_default()
+                            .push(plugin_key.clone());
+                        self.command_winners
+                            .entry(key)
+                            .or_insert_with(|| plugin_key.clone());
+                    }
+                }
+
+                if plugin.manifest().capabilities.provides_formatters {
+                    for formatter in plugin.plugin().formatters() {
+                        let key = Self::normalize_plugin_item_name(&formatter.name);
+                        self.formatter_conflicts
+                            .entry(key.clone())
+                            .or_default()
+                            .push(plugin_key.clone());
+                        self.formatter_winners
+                            .entry(key)
+                            .or_insert_with(|| plugin_key.clone());
+                    }
+                }
+            }
+        }
+
+        for (command, providers) in &self.command_conflicts {
+            if providers.len() > 1 {
+                let ignored = providers[1..].join(", ");
+                warn!(
+                    "Plugin command collision: '{}' winner: {} ignored: {}",
+                    command, providers[0], ignored
+                );
+            }
+        }
+
+        for (formatter, providers) in &self.formatter_conflicts {
+            if providers.len() > 1 {
+                let ignored = providers[1..].join(", ");
+                warn!(
+                    "Plugin formatter collision: '{}' winner: {} ignored: {}",
+                    formatter, providers[0], ignored
+                );
+            }
+        }
     }
 
     /// Get the number of loaded plugins
@@ -760,6 +895,10 @@ impl PluginRegistry {
     pub fn unload_all(&mut self) {
         info!("Unloading all plugins");
         self.plugins.clear();
+        self.command_winners.clear();
+        self.formatter_winners.clear();
+        self.command_conflicts.clear();
+        self.formatter_conflicts.clear();
         if let Ok(mut health) = self.health.write() {
             health.clear();
         }
@@ -785,11 +924,12 @@ impl PluginRegistry {
                 if caps.supports_hot_reload {
                     stats.supports_hot_reload += 1;
                 }
+                let plugin_key = Self::plugin_registration_key(&plugin);
                 if let Some(health) = self
                     .health
                     .read()
                     .ok()
-                    .and_then(|health| health.get(plugin.manifest().name.as_str()).cloned())
+                    .and_then(|health| health.get(plugin_key.as_str()).cloned())
                 {
                     stats.plugin_failures += health.total_failures;
                     stats.plugin_timeouts += health.total_timeouts;
@@ -803,6 +943,16 @@ impl PluginRegistry {
 
         stats.total = self.plugins.len();
         stats
+    }
+
+    /// Get all plugin command conflicts, including the winner first.
+    pub fn command_conflicts(&self) -> &HashMap<String, Vec<String>> {
+        &self.command_conflicts
+    }
+
+    /// Get all plugin formatter conflicts, including the winner first.
+    pub fn formatter_conflicts(&self) -> &HashMap<String, Vec<String>> {
+        &self.formatter_conflicts
     }
 
     pub fn all_commands(&self) -> Vec<PluginCommand> {
@@ -835,71 +985,60 @@ impl PluginRegistry {
 
     /// Execute a plugin-provided command, if any plugin declares it.
     pub fn execute_command(&self, command: &str, args: &[String]) -> PluginResult<Option<String>> {
-        let names: Vec<String> = self.plugins.keys().cloned().collect();
-        for name in names {
-            let Some(plugin_arc) = self.plugins.get(&name) else {
-                continue;
-            };
-            {
-                let plugin = plugin_arc.read().map_err(|_| {
-                    PluginError::ExecutionFailed(format!("Failed to acquire plugin lock: {}", name))
-                })?;
-                if !plugin.manifest().capabilities.provides_commands {
-                    continue;
-                }
-                if !plugin
-                    .plugin()
-                    .commands()
-                    .iter()
-                    .any(|cmd| cmd.name == command)
-                {
-                    continue;
-                }
-            }
+        let key = Self::normalize_plugin_item_name(command);
+        let plugin_name = match self.command_winners.get(&key) {
+            Some(name) => name.clone(),
+            None => return Ok(None),
+        };
 
-            let mut health = self.health.write().map_err(|_| {
-                PluginError::ExecutionFailed("Failed to update plugin health".to_string())
-            })?;
-            let result =
-                self.run_command_with_policy(&mut health, &name, plugin_arc, command, args)?;
-            return Ok(Some(result));
-        }
+        let plugin_arc = self
+            .plugins
+            .get(&plugin_name)
+            .ok_or_else(|| {
+                PluginError::ExecutionFailed(format!(
+                    "Plugin '{}' registered as command winner but is missing",
+                    plugin_name
+                ))
+            })?
+            .clone();
 
-        Ok(None)
+        let mut health = self.health.write().map_err(|_| {
+            PluginError::ExecutionFailed("Failed to update plugin health".to_string())
+        })?;
+        let result =
+            self.run_command_with_policy(&mut health, &plugin_name, &plugin_arc, command, args)?;
+        Ok(Some(result))
     }
 
     pub fn format_output(&self, formatter: &str, data: &str) -> PluginResult<Option<String>> {
-        let names: Vec<String> = self.plugins.keys().cloned().collect();
-        for name in names {
-            let Some(plugin_arc) = self.plugins.get(&name) else {
-                continue;
-            };
-            {
-                let plugin = plugin_arc.read().map_err(|_| {
-                    PluginError::ExecutionFailed(format!("Failed to acquire plugin lock: {}", name))
-                })?;
-                if !plugin.manifest().capabilities.provides_formatters {
-                    continue;
-                }
-                if !plugin
-                    .plugin()
-                    .formatters()
-                    .iter()
-                    .any(|fmt| fmt.name == formatter)
-                {
-                    continue;
-                }
-            }
+        let key = Self::normalize_plugin_item_name(formatter);
+        let plugin_name = match self.formatter_winners.get(&key) {
+            Some(name) => name.clone(),
+            None => return Ok(None),
+        };
 
-            let mut health = self.health.write().map_err(|_| {
-                PluginError::ExecutionFailed("Failed to update plugin health".to_string())
-            })?;
-            let result =
-                self.run_formatter_with_policy(&mut health, &name, plugin_arc, formatter, data)?;
-            return Ok(Some(result));
-        }
+        let plugin_arc = self
+            .plugins
+            .get(&plugin_name)
+            .ok_or_else(|| {
+                PluginError::ExecutionFailed(format!(
+                    "Plugin '{}' registered as formatter winner but is missing",
+                    plugin_name
+                ))
+            })?
+            .clone();
 
-        Ok(None)
+        let mut health = self.health.write().map_err(|_| {
+            PluginError::ExecutionFailed("Failed to update plugin health".to_string())
+        })?;
+        let result = self.run_formatter_with_policy(
+            &mut health,
+            &plugin_name,
+            &plugin_arc,
+            formatter,
+            data,
+        )?;
+        Ok(Some(result))
     }
 
     fn run_hook_with_policy(
@@ -1194,6 +1333,7 @@ mod tests {
     use crate::plugin::manifest::{PluginCapabilities, PluginManifest};
     use crate::plugin::InspectorPlugin;
     use std::any::Any;
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
     use std::thread;
 
@@ -1492,6 +1632,249 @@ mod tests {
         let stats = registry.statistics();
         assert_eq!(stats.total, 0);
         assert_eq!(stats.hooks_execution, 0);
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    struct NamedCommandPlugin {
+        manifest: PluginManifest,
+        command_name: String,
+        response: String,
+    }
+
+    impl NamedCommandPlugin {
+        fn new(name: &str, command_name: &str, response: &str) -> Self {
+            Self {
+                manifest: PluginManifest {
+                    name: name.to_string(),
+                    version: "1.0.0".to_string(),
+                    description: "test plugin".to_string(),
+                    author: "test".to_string(),
+                    license: Some("MIT".to_string()),
+                    min_debugger_version: Some("0.1.0".to_string()),
+                    capabilities: PluginCapabilities {
+                        hooks_execution: true,
+                        provides_commands: true,
+                        provides_formatters: false,
+                        supports_hot_reload: false,
+                    },
+                    library: "test.so".to_string(),
+                    dependencies: vec![],
+                    signature: None,
+                },
+                command_name: command_name.to_string(),
+                response: response.to_string(),
+            }
+        }
+    }
+
+    impl InspectorPlugin for NamedCommandPlugin {
+        fn metadata(&self) -> PluginManifest {
+            self.manifest.clone()
+        }
+
+        fn on_event(
+            &mut self,
+            _event: &ExecutionEvent,
+            _context: &mut EventContext,
+        ) -> PluginResult<()> {
+            Ok(())
+        }
+
+        fn commands(&self) -> Vec<PluginCommand> {
+            vec![PluginCommand {
+                name: self.command_name.clone(),
+                description: "test".to_string(),
+                arguments: vec![],
+            }]
+        }
+
+        fn execute_command(&mut self, _command: &str, _args: &[String]) -> PluginResult<String> {
+            Ok(self.response.clone())
+        }
+    }
+
+    #[test]
+    fn plugin_command_conflicts_are_detected_and_winner_is_deterministic() {
+        let temp_dir = std::env::temp_dir().join("soroban-debug-test-plugins-conflicts");
+        let mut registry = PluginRegistry::with_plugin_dir(temp_dir.clone()).unwrap();
+
+        let plugin_a = NamedCommandPlugin::new("plugin-a", "foo", "result-a");
+        let loaded_a = LoadedPlugin::from_parts_for_tests(
+            Box::new(plugin_a),
+            PathBuf::from("plugin-a.so"),
+            PluginManifest {
+                name: "plugin-a".to_string(),
+                version: "1.0.0".to_string(),
+                description: "test plugin".to_string(),
+                author: "test".to_string(),
+                license: Some("MIT".to_string()),
+                min_debugger_version: Some("0.1.0".to_string()),
+                capabilities: PluginCapabilities {
+                    hooks_execution: true,
+                    provides_commands: true,
+                    provides_formatters: false,
+                    supports_hot_reload: false,
+                },
+                library: "plugin-a.so".to_string(),
+                dependencies: vec![],
+                signature: None,
+            },
+            PluginTrustAssessment {
+                trusted: true,
+                warnings: Vec::new(),
+                signer: None,
+            },
+        );
+
+        let plugin_b = NamedCommandPlugin::new("plugin-b", " Foo ", "result-b");
+        let loaded_b = LoadedPlugin::from_parts_for_tests(
+            Box::new(plugin_b),
+            PathBuf::from("plugin-b.so"),
+            PluginManifest {
+                name: "plugin-b".to_string(),
+                version: "1.0.0".to_string(),
+                description: "test plugin".to_string(),
+                author: "test".to_string(),
+                license: Some("MIT".to_string()),
+                min_debugger_version: Some("0.1.0".to_string()),
+                capabilities: PluginCapabilities {
+                    hooks_execution: true,
+                    provides_commands: true,
+                    provides_formatters: false,
+                    supports_hot_reload: false,
+                },
+                library: "plugin-b.so".to_string(),
+                dependencies: vec![],
+                signature: None,
+            },
+            PluginTrustAssessment {
+                trusted: true,
+                warnings: Vec::new(),
+                signer: None,
+            },
+        );
+
+        registry.register_plugin(loaded_a).unwrap();
+        registry.register_plugin(loaded_b).unwrap();
+
+        let conflicts = registry.command_conflicts();
+        assert_eq!(
+            conflicts.get("foo").unwrap(),
+            &vec!["plugin-a".to_string(), "plugin-b".to_string()]
+        );
+
+        let result = registry.execute_command("FOO", &[]).unwrap().unwrap();
+        assert_eq!(result, "result-a");
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn plugin_formatter_conflicts_are_detected_and_winner_is_deterministic() {
+        struct NamedFormatterPlugin {
+            manifest: PluginManifest,
+            formatter_name: String,
+            response: String,
+        }
+
+        impl InspectorPlugin for NamedFormatterPlugin {
+            fn metadata(&self) -> PluginManifest {
+                self.manifest.clone()
+            }
+
+            fn formatters(&self) -> Vec<OutputFormatter> {
+                vec![OutputFormatter {
+                    name: self.formatter_name.clone(),
+                    supported_types: vec!["text".to_string()],
+                }]
+            }
+
+            fn format_output(&self, _formatter: &str, _data: &str) -> PluginResult<String> {
+                Ok(self.response.clone())
+            }
+        }
+
+        let temp_dir = std::env::temp_dir().join("soroban-debug-test-formatter-conflicts");
+        let mut registry = PluginRegistry::with_plugin_dir(temp_dir.clone()).unwrap();
+
+        let manifest_a = PluginManifest {
+            name: "plugin-a".to_string(),
+            version: "1.0.0".to_string(),
+            description: "test plugin".to_string(),
+            author: "test".to_string(),
+            license: Some("MIT".to_string()),
+            min_debugger_version: Some("0.1.0".to_string()),
+            capabilities: PluginCapabilities {
+                hooks_execution: true,
+                provides_commands: false,
+                provides_formatters: true,
+                supports_hot_reload: false,
+            },
+            library: "plugin-a.so".to_string(),
+            dependencies: vec![],
+            signature: None,
+        };
+        let plugin_a = NamedFormatterPlugin {
+            manifest: manifest_a.clone(),
+            formatter_name: "jsonx".to_string(),
+            response: "formatted-a".to_string(),
+        };
+        let loaded_a = LoadedPlugin::from_parts_for_tests(
+            Box::new(plugin_a),
+            PathBuf::from("plugin-a.so"),
+            manifest_a,
+            PluginTrustAssessment {
+                trusted: true,
+                warnings: Vec::new(),
+                signer: None,
+            },
+        );
+
+        let manifest_b = PluginManifest {
+            name: "plugin-b".to_string(),
+            version: "1.0.0".to_string(),
+            description: "test plugin".to_string(),
+            author: "test".to_string(),
+            license: Some("MIT".to_string()),
+            min_debugger_version: Some("0.1.0".to_string()),
+            capabilities: PluginCapabilities {
+                hooks_execution: true,
+                provides_commands: false,
+                provides_formatters: true,
+                supports_hot_reload: false,
+            },
+            library: "plugin-b.so".to_string(),
+            dependencies: vec![],
+            signature: None,
+        };
+        let plugin_b = NamedFormatterPlugin {
+            manifest: manifest_b.clone(),
+            formatter_name: " jsonx ".to_string(),
+            response: "formatted-b".to_string(),
+        };
+        let loaded_b = LoadedPlugin::from_parts_for_tests(
+            Box::new(plugin_b),
+            PathBuf::from("plugin-b.so"),
+            manifest_b,
+            PluginTrustAssessment {
+                trusted: true,
+                warnings: Vec::new(),
+                signer: None,
+            },
+        );
+
+        registry.register_plugin(loaded_a).unwrap();
+        registry.register_plugin(loaded_b).unwrap();
+
+        let conflicts = registry.formatter_conflicts();
+        assert_eq!(
+            conflicts.get("jsonx").unwrap(),
+            &vec!["plugin-a".to_string(), "plugin-b".to_string()]
+        );
+
+        let result = registry.format_output("JSONX", "data").unwrap().unwrap();
+        assert_eq!(result, "formatted-a");
+
         let _ = std::fs::remove_dir_all(&temp_dir);
     }
 


### PR DESCRIPTION
## Description

Adds deterministic resolution for plugin command and formatter namespaces.

Prevents collisions between plugins by introducing a stable precedence model, exposing conflicts via the registry, and surfacing user-facing warnings for collisions.

---

## Related Issue

Closes #851

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code cleanup

---

## CI/Test Behavior Changes

**What changed in CI or test behavior?**  
N/A — no CI/test behavior changes

**Migration notes**  
N/A

---

## Checklist

- [x] All tests pass locally (`cargo test --workspace --all-features`)
- [x] Code is formatted (`cargo fmt --all -- --check`)
- [x] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Commit message follows Conventional Commits
- [x] PR description mentions the related issue(s)
- [x] CI/test behavior changes documented above (or marked N/A)