### PR TITLE
feat: replace permissive schema with strict validation (#703)

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -438,6 +438,99 @@ The extension consists of three main components:
 - Consider using a minimal snapshot for testing
 - Disable trace logging if enabled
 
+---
+
+## Manifest Schema Validation
+
+`extensions/vscode/package.schema.json` provides an offline, strict JSON Schema (draft-07) that validates the shape of `package.json` for this extension.
+
+### Why this exists
+
+VS Code normally validates extension manifests against a network-fetched schema. In offline environments, CI sandboxes, or air-gapped machines that schema fetch silently fails, leaving `package.json` unvalidated. The local schema closes that gap: unknown top-level keys, mistyped settings, and malformed launch-config attribute trees are all rejected at authoring time rather than silently drifting.
+
+### What is validated
+
+| Area | Validated fields |
+|------|------------------|
+| **Top-level manifest** | `name`, `version` (semver), `engines.vscode`, `main`, `contributes` — unknown keys rejected |
+| **contributes.commands** | `command` and `title` required; unknown keys rejected |
+| **contributes.configuration** | `soroban-debugger.requestTimeoutMs` and `soroban-debugger.connectTimeoutMs` shape and types |
+| **contributes.debuggers** | `type` must be `"soroban"`; both `launch` and `attach` attribute trees validated |
+| **Launch config attributes** | All supported fields: `contractPath`, `entrypoint`, `args`, `port` (1–65535), `token`, `tlsCert`/`tlsKey`, `storageFilter`, `repeat`, `batchArgs`, `requestTimeoutMs`, `connectTimeoutMs`, `dryRun` |
+| **Attach config attributes** | `host`, `port`, and all shared optional fields |
+| **initialConfigurations / configurationSnippets** | `name`, `type: "soroban"`, `request: "launch" \| "attach"` required; unknown body keys rejected |
+
+### How to validate locally
+
+Using `ajv-cli`:
+
+```bash
+npm install -g ajv-cli
+
+# Validate package.json against the local schema
+ajv validate \
+  -s extensions/vscode/package.schema.json \
+  -d extensions/vscode/package.json \
+  --spec=draft7 \
+  --strict=false
+```
+
+A passing run prints:
+```
+extensions/vscode/package.json valid
+```
+
+Any violation prints the JSON path and error message, e.g.:
+```
+extensions/vscode/package.json invalid
+[
+  {
+    "instancePath": "/contributes/debuggers/0/type",
+    "message": "must be equal to constant"
+  }
+]
+```
+
+### Integrating into CI
+
+Add a validation step before the compile step in your CI pipeline:
+
+```yaml
+# .github/workflows/extension.yml (example)
+- name: Validate extension manifest schema
+  run: |
+    npm install -g ajv-cli
+    ajv validate \
+      -s extensions/vscode/package.schema.json \
+      -d extensions/vscode/package.json \
+      --spec=draft7 \
+      --strict=false
+```
+
+The `make ci-local` target already runs this check. For sandbox CI use `make ci-sandbox`, which skips network-dependent steps but still runs schema validation.
+
+### Updating the schema
+
+When you add a new launch/attach config field to `package.json`, you must also add it to `package.schema.json` or the manifest validation step will fail.
+
+| What you're adding | Where to add it in the schema |
+|-------------------|------------------------------|
+| New launch attribute | `definitions.launchConfig.properties.properties` |
+| New attach attribute | `definitions.attachConfig.properties.properties` |
+| New VS Code setting | `contributes.configuration.properties` |
+| New command | No schema change needed (commands validate `command`+`title` only) |
+
+Use the existing `$ref` helper definitions (`stringProp`, `boolProp`, `portProp`, `timeoutProp`, etc.) for common patterns to keep the schema consistent.
+
+### Constraints and known limitations
+
+- The schema is draft-07 to match the `$schema` declaration already in `package.json`.
+- `configurationAttributes.launch.properties` and `.attach.properties` use `additionalProperties: false` — any field not listed in `definitions.launchConfig` / `definitions.attachConfig` will cause a validation error.
+- The `anyDebugConfig` definition (used for `initialConfigurations` and snippet body objects) is also strict; keep it in sync when adding new fields.
+- The schema does not validate `contributes.debuggers[].program` or `runtime` against actual file paths — those are checked at runtime by VS Code.
+
+---
+
 ## Development
 
 ### Build and Test

--- a/extensions/vscode/package.schema.json
+++ b/extensions/vscode/package.schema.json
@@ -1,8 +1,332 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "./package.schema.json",
-  "title": "Local fallback schema for VS Code extension package.json",
-  "description": "Fallback schema to avoid network-dependent schema fetch failures in offline environments.",
+  "title": "Soroban Debugger VS Code Extension Manifest",
+  "description": "Offline validation schema for extensions/vscode/package.json. Validates the extension manifest shape including launch configuration attributes, commands, and settings contributions. Unknown top-level keys are rejected to catch config drift early.",
   "type": "object",
-  "additionalProperties": true
+  "additionalProperties": false,
+  "required": ["name", "version", "engines", "main", "contributes"],
+
+  "properties": {
+
+    "$schema":     { "type": "string" },
+    "name":        { "type": "string", "minLength": 1 },
+    "displayName": { "type": "string" },
+    "description": { "type": "string" },
+    "version":     { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
+    "author":      { "type": "string" },
+    "publisher":   { "type": "string" },
+    "license":     { "type": "string" },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string" },
+        "url":  { "type": "string", "format": "uri" }
+      }
+    },
+    "engines": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vscode"],
+      "properties": {
+        "vscode": { "type": "string", "minLength": 1 }
+      }
+    },
+    "categories": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "activationEvents": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "main": { "type": "string", "minLength": 1 },
+
+    "scripts": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "devDependencies": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+
+    "contributes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["command", "title"],
+            "properties": {
+              "command":  { "type": "string", "minLength": 1 },
+              "title":    { "type": "string", "minLength": 1 },
+              "category": { "type": "string" }
+            }
+          }
+        },
+
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "title": { "type": "string" },
+            "properties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "soroban-debugger.requestTimeoutMs": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["type", "default", "description"],
+                  "properties": {
+                    "type":        { "type": "string", "const": "number" },
+                    "default":     { "type": "number", "minimum": 1 },
+                    "description": { "type": "string" }
+                  }
+                },
+                "soroban-debugger.connectTimeoutMs": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["type", "default", "description"],
+                  "properties": {
+                    "type":        { "type": "string", "const": "number" },
+                    "default":     { "type": "number", "minimum": 1 },
+                    "description": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+
+        "debuggers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "label"],
+            "properties": {
+              "type":      { "type": "string", "const": "soroban" },
+              "label":     { "type": "string" },
+              "program":   { "type": "string" },
+              "runtime":   { "type": "string" },
+              "languages": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+
+              "configurationAttributes": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "launch": { "$ref": "#/definitions/launchConfig" },
+                  "attach": { "$ref": "#/definitions/attachConfig" }
+                }
+              },
+
+              "initialConfigurations": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/anyDebugConfig" }
+              },
+              "configurationSnippets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["label", "body"],
+                  "properties": {
+                    "label":       { "type": "string" },
+                    "description": { "type": "string" },
+                    "body":        { "$ref": "#/definitions/anyDebugConfig" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "definitions": {
+
+    "launchConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "properties"],
+      "properties": {
+        "required": { "type": "array", "items": { "type": "string" } },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "contractPath":         { "$ref": "#/definitions/stringProp" },
+            "snapshotPath":         { "$ref": "#/definitions/stringProp" },
+            "entrypoint":           { "$ref": "#/definitions/stringProp" },
+            "args":                 { "$ref": "#/definitions/arrayProp" },
+            "trace":                { "$ref": "#/definitions/boolProp" },
+            "binaryPath":           { "$ref": "#/definitions/stringProp" },
+            "port":                 { "$ref": "#/definitions/portProp" },
+            "token":                { "$ref": "#/definitions/tokenProp" },
+            "tlsCert":              { "$ref": "#/definitions/stringProp" },
+            "tlsKey":               { "$ref": "#/definitions/stringProp" },
+            "storageFilter":        { "$ref": "#/definitions/stringArrayProp" },
+            "repeat":               { "$ref": "#/definitions/positiveIntProp" },
+            "batchArgs":            { "$ref": "#/definitions/stringProp" },
+            "requestTimeoutMs":     { "$ref": "#/definitions/timeoutProp" },
+            "connectTimeoutMs":     { "$ref": "#/definitions/timeoutProp" },
+            "dryRun":               { "$ref": "#/definitions/boolProp" }
+          }
+        }
+      }
+    },
+
+    "attachConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "properties"],
+      "properties": {
+        "required": { "type": "array", "items": { "type": "string" } },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host":             { "$ref": "#/definitions/stringProp" },
+            "port":             { "$ref": "#/definitions/portProp" },
+            "contractPath":     { "$ref": "#/definitions/stringProp" },
+            "snapshotPath":     { "$ref": "#/definitions/stringProp" },
+            "entrypoint":       { "$ref": "#/definitions/stringProp" },
+            "args":             { "$ref": "#/definitions/arrayProp" },
+            "token":            { "$ref": "#/definitions/tokenProp" },
+            "tlsCert":          { "$ref": "#/definitions/stringProp" },
+            "tlsKey":           { "$ref": "#/definitions/stringProp" },
+            "trace":            { "$ref": "#/definitions/boolProp" },
+            "requestTimeoutMs": { "$ref": "#/definitions/timeoutProp" },
+            "connectTimeoutMs": { "$ref": "#/definitions/timeoutProp" },
+            "storageFilter":    { "$ref": "#/definitions/stringArrayProp" },
+            "repeat":           { "$ref": "#/definitions/positiveIntProp" }
+          }
+        }
+      }
+    },
+
+    "anyDebugConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "request"],
+      "properties": {
+        "name":             { "type": "string", "minLength": 1 },
+        "type":             { "type": "string", "const": "soroban" },
+        "request":          { "type": "string", "enum": ["launch", "attach"] },
+        "contractPath":     { "type": "string" },
+        "snapshotPath":     { "type": "string" },
+        "entrypoint":       { "type": "string" },
+        "args":             { "type": "array" },
+        "trace":            { "type": "boolean" },
+        "binaryPath":       { "type": "string" },
+        "port":             { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "host":             { "type": "string" },
+        "token":            { "type": "string" },
+        "tlsCert":          { "type": "string" },
+        "tlsKey":           { "type": "string" },
+        "storageFilter":    { "type": "array", "items": { "type": "string" } },
+        "repeat":           { "type": "integer", "minimum": 1 },
+        "batchArgs":        { "type": "string" },
+        "requestTimeoutMs": { "type": "number", "minimum": 1 },
+        "connectTimeoutMs": { "type": "number", "minimum": 1 },
+        "dryRun":           { "type": "boolean" }
+      }
+    },
+
+    "stringProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "string" },
+        "description": { "type": "string" },
+        "default":     { "type": "string" }
+      }
+    },
+    "arrayProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "array" },
+        "description": { "type": "string" }
+      }
+    },
+    "boolProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "boolean" },
+        "description": { "type": "string" },
+        "default":     { "type": "boolean" }
+      }
+    },
+    "portProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "integer" },
+        "description": { "type": "string" },
+        "minimum":     { "type": "number", "const": 1 },
+        "maximum":     { "type": "number", "const": 65535 }
+      }
+    },
+    "tokenProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "string" },
+        "description": { "type": "string" },
+        "minLength":   { "type": "number", "const": 1 },
+        "pattern":     { "type": "string" }
+      }
+    },
+    "timeoutProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "number" },
+        "description": { "type": "string" },
+        "default":     { "type": "number", "minimum": 1 }
+      }
+    },
+    "stringArrayProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "array" },
+        "description": { "type": "string" },
+        "items":       { "type": "object" },
+        "default":     { "type": "array" }
+      }
+    },
+    "positiveIntProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "integer" },
+        "description": { "type": "string" },
+        "minimum":     { "type": "number", "const": 1 },
+        "default":     { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request: Issue #703

##  Closes #703

##  Description

Replace permissive schema with strict validation. Changed `additionalProperties: true` to `false` to catch config errors early.

## Changes

- Strict schema validation for all fields
- Added "Manifest Schema Validation" section to README
- Documented how to validate locally with ajv-cli
- Provided CI integration examples

##  Files Changed

- `extensions/vscode/package.schema.json`
- `extensions/vscode/README.md`

