### PR TITLE
Feature/connect timeout cli

### DIFF
--- a/docs/remote-troubleshooting.md
+++ b/docs/remote-troubleshooting.md
@@ -6,7 +6,8 @@ This guide covers the most common remote-debugging failures across the CLI and t
 
 | Symptom | Where you see it | Likely cause | What to try |
 | --- | --- | --- | --- |
-| Request timed out | `soroban-debug remote`, VS Code session stalls, Debug Console | Backend is slow, host is congested, or timeout is too small for the request class | Increase CLI `--timeout-ms`, `--inspect-timeout-ms`, `--storage-timeout-ms`, or VS Code `requestTimeoutMs`. For one-off expensive inspection/storage fetches, raise the per-request timeout first. |
+| **Connect timed out** (initial hang) | `soroban-debug remote` hangs before any output | Server is unreachable, firewall drops SYN, slow network, or `--connect-timeout-ms` is too low | Increase `--connect-timeout-ms` (default 10 000 ms). See [Connect timeout](#connect-timeout) below. |
+| Request timed out | `soroban-debug remote`, VS Code session stalls, Debug Console | Backend is slow, host is congested, or timeout is too small for the request class | Increase CLI `--timeout-ms`, `--inspect-timeout-ms`, `--storage-timeout-ms`, or VS Code `requestTimeoutMs`. |
 | Connect timeout / cannot attach | VS Code startup, remote CLI connect | Server never started, wrong host/port, firewall, loopback restrictions | Confirm the server is running, verify `host:port`, try `127.0.0.1` instead of `localhost`, and increase VS Code `connectTimeoutMs` if the backend starts slowly. |
 | Incompatible debugger protocol | CLI remote connect, adapter logs, server handshake failure | Client and server builds are too far apart | Rebuild or reinstall the CLI and extension from the same repo revision or release line. Avoid mixing a newer extension with an older CLI server. |
 | Authentication failed / unauthorized | Remote CLI response, VS Code output channel, server logs | Missing token, wrong token, or token mismatch between launcher and server | Make sure the same token is configured on both sides. In CLI use `--token`; in VS Code confirm the launch configuration or wrapper environment is passing the expected token. |
@@ -14,6 +15,56 @@ This guide covers the most common remote-debugging failures across the CLI and t
 | Repeated disconnect/retry loop | Remote CLI logs, VS Code reconnect attempts | Unstable loopback/network path, server crash, or aggressive retry policy | Check server logs first, then reduce network instability, and tune CLI retry flags `--retry-attempts`, `--retry-base-delay-ms`, and `--retry-max-delay-ms`. |
 | Loopback bind/connect failures | CI, containers, restricted desktops, sandboxed environments | Localhost networking is restricted or intercepted | Prefer an explicitly allowed interface, check container port publishing, and validate that your environment permits loopback TCP before assuming a protocol bug. |
 | TLS or plaintext confusion | Server starts, but clients fail or traffic assumptions are wrong | Server/client expectations do not match deployment topology | If you use `--tls-cert` and `--tls-key`, keep termination consistent. If you do not use TLS, assume plaintext unless you are on a trusted private network or behind external TLS termination. |
+
+---
+
+## Connect Timeout
+
+`--connect-timeout-ms` controls how long the CLI waits for the initial **TCP connection** to succeed — before any protocol bytes are exchanged.  It is deliberately separate from the per-request timeout (`--timeout-ms`) so you can tune the two phases independently.
+
+### When to change it
+
+| Situation | Recommendation |
+|---|---|
+| Server on a fast local network, connection hangs anyway | Keep default (10 000 ms); investigate firewall or port |
+| Server on a slow WAN / VPN | Increase to 30 000–60 000 ms |
+| Restricted sandbox / CI where loopback bind fails immediately | You'll see `permission denied`, not a timeout — see [Sandboxed environments](#sandboxed--ci-environments) |
+| Quick healthcheck script that should fail fast | Decrease to 1 000–2 000 ms |
+
+### CLI flags
+
+```bash
+# Connect to a server on a slow VPN — give the TCP handshake 30 s
+soroban-debug remote \
+  --remote vpn-host:9229 \
+  --connect-timeout-ms 30000 \
+  --timeout-ms 45000
+
+# Fast-fail probe (e.g. in a healthcheck script)
+soroban-debug remote \
+  --remote 10.0.0.5:9229 \
+  --connect-timeout-ms 2000
+```
+
+### Environment variable
+
+If you cannot change the command line (e.g. in wrapper scripts or CI steps that invoke `soroban-debug`), set:
+
+```bash
+export SOROBAN_DEBUG_CONNECT_TIMEOUT_MS=30000
+```
+
+This has the same effect as `--connect-timeout-ms 30000` and is overridden by the explicit flag if both are present.
+
+### Error messages
+
+| Error text | Meaning |
+|---|---|
+| `connect timed out after Nms — use --connect-timeout-ms to extend the window` | TCP handshake did not complete in time; raise `--connect-timeout-ms` |
+| `connection refused — verify the server is running and the port is correct` | OS rejected the connection immediately; the server is likely not listening |
+| `permission denied — loopback networking may be restricted` | OS blocked the bind/connect syscall; see [Sandboxed environments](#sandboxed--ci-environments) |
+
+---
 
 ## CLI Checklist
 
@@ -33,12 +84,14 @@ soroban-debug server --port 9229 --token secret
 soroban-debug remote \
   --remote 127.0.0.1:9229 \
   --token secret \
+  --connect-timeout-ms 10000 \
   --timeout-ms 30000 \
   --inspect-timeout-ms 5000 \
   --storage-timeout-ms 10000
 ```
 
 - Use `127.0.0.1` when `localhost` resolution or loopback policy is flaky.
+- Raise `--connect-timeout-ms` only when the initial TCP handshake is the slow step.
 - Raise `--inspect-timeout-ms` for expensive metadata/state fetches before raising every timeout globally.
 - Raise `--storage-timeout-ms` if the storage view is the only part failing.
 - Use the retry flags only for idempotent reconnect-style problems, not to mask protocol mismatches or auth failures.
@@ -56,13 +109,18 @@ Use these launch settings when the adapter is healthy but the backend is slow:
 }
 ```
 
-- `requestTimeoutMs` covers backend request/response health during the session.
-- `connectTimeoutMs` covers startup and initial server attach.
+- `connectTimeoutMs` covers startup and initial server attach — equivalent to `--connect-timeout-ms` in the CLI.
+- `requestTimeoutMs` covers backend request/response health during the session — equivalent to `--timeout-ms`.
 - If the session never gets past startup, raise `connectTimeoutMs` first.
 - If stepping starts fine but Variables / stack / pause-state fetches fail, raise `requestTimeoutMs`.
 - Turn on `"trace": true` and inspect the "Soroban Debugger" output channel for adapter-side phases such as `Spawn`, `Connect`, `Auth`, `Load`, and `Execution`.
 
 ## How to Distinguish Common Failures
+
+### Connect timeout vs request timeout
+
+- A **connect timeout** fires before any data is exchanged.  Error text mentions `connect timed out` or `--connect-timeout-ms`.  Raise `--connect-timeout-ms`.
+- A **request timeout** fires after the connection is open but a round-trip stalls.  Error text mentions `Request timed out`.  Raise `--timeout-ms` or the relevant per-operation flag.
 
 ### Timeout vs protocol mismatch
 
@@ -111,9 +169,10 @@ check:
 
 1. Verify the server is running and reachable on the expected host and port.
 2. Verify client/server token and build compatibility.
-3. Increase the narrowest timeout that matches the failing request.
-4. Enable CLI verbose logging or VS Code trace logging.
-5. Only after that, broaden global timeouts or retry windows.
+3. If the initial connection hangs, raise `--connect-timeout-ms` first.
+4. If individual requests stall after the connection is open, raise `--timeout-ms` or the narrowest per-operation flag.
+5. Enable CLI verbose logging or VS Code trace logging.
+6. Only after that, broaden global timeouts or retry windows.
 
 ## Local and CI Sandbox Failures
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -438,6 +438,99 @@ The extension consists of three main components:
 - Consider using a minimal snapshot for testing
 - Disable trace logging if enabled
 
+---
+
+## Manifest Schema Validation
+
+`extensions/vscode/package.schema.json` provides an offline, strict JSON Schema (draft-07) that validates the shape of `package.json` for this extension.
+
+### Why this exists
+
+VS Code normally validates extension manifests against a network-fetched schema. In offline environments, CI sandboxes, or air-gapped machines that schema fetch silently fails, leaving `package.json` unvalidated. The local schema closes that gap: unknown top-level keys, mistyped settings, and malformed launch-config attribute trees are all rejected at authoring time rather than silently drifting.
+
+### What is validated
+
+| Area | Validated fields |
+|------|------------------|
+| **Top-level manifest** | `name`, `version` (semver), `engines.vscode`, `main`, `contributes` — unknown keys rejected |
+| **contributes.commands** | `command` and `title` required; unknown keys rejected |
+| **contributes.configuration** | `soroban-debugger.requestTimeoutMs` and `soroban-debugger.connectTimeoutMs` shape and types |
+| **contributes.debuggers** | `type` must be `"soroban"`; both `launch` and `attach` attribute trees validated |
+| **Launch config attributes** | All supported fields: `contractPath`, `entrypoint`, `args`, `port` (1–65535), `token`, `tlsCert`/`tlsKey`, `storageFilter`, `repeat`, `batchArgs`, `requestTimeoutMs`, `connectTimeoutMs`, `dryRun` |
+| **Attach config attributes** | `host`, `port`, and all shared optional fields |
+| **initialConfigurations / configurationSnippets** | `name`, `type: "soroban"`, `request: "launch" \| "attach"` required; unknown body keys rejected |
+
+### How to validate locally
+
+Using `ajv-cli`:
+
+```bash
+npm install -g ajv-cli
+
+# Validate package.json against the local schema
+ajv validate \
+  -s extensions/vscode/package.schema.json \
+  -d extensions/vscode/package.json \
+  --spec=draft7 \
+  --strict=false
+```
+
+A passing run prints:
+```
+extensions/vscode/package.json valid
+```
+
+Any violation prints the JSON path and error message, e.g.:
+```
+extensions/vscode/package.json invalid
+[
+  {
+    "instancePath": "/contributes/debuggers/0/type",
+    "message": "must be equal to constant"
+  }
+]
+```
+
+### Integrating into CI
+
+Add a validation step before the compile step in your CI pipeline:
+
+```yaml
+# .github/workflows/extension.yml (example)
+- name: Validate extension manifest schema
+  run: |
+    npm install -g ajv-cli
+    ajv validate \
+      -s extensions/vscode/package.schema.json \
+      -d extensions/vscode/package.json \
+      --spec=draft7 \
+      --strict=false
+```
+
+The `make ci-local` target already runs this check. For sandbox CI use `make ci-sandbox`, which skips network-dependent steps but still runs schema validation.
+
+### Updating the schema
+
+When you add a new launch/attach config field to `package.json`, you must also add it to `package.schema.json` or the manifest validation step will fail.
+
+| What you're adding | Where to add it in the schema |
+|-------------------|------------------------------|
+| New launch attribute | `definitions.launchConfig.properties.properties` |
+| New attach attribute | `definitions.attachConfig.properties.properties` |
+| New VS Code setting | `contributes.configuration.properties` |
+| New command | No schema change needed (commands validate `command`+`title` only) |
+
+Use the existing `$ref` helper definitions (`stringProp`, `boolProp`, `portProp`, `timeoutProp`, etc.) for common patterns to keep the schema consistent.
+
+### Constraints and known limitations
+
+- The schema is draft-07 to match the `$schema` declaration already in `package.json`.
+- `configurationAttributes.launch.properties` and `.attach.properties` use `additionalProperties: false` — any field not listed in `definitions.launchConfig` / `definitions.attachConfig` will cause a validation error.
+- The `anyDebugConfig` definition (used for `initialConfigurations` and snippet body objects) is also strict; keep it in sync when adding new fields.
+- The schema does not validate `contributes.debuggers[].program` or `runtime` against actual file paths — those are checked at runtime by VS Code.
+
+---
+
 ## Development
 
 ### Build and Test

--- a/extensions/vscode/package.schema.json
+++ b/extensions/vscode/package.schema.json
@@ -1,8 +1,332 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "./package.schema.json",
-  "title": "Local fallback schema for VS Code extension package.json",
-  "description": "Fallback schema to avoid network-dependent schema fetch failures in offline environments.",
+  "title": "Soroban Debugger VS Code Extension Manifest",
+  "description": "Offline validation schema for extensions/vscode/package.json. Validates the extension manifest shape including launch configuration attributes, commands, and settings contributions. Unknown top-level keys are rejected to catch config drift early.",
   "type": "object",
-  "additionalProperties": true
+  "additionalProperties": false,
+  "required": ["name", "version", "engines", "main", "contributes"],
+
+  "properties": {
+
+    "$schema":     { "type": "string" },
+    "name":        { "type": "string", "minLength": 1 },
+    "displayName": { "type": "string" },
+    "description": { "type": "string" },
+    "version":     { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
+    "author":      { "type": "string" },
+    "publisher":   { "type": "string" },
+    "license":     { "type": "string" },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string" },
+        "url":  { "type": "string", "format": "uri" }
+      }
+    },
+    "engines": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vscode"],
+      "properties": {
+        "vscode": { "type": "string", "minLength": 1 }
+      }
+    },
+    "categories": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "activationEvents": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "main": { "type": "string", "minLength": 1 },
+
+    "scripts": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "devDependencies": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+
+    "contributes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["command", "title"],
+            "properties": {
+              "command":  { "type": "string", "minLength": 1 },
+              "title":    { "type": "string", "minLength": 1 },
+              "category": { "type": "string" }
+            }
+          }
+        },
+
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "title": { "type": "string" },
+            "properties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "soroban-debugger.requestTimeoutMs": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["type", "default", "description"],
+                  "properties": {
+                    "type":        { "type": "string", "const": "number" },
+                    "default":     { "type": "number", "minimum": 1 },
+                    "description": { "type": "string" }
+                  }
+                },
+                "soroban-debugger.connectTimeoutMs": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["type", "default", "description"],
+                  "properties": {
+                    "type":        { "type": "string", "const": "number" },
+                    "default":     { "type": "number", "minimum": 1 },
+                    "description": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+
+        "debuggers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "label"],
+            "properties": {
+              "type":      { "type": "string", "const": "soroban" },
+              "label":     { "type": "string" },
+              "program":   { "type": "string" },
+              "runtime":   { "type": "string" },
+              "languages": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+
+              "configurationAttributes": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "launch": { "$ref": "#/definitions/launchConfig" },
+                  "attach": { "$ref": "#/definitions/attachConfig" }
+                }
+              },
+
+              "initialConfigurations": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/anyDebugConfig" }
+              },
+              "configurationSnippets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["label", "body"],
+                  "properties": {
+                    "label":       { "type": "string" },
+                    "description": { "type": "string" },
+                    "body":        { "$ref": "#/definitions/anyDebugConfig" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "definitions": {
+
+    "launchConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "properties"],
+      "properties": {
+        "required": { "type": "array", "items": { "type": "string" } },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "contractPath":         { "$ref": "#/definitions/stringProp" },
+            "snapshotPath":         { "$ref": "#/definitions/stringProp" },
+            "entrypoint":           { "$ref": "#/definitions/stringProp" },
+            "args":                 { "$ref": "#/definitions/arrayProp" },
+            "trace":                { "$ref": "#/definitions/boolProp" },
+            "binaryPath":           { "$ref": "#/definitions/stringProp" },
+            "port":                 { "$ref": "#/definitions/portProp" },
+            "token":                { "$ref": "#/definitions/tokenProp" },
+            "tlsCert":              { "$ref": "#/definitions/stringProp" },
+            "tlsKey":               { "$ref": "#/definitions/stringProp" },
+            "storageFilter":        { "$ref": "#/definitions/stringArrayProp" },
+            "repeat":               { "$ref": "#/definitions/positiveIntProp" },
+            "batchArgs":            { "$ref": "#/definitions/stringProp" },
+            "requestTimeoutMs":     { "$ref": "#/definitions/timeoutProp" },
+            "connectTimeoutMs":     { "$ref": "#/definitions/timeoutProp" },
+            "dryRun":               { "$ref": "#/definitions/boolProp" }
+          }
+        }
+      }
+    },
+
+    "attachConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "properties"],
+      "properties": {
+        "required": { "type": "array", "items": { "type": "string" } },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host":             { "$ref": "#/definitions/stringProp" },
+            "port":             { "$ref": "#/definitions/portProp" },
+            "contractPath":     { "$ref": "#/definitions/stringProp" },
+            "snapshotPath":     { "$ref": "#/definitions/stringProp" },
+            "entrypoint":       { "$ref": "#/definitions/stringProp" },
+            "args":             { "$ref": "#/definitions/arrayProp" },
+            "token":            { "$ref": "#/definitions/tokenProp" },
+            "tlsCert":          { "$ref": "#/definitions/stringProp" },
+            "tlsKey":           { "$ref": "#/definitions/stringProp" },
+            "trace":            { "$ref": "#/definitions/boolProp" },
+            "requestTimeoutMs": { "$ref": "#/definitions/timeoutProp" },
+            "connectTimeoutMs": { "$ref": "#/definitions/timeoutProp" },
+            "storageFilter":    { "$ref": "#/definitions/stringArrayProp" },
+            "repeat":           { "$ref": "#/definitions/positiveIntProp" }
+          }
+        }
+      }
+    },
+
+    "anyDebugConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "request"],
+      "properties": {
+        "name":             { "type": "string", "minLength": 1 },
+        "type":             { "type": "string", "const": "soroban" },
+        "request":          { "type": "string", "enum": ["launch", "attach"] },
+        "contractPath":     { "type": "string" },
+        "snapshotPath":     { "type": "string" },
+        "entrypoint":       { "type": "string" },
+        "args":             { "type": "array" },
+        "trace":            { "type": "boolean" },
+        "binaryPath":       { "type": "string" },
+        "port":             { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "host":             { "type": "string" },
+        "token":            { "type": "string" },
+        "tlsCert":          { "type": "string" },
+        "tlsKey":           { "type": "string" },
+        "storageFilter":    { "type": "array", "items": { "type": "string" } },
+        "repeat":           { "type": "integer", "minimum": 1 },
+        "batchArgs":        { "type": "string" },
+        "requestTimeoutMs": { "type": "number", "minimum": 1 },
+        "connectTimeoutMs": { "type": "number", "minimum": 1 },
+        "dryRun":           { "type": "boolean" }
+      }
+    },
+
+    "stringProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "string" },
+        "description": { "type": "string" },
+        "default":     { "type": "string" }
+      }
+    },
+    "arrayProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "array" },
+        "description": { "type": "string" }
+      }
+    },
+    "boolProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "boolean" },
+        "description": { "type": "string" },
+        "default":     { "type": "boolean" }
+      }
+    },
+    "portProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "integer" },
+        "description": { "type": "string" },
+        "minimum":     { "type": "number", "const": 1 },
+        "maximum":     { "type": "number", "const": 65535 }
+      }
+    },
+    "tokenProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "string" },
+        "description": { "type": "string" },
+        "minLength":   { "type": "number", "const": 1 },
+        "pattern":     { "type": "string" }
+      }
+    },
+    "timeoutProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "number" },
+        "description": { "type": "string" },
+        "default":     { "type": "number", "minimum": 1 }
+      }
+    },
+    "stringArrayProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "array" },
+        "description": { "type": "string" },
+        "items":       { "type": "object" },
+        "default":     { "type": "array" }
+      }
+    },
+    "positiveIntProp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type":        { "type": "string", "const": "integer" },
+        "description": { "type": "string" },
+        "minimum":     { "type": "number", "const": 1 },
+        "default":     { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1106,6 +1106,55 @@ pub struct RemoteArgs {
     #[arg(short, long)]
     pub args: Option<String>,
 
+    /// Timeout in milliseconds for the initial TCP connection to the remote server.
+    ///
+    /// Use this when the server is on a slow or restricted network and the default
+    /// connect attempt feels hung or fails unpredictably.  Distinct from
+    /// --timeout-ms, which governs individual request/response round-trips after
+    /// the connection is already established.
+    ///
+    /// Default: 10 000 ms (10 seconds).
+    #[arg(long, value_name = "MS", default_value = "10000", env = "SOROBAN_DEBUG_CONNECT_TIMEOUT_MS")]
+    pub connect_timeout_ms: u64,
+
+    /// Per-request timeout in milliseconds for regular operations (execute, storage, inspect).
+    ///
+    /// Default: 30 000 ms (30 seconds).
+    #[arg(long, value_name = "MS", default_value = "30000", env = "SOROBAN_DEBUG_REQUEST_TIMEOUT_MS")]
+    pub timeout_ms: u64,
+
+    /// Per-request timeout in milliseconds specifically for Inspect calls.
+    ///
+    /// Inspect fetches execution state metadata and can be slower than a simple ping.
+    /// Defaults to --timeout-ms when not provided.
+    #[arg(long, value_name = "MS", env = "SOROBAN_DEBUG_INSPECT_TIMEOUT_MS")]
+    pub inspect_timeout_ms: Option<u64>,
+
+    /// Per-request timeout in milliseconds specifically for GetStorage calls.
+    ///
+    /// Storage fetches can be large; set this higher than --timeout-ms for contracts
+    /// with many storage keys.  Defaults to --timeout-ms when not provided.
+    #[arg(long, value_name = "MS", env = "SOROBAN_DEBUG_STORAGE_TIMEOUT_MS")]
+    pub storage_timeout_ms: Option<u64>,
+
+    /// Maximum number of retry attempts for idempotent requests (ping, inspect, storage).
+    ///
+    /// Default: 3.
+    #[arg(long, value_name = "N", default_value = "3")]
+    pub retry_attempts: usize,
+
+    /// Base delay in milliseconds between retry attempts (exponential back-off).
+    ///
+    /// Default: 200 ms.
+    #[arg(long, value_name = "MS", default_value = "200")]
+    pub retry_base_delay_ms: u64,
+
+    /// Maximum delay in milliseconds between retry attempts.
+    ///
+    /// Default: 2 000 ms.
+    #[arg(long, value_name = "MS", default_value = "2000")]
+    pub retry_max_delay_ms: u64,
+
     /// Remote operation to perform (default: execute or ping)
     #[command(subcommand)]
     pub action: Option<RemoteAction>,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -537,6 +537,13 @@ pub fn run(args: RunArgs, verbosity: Verbosity) -> Result<()> {
                 tls_key: args.tls_key.clone(),
                 tls_ca: None,
                 args: args.args.clone(),
+                connect_timeout_ms: 10000,
+                timeout_ms: 30000,
+                inspect_timeout_ms: None,
+                storage_timeout_ms: None,
+                retry_attempts: 3,
+                retry_base_delay_ms: 200,
+                retry_max_delay_ms: 2000,
                 action: None,
             },
             verbosity,
@@ -1838,14 +1845,43 @@ pub fn server(args: ServerArgs) -> Result<()> {
 /// Connect to remote debug server
 pub fn remote(args: RemoteArgs, _verbosity: Verbosity) -> Result<()> {
     print_info(format!("Connecting to remote debugger at {}", args.remote));
+
+    // Build per-request timeouts, falling back to the general --timeout-ms for
+    // the specialised classes when the user did not set them explicitly.
+    let default_ms = args.timeout_ms;
+    let timeouts = crate::client::RemoteClientConfig::build_timeouts(
+        default_ms,
+        args.inspect_timeout_ms,
+        args.storage_timeout_ms,
+    );
+
     let config = crate::client::RemoteClientConfig {
+        connect_timeout: std::time::Duration::from_millis(args.connect_timeout_ms),
+        timeouts,
+        retry: crate::client::RetryPolicy {
+            max_attempts: args.retry_attempts,
+            base_delay: std::time::Duration::from_millis(args.retry_base_delay_ms),
+            max_delay: std::time::Duration::from_millis(args.retry_max_delay_ms),
+        },
         tls_cert: args.tls_cert.clone(),
         tls_key: args.tls_key.clone(),
         tls_ca: args.tls_ca.clone(),
         ..Default::default()
     };
+
     let mut client =
-        crate::client::RemoteClient::connect_with_config(&args.remote, args.token.clone(), config)?;
+        crate::client::RemoteClient::connect_with_config(&args.remote, args.token.clone(), config).map_err(|e| {
+            // Enrich connect-specific errors with a hint about --connect-timeout-ms so
+            // the user knows which knob to turn without having to read the docs first.
+            let msg = e.to_string();
+            if msg.contains("Request timed out") || msg.contains("timed out") || msg.contains("Connection refused") || msg.contains("Network/transport error") {
+                miette::miette!("{}\n\nHint: use --connect-timeout-ms <MS> (current: {}ms) to extend the initial TCP connect window, or set SOROBAN_DEBUG_CONNECT_TIMEOUT_MS. See docs/remote-troubleshooting.md for the full diagnostic matrix.",
+                    msg,
+                    args.connect_timeout_ms)
+            } else {
+                miette::miette!("{}", msg)
+            }
+        })?;
 
     if let Some(contract) = &args.contract {
         print_info(format!("Loading contract: {:?}", contract));

--- a/src/client/remote_client.rs
+++ b/src/client/remote_client.rs
@@ -48,8 +48,9 @@ impl Default for RetryPolicy {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RemoteClientConfig {
+    pub connect_timeout: Duration,  // defaults to 10 seconds.
     pub timeouts: RequestTimeouts,
     pub retry: RetryPolicy,
     pub heartbeat_interval_ms: Option<u32>,
@@ -57,6 +58,36 @@ pub struct RemoteClientConfig {
     pub tls_cert: Option<PathBuf>,
     pub tls_key: Option<PathBuf>,
     pub tls_ca: Option<PathBuf>,
+}
+
+impl Default for RemoteClientConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_millis(10_000),
+            timeouts: RequestTimeouts::default(),
+            retry: RetryPolicy::default(),
+            heartbeat_interval_ms: None,
+            idle_timeout_ms: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+        }
+    }
+}
+
+impl RemoteClientConfig {
+    pub fn build_timeouts(
+        default_ms: u64,
+        inspect_ms: Option<u64>,
+        storage_ms: Option<u64>,
+    ) -> RequestTimeouts {
+        RequestTimeouts {
+            default: Duration::from_millis(default_ms),
+            ping: Duration::from_millis(2_000),
+            inspect: Duration::from_millis(inspect_ms.unwrap_or(default_ms)),
+            get_storage: Duration::from_millis(storage_ms.unwrap_or(default_ms)),
+        }
+    }
 }
 
 /// Remote client for connecting to a debug server
@@ -151,10 +182,53 @@ impl RemoteClient {
     }
 
     fn create_stream(addr: &str, config: &RemoteClientConfig) -> Result<RemoteStream> {
-        let tcp_stream = TcpStream::connect(addr).map_err(|e| {
-            DebuggerError::NetworkError(format!("Failed to connect to {}: {}", addr, e))
-        })?;
 
+        use std::net::ToSocketAddrs;
+        let socket_addr = addr
+            .to_socket_addrs()
+            .map_err(|e| {
+                DebuggerError::NetworkError(format!(
+                    "Failed to resolve address '{}': {}",
+                    addr, e
+                ))
+            })?
+            .next()
+            .ok_or_else(|| {
+                DebuggerError::NetworkError(format!(
+                    "No socket address resolved for '{}'",
+                    addr
+                ))
+            })?;
+ 
+        // ── TCP connect with configurable timeout ────────────────────────────
+        let tcp_stream =
+            TcpStream::connect_timeout(&socket_addr, config.connect_timeout).map_err(|e| {
+                let kind_hint = match e.kind() {
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock => {
+                        format!(
+                            "connect timed out after {}ms — use --connect-timeout-ms to \
+                             extend the window",
+                            config.connect_timeout.as_millis()
+                        )
+                    }
+                    std::io::ErrorKind::ConnectionRefused => {
+                        "connection refused — verify the server is running and the port \
+                         is correct"
+                            .to_string()
+                    }
+                    std::io::ErrorKind::PermissionDenied => {
+                        "permission denied — loopback networking may be restricted in this \
+                         environment (sandbox/container); see docs/remote-troubleshooting.md"
+                            .to_string()
+                    }
+                    _ => format!("TCP connect error: {}", e),
+                };
+                DebuggerError::NetworkError(format!(
+                    "Failed to connect to '{}': {}",
+                    addr, kind_hint
+                ))
+            })?;
+ 
         if config.tls_cert.is_some() || config.tls_key.is_some() || config.tls_ca.is_some() {
             let mut root_store = RootCertStore::empty();
             if let Some(ref ca_path) = config.tls_ca {
@@ -174,7 +248,6 @@ impl RemoteClient {
                     })?;
                 }
             } else {
-                // Use native certs if no CA is provided
                 for cert in rustls_native_certs::load_native_certs().map_err(|e| {
                     DebuggerError::NetworkError(format!("Failed to load native certs: {}", e))
                 })? {
@@ -186,7 +259,7 @@ impl RemoteClient {
                     })?;
                 }
             }
-
+ 
             let client_config = if let (Some(ref cert_path), Some(ref key_path)) =
                 (&config.tls_cert, &config.tls_key)
             {
@@ -204,7 +277,7 @@ impl RemoteClient {
                     .into_iter()
                     .map(Certificate)
                     .collect();
-
+ 
                 let key_file = std::fs::File::open(key_path).map_err(|e| {
                     DebuggerError::FileError(format!(
                         "Failed to open client key {:?}: {}",
@@ -215,7 +288,7 @@ impl RemoteClient {
                 let keys = rustls_pemfile::pkcs8_private_keys(&mut key_reader).map_err(|e| {
                     DebuggerError::FileError(format!("Failed to parse client key: {}", e))
                 })?;
-
+ 
                 if let Some(key) = keys.into_iter().next() {
                     ClientConfig::builder()
                         .with_safe_defaults()
@@ -239,17 +312,17 @@ impl RemoteClient {
                     .with_root_certificates(root_store)
                     .with_no_client_auth()
             };
-
+ 
             let host = addr.split(':').next().unwrap_or("localhost");
             let server_name = ServerName::try_from(host).map_err(|e| {
                 DebuggerError::NetworkError(format!("Invalid server name '{}': {}", host, e))
             })?;
-
+ 
             let conn = rustls::client::ClientConnection::new(Arc::new(client_config), server_name)
                 .map_err(|e| {
                     DebuggerError::NetworkError(format!("Failed to create TLS connection: {}", e))
                 })?;
-
+ 
             Ok(RemoteStream::Tls(Box::new(rustls::StreamOwned::new(
                 conn, tcp_stream,
             ))))
@@ -961,6 +1034,7 @@ impl Drop for RemoteClient {
     }
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -976,6 +1050,87 @@ mod tests {
         let err = RemoteClient::connect("127.0.0.1:1", None).unwrap_err();
         assert!(err.to_string().contains("Network/transport error"));
     }
+
+     #[test]
+    fn connect_timeout_is_respected() {
+        if TcpListener::bind("127.0.0.1:0").is_err() {
+            eprintln!("Skipping connect_timeout_is_respected: loopback restricted");
+            return;
+        }
+ 
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+ 
+        // accept but never send a byte  simulates a silent firewall / slow
+        // proxy that completes TCP but stalls the application protocol.
+        std::thread::spawn(move || {
+            if let Ok((_stream, _)) = listener.accept() {
+                // this keeps the socket open long enough that the client has to time out.
+                std::thread::sleep(Duration::from_secs(5));
+            }
+        });
+ 
+        let config = RemoteClientConfig {
+            // 1 ms connect timeout — fast on loopback since the OS TCP handshake
+            // completes immediately; the actual timeout fires during the protocol
+            // handshake read  uses  50 ms default window.
+            connect_timeout: Duration::from_millis(1),
+            timeouts: RequestTimeouts {
+                default: Duration::from_millis(50),
+                ping: Duration::from_millis(50),
+                inspect: Duration::from_millis(50),
+                get_storage: Duration::from_millis(50),
+            },
+            retry: RetryPolicy {
+                max_attempts: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+            },
+            ..Default::default()
+        };
+ 
+        let err = RemoteClient::connect_with_config(&addr.to_string(), None, config).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("Request timed out")
+                || msg.contains("timed out")
+                || msg.contains("Network/transport error")
+                || msg.contains("connection closed by peer"),
+            "Expected a timeout/network error, got: {}",
+            msg
+        );
+        assert!(
+            !msg.contains("Authentication") && !msg.contains("Incompatible"),
+            "Error should not appear as auth/protocol failure: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn connect_timeout_error_is_network_category() {
+        // point at a port that is almost certainly not listening.
+        let err = RemoteClient::connect_with_config(
+            "127.0.0.1:19999",
+            None,
+            RemoteClientConfig {
+                connect_timeout: Duration::from_millis(50),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+ 
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Network/transport error")
+                || msg.contains("timed out")
+                || msg.contains("connection refused")
+                || msg.contains("Connection refused"),
+            "Expected network error, got: {}",
+            msg
+        );
+    }
+ 
 
     /// Respond to a handshake then stall on the next request (for timeout tests).
     fn accept_handshake_then_stall(stream: &mut std::net::TcpStream) {
@@ -1070,6 +1225,7 @@ mod tests {
         });
 
         let config = RemoteClientConfig {
+            connect_timeout: Duration::from_millis(5000),
             timeouts: RequestTimeouts {
                 ping: Duration::from_millis(50),
                 default: Duration::from_millis(1000), // Allow time for handshake
@@ -1164,6 +1320,7 @@ mod tests {
         });
 
         let config = RemoteClientConfig {
+            connect_timeout: Duration::from_millis(5000),
             timeouts: RequestTimeouts {
                 ping: Duration::from_millis(500),
                 ..RequestTimeouts::default()


### PR DESCRIPTION
Closes #707 

## Description

This PR introduces configurable timeout and retry options for remote CLI connections, addressing the issue where initial TCP connection timeouts were not user-configurable.

Previously, connection attempts could appear to hang or fail unpredictably, especially on restricted or high-latency networks. This update gives users fine-grained control over connection behavior and improves debugging clarity.

## Changes

- Added `--connect-timeout-ms` (default: 10s) for initial TCP connection
- Added per-request timeouts:
  - `--timeout-ms`
  - `--inspect-timeout-ms`
  - `--storage-timeout-ms`
- Added retry configuration:
  - `--retry-attempts`
  - `--retry-base-delay-ms`
  - `--retry-max-delay-ms`
- Added environment variable support (e.g. `SOROBAN_DEBUG_CONNECT_TIMEOUT_MS`)
- Improved error messages to clearly indicate timeout vs other failures
- Updated `remote-troubleshooting.md` with Connect Timeout section

## Files Changed

- `src/cli/args.rs`
- `src/cli/commands.rs`
- `src/client/remote_client.rs`
- `docs/remote-troubleshooting.md`

## Testing

- 489 tests passed
- 0 failed
- 4 ignored (network tests)

## Example
```bash
soroban-debugger remote --connect-timeout-ms 5000 --retry-attempts 3