### PR TITLE
feat: deterministic state fingerprints + scenario step tags (drips wave 4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,3 @@ bench = false
 [lib]
 crate-type = ["cdylib"]
 
-[dependencies]
-soroban-debugger = { path = "../../../" }
-tracing = "0.1"

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,432 @@
+# Soroban Debugger
+
+[![CI](https://github.com/Timi16/soroban-debugger/actions/workflows/ci.yml/badge.svg)](https://github.com/Timi16/soroban-debugger/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Timi16/soroban-debugger/branch/main/graph/badge.svg)](https://codecov.io/gh/Timi16/soroban-debugger)
+[![Latest Release](https://img.shields.io/github/v/release/Timi16/soroban-debugger?logo=github)](https://github.com/Timi16/soroban-debugger/releases)
+
+A command-line debugger for Soroban smart contracts on the Stellar network. Debug your contracts interactively with breakpoints, step-through execution, state inspection, and budget tracking.
+
+## Table of Contents
+- [Quick Start](#quick-start)
+- [User Journeys](#user-journeys)
+- [Command Index](#command-index)
+- [Reference](#reference)
+  - [Supported Argument Types](#supported-argument-types)
+  - [Storage Filtering](#storage-filtering)
+  - [Exporting Execution Traces](#exporting-execution-traces)
+- [Interactive Commands](#interactive-command)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Quick Start
+
+### 1. Installation
+
+#### Using Cargo (Recommended)
+```bash
+cargo install soroban-debugger
+```
+
+#### From Source
+```bash
+git clone https://github.com/Timi16/soroban-debugger.git
+cd soroban-debugger
+cargo install --path .
+```
+
+### 2. Your First Debug Run
+
+Debug a contract by specifying the WASM file and function to execute:
+
+```bash
+soroban-debug run --contract token.wasm --function transfer --args '["Alice", "Bob", 100]'
+```
+
+For an interactive session with a terminal UI:
+```bash
+soroban-debug interactive --contract my_contract.wasm --function hello
+```
+
+For a comprehensive introduction, see the [Getting Started Guide](docs/getting-started.md).
+
+---
+
+## User Journeys
+
+### 🛠️ Debugging Your First Contract
+Learn how to execute functions, pass complex arguments, and use the interactive debugger.
+
+- **Basic Execution**: Use the `run` command to execute functions and see results immediately.
+- **Interactive Mode**: Use `interactive` for a step-by-step walkthrough with breakpoints.
+- **REPL**: Use `repl` for repeated calls and exploration without restarting.
+- **Complex Arguments**: Support for JSON-nested vectors, maps, and [typed annotations](#typed-annotations).
+
+### 🔍 Source-Level Debugging
+Debug your Rust code directly instead of raw WASM instructions.
+
+- **Rust Source Mapping**: Automatically maps WASM offsets back to Rust lines using DWARF debug info.
+- **Instruction Stepping**: Step into, over, or out of functions at the source level.
+- **Source Map Caching**: Fast O(1) lookups for source locations after the first load.
+
+See [Source-Level Debugging Guide](docs/source-level-debugging.md) for details.
+
+### 🌐 Remote Debugging Sessions
+Debug contracts running on remote servers or in CI environments.
+
+- **Debug Server**: Start a `server` process to host a debugging session.
+- **Remote Client**: Connect to a running server using the `remote` command.
+- **Secure Connections**: Support for TLS and token-based authentication.
+
+See [Remote Debugging Guide](docs/remote-debugging.md) for setup instructions.
+
+### 📈 Analysis & Optimization
+Analyze contract metadata, resource usage, and upgrade compatibility.
+
+- **Inspection**: Use `inspect` to view contract functions and metadata without executing.
+- **Profiling**: Use `profile` to find hotspots and budget-heavy execution paths.
+- **Optimization**: Use `optimize` for automated gas and performance suggestions.
+- **Upgrade Checks**: Use `upgrade-check` to ensure API compatibility between versions.
+
+### 🤖 Regression & Automated Testing
+Integrate debugging into your CI/CD pipeline and discover edge cases.
+
+- **Scenarios**: Define multi-step integration tests in simple [TOML files](docs/tutorials/scenario-runner.md).
+- **Batch Execution**: Run the same function with [multiple argument sets](docs/batch-execution.md) in parallel.
+- **Symbolic Analysis**: Automatically explore input spaces to find panics and edge cases.
+- **Test Generation**: Generate ready-to-run Rust unit tests from any debug session.
+
+---
+
+## Command Index
+
+| Category | Commands |
+| --- | --- |
+| **Run & Debug** | `run`, `interactive`, `repl`, `tui`, `scenario`, `replay` |
+| **Analyze & Compare** | `inspect`, `upgrade-check`, `optimize`, `profile`, `compare`, `symbolic`, `analyze` |
+| **Remote & Server** | `server`, `remote` |
+| **Utilities** | `completions`, `history-prune` |
+
+> Use `soroban-debug <command> --help` for full flags and examples.
+
+---
+
+## Reference
+
+### Supported Argument Types
+
+The debugger supports passing typed arguments via the `--args` flag.
+
+| JSON Value | Soroban Type | Example |
+| --- | --- | --- |
+| Number | `i128` | `10`, `-5` |
+| String | `Symbol` | `"hello"` |
+| Boolean | `Bool` | `true` |
+| Array | `Vec<Val>` | `[1, 2, 3]` |
+| Object | `Map` | `{"key": "value"}` |
+
+#### Typed Annotations
+For precise control, use `{"type": "...", "value": ...}`:
+`u32`, `i32`, `u64`, `i64`, `u128`, `i128`, `bool`, `symbol`, `string`, `address`.
+
+### Storage Filtering
+
+Filter large storage outputs by key pattern using `--storage-filter`:
+
+```bash
+# Prefix match: keys starting with "balance:"
+soroban-debug run --contract token.wasm --function mint \
+  --storage-filter 'balance:*'
+
+# Regex match: keys matching a pattern
+soroban-debug run --contract token.wasm --function mint \
+  --storage-filter 're:^user_\d+$'
+
+# Exact match
+soroban-debug run --contract token.wasm --function mint \
+  --storage-filter 'total_supply'
+
+# Multiple filters (combined with OR)
+soroban-debug run --contract token.wasm --function mint \
+  --storage-filter 'balance:*' \
+  --storage-filter 'total_supply'
+```
+
+#### Exporting Execution Traces
+
+You can export a full record of the contract execution to a JSON file using the `--trace-output` flag. This trace captures function calls, arguments, return values, storage snapshots (before and after), events, and budget consumption.
+
+```bash
+soroban-debug run \
+  --contract contract.wasm \
+  --function hello \
+  --trace-output execution_trace.json
+```
+
+These traces can later be used with the `compare` command to identify regressions or differences between runs.
+
+##### Example Trace Output (JSON)
+
+An exported trace includes versioning, metadata, and full execution state:
+
+```json
+{
+  "version": "1.0",
+  "label": "Execution of hello",
+  "contract": "CA7QYNF5GE5XEC4HALXWFVQQ5TQWQ5LF7WMXMEQG7BWHBQV26YCWL5",
+  "function": "hello",
+  "args": "[\"world\"]",
+  "storage_before": {
+    "counter": "0"
+  },
+  "storage": {
+    "counter": "1"
+  },
+  "budget": {
+    "cpu_instructions": 1540,
+    "memory_bytes": 450,
+    "cpu_limit": 1000000,
+    "memory_limit": 1000000
+  },
+  "return_value": "void",
+  "call_sequence": [
+    {
+      "function": "hello",
+      "args": "[\"world\"]",
+      "depth": 0,
+      "budget": {
+        "cpu_instructions": 1540,
+        "memory_bytes": 450
+      }
+    }
+  ],
+  "events": [
+    {
+      "contract_id": "CA7Q...",
+      "topics": ["\"greeting\""],
+      "data": "\"Hello, world!\""
+    }
+  ]
+}
+```
+
+| Pattern          | Type   | Matches                                |
+|------------------|--------|----------------------------------------|
+| `balance:*`      | Prefix | Keys starting with `balance:`          |
+| `re:^user_\d+$`  | Regex  | Keys matching the regex                |
+| `total_supply`   | Exact  | Only the key `total_supply`            |
+
+### Interactive Command
+
+Start an interactive debugging session:
+
+```bash
+soroban-debug interactive [OPTIONS]
+
+Options:
+  -c, --contract <FILE>     Path to the contract WASM file
+```
+
+### Inspect Command
+
+View contract information without executing:
+
+```bash
+soroban-debug inspect [OPTIONS]
+
+Options:
+  -c, --contract <FILE>     Path to the contract WASM file
+      --source-map-diagnostics
+                            Print resolved mappings, missing DWARF sections, and fallback behavior
+      --dependency-graph     Export cross-contract dependency graph (DOT + Mermaid)
+```
+
+Use `soroban-debug inspect --contract my_contract.wasm --source-map-diagnostics --format json`
+when you want a non-interactive DWARF triage report for CI or editor tooling.
+
+For full examples, see [docs/dependency-graph.md](https://github.com/Timi16/soroban-debugger/blob/main/docs/dependency-graph.md).
+
+### Upgrade Check Command
+
+Compare two contract binaries for API breakage and execution differences before releasing:
+
+```bash
+soroban-debug upgrade-check --old current.wasm --new upgraded.wasm
+```
+
+The debugger runs parallel traces and classifies the upgrade:
+- **Safe:** No breaking changes, stable inputs execution.
+- **Caution:** Non-breaking changes like new map arguments or endpoints.
+- **Breaking:** Removed functions, changed signatures, or execution panic regressions.
+
+### Completions Command
+
+Generate shell completion scripts for your favorite shell:
+
+```bash
+soroban-debug completions bash > /usr/local/etc/bash_completion.d/soroban-debug
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `powershell`.
+
+#### Installation Instructions
+
+**Bash:**
+
+```bash
+soroban-debug completions bash > /usr/local/etc/bash_completion.d/soroban-debug
+```
+
+**Zsh:**
+
+```bash
+soroban-debug completions zsh > /usr/local/share/zsh/site-functions/_soroban-debug
+```
+
+**Fish:**
+
+```bash
+soroban-debug completions fish > ~/.config/fish/completions/soroban-debug.fish
+```
+
+**PowerShell:**
+
+```powershell
+soroban-debug completions powershell >> $PROFILE
+```
+
+### Compare Command
+
+Compare two execution trace JSON files side-by-side to identify
+differences and regressions in storage, budget, return values, and
+execution flow:
+
+```bash
+soroban-debug compare <TRACE_A> <TRACE_B> [OPTIONS]
+
+Options:
+  -o, --output <FILE>       Output file for the comparison report (default: stdout)
+```
+
+Example:
+
+```bash
+# Compare two saved execution traces
+soroban-debug compare examples/trace_a.json examples/trace_b.json
+
+# Save report to a file
+soroban-debug compare baseline.json new.json --output diff_report.txt
+```
+
+See [`doc/compare.md`](https://github.com/Timi16/soroban-debugger/blob/main/docs/doc/compare.md) for the full trace JSON format reference
+and a regression testing workflow guide.
+
+## Examples
+
+For a comprehensive overview of available examples mapped to debugger concepts (auth, storage, plugins, etc.), see the **[Examples Index](examples/README.md)**.
+
+### Example 1: Debug a Token Transfer
+
+```bash
+soroban-debug run \
+  --contract token.wasm \
+  --function transfer \
+  --args '["user1", "user2", 100]'
+```
+
+### Example 1a: Debug with Map Arguments
+
+Pass JSON objects as Map arguments:
+
+```bash
+# Flat map argument
+soroban-debug run \
+  --contract token.wasm \
+  --function update_user \
+  --args '{"user":"ABC","balance":1000}'
+
+# Nested map argument
+soroban-debug run \
+  --contract token.wasm \
+  --function update_user \
+  --args '{"user":"ABC","balance":1000,"metadata":{"verified":true,"level":"premium"}}'
+
+# Mixed-type values in map
+soroban-debug run \
+  --contract dao.wasm \
+  --function create_proposal \
+  --args '{"title":"Proposal 1","votes":42,"active":true,"tags":["important","urgent"]}'
+```
+
+Output:
+
+```
+> Debugger started
+> Paused at: transfer
+> Args: from=user1, to=user2, amount=100
+
+(debug) s
+> Executing: get_balance(user1)
+> Storage: balances[user1] = 500
+
+(debug) s
+> Executing: set_balance(user1, 400)
+
+(debug) storage
+Storage:
+  balances[user1] = 400
+  balances[user2] = 100
+
+(debug) c
+> Execution completed
+> Result: Ok(())
+```
+
+### Example 2: Set Breakpoints
+
+```bash
+soroban-debug run \
+  --contract dao.wasm \
+  --function execute \
+  --breakpoint verify_signature \
+  --breakpoint update_state
+```
+
+### Example 3: Initial Storage State
+
+```bash
+soroban-debug run --contract token.wasm --function mint --storage-filter 'balance:*'
+```
+Supports `prefix*`, `re:<regex>`, and `exact_match`.
+
+### Configuration File
+Load default settings from `.soroban-debug.toml`:
+```toml
+[debug]
+breakpoints = ["verify", "auth"]
+[output]
+show_events = true
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Solution |
+| --- | --- | --- |
+| Request timed out | Slow host or low timeout | Increase `--timeout-ms` |
+| Incompatible protocol | Build version mismatch | Reinstall client/server from same release |
+| Auth failed | Token mismatch | Verify `--token` values match |
+
+For more scenarios, see the [Full FAQ](docs/faq.md) and [Remote Troubleshooting Guide](docs/remote-troubleshooting.md).
+
+---
+
+## Contributing
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and workflow.
+
+## License
+Licensed under [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT).

--- a/docs/scenario-tags.md
+++ b/docs/scenario-tags.md
@@ -1,0 +1,51 @@
+# Scenario Step Tags and Annotations
+
+## Overview
+
+Large scenario files can sometimes become hard to reason about as steps accumulate. To add lightweight categorization and ownership metadata, `soroban-debugger` allows you to annotate scenario steps with tags and notes. 
+
+This enables you to clearly communicate which steps are meant for `setup`, `validation`, `smoke` testing, or are `expensive` / `release-critical`.
+
+## Syntax
+
+You can add `tags` (an array of strings) and `notes` (a string) to any `[[steps]]` block in your scenario TOML file.
+
+```toml
+[[steps]]
+name = "Initialize Environment"
+function = "init"
+tags = ["setup", "core"]
+notes = "This step must always run first to set the admin account."
+
+[[steps]]
+name = "Expensive Calculation"
+function = "compute"
+tags = ["expensive", "math"]
+notes = "Takes several seconds; excluded during fast CI runs."
+
+[[steps]]
+name = "Smoke Test Flow"
+function = "verify"
+tags = ["smoke"]
+```
+
+## Running Tagged Scenarios
+
+The `soroban-debug scenario` command includes two flags to filter the executed steps based on their tags:
+
+- `--tags <TAGS>`: Comma-separated list of tags. If provided, *only* steps containing at least one of these tags will be executed.
+- `--exclude-tags <TAGS>`: Comma-separated list of tags. If provided, steps containing *any* of these tags will be skipped.
+
+### Examples
+
+**Only run setup and smoke tests:**
+```bash
+soroban-debug scenario --scenario my_scenario.toml --contract my_contract.wasm --tags setup,smoke
+```
+
+**Run everything except expensive tests:**
+```bash
+soroban-debug scenario --scenario my_scenario.toml --contract my_contract.wasm --exclude-tags expensive
+```
+
+During execution, any skipped steps will be logged as skipped, and the notes and tags of executed steps will be cleanly printed to the console to improve operational visibility.

--- a/docs/state-fingerprints.md
+++ b/docs/state-fingerprints.md
@@ -1,0 +1,44 @@
+# State Fingerprints
+
+## Overview
+
+The runtime layer in `soroban-debugger` supports generating a deterministic state fingerprint for any given ledger state. The fingerprint provides a quick and stable way to determine if two states are equivalent without manual diffing.
+
+## Determinism
+
+The state fingerprint uniquely represents a given state and is stable across different runs. It avoids any non-deterministic ordering (such as the insertion order of maps) by sorting its data structures canonically before computing the hash.
+
+## What is Included
+
+The state fingerprint calculates a hash of the following data:
+
+1. **Ledger Metadata**: `sequence`, `timestamp`, and `network_passphrase`.
+2. **Accounts**: Each account is sorted alphabetically by `address`. The hash includes the address, balance, sequence, flags, and account data (key-value pairs, which are intrinsically sorted via `BTreeMap`).
+3. **Contracts**: Each contract is sorted alphabetically by `contract_id`. The hash includes the contract ID, wasm hash, wasm ref, and the full storage (key-value pairs, which are intrinsically sorted via `BTreeMap`).
+
+## How it is Generated
+
+1. A complete `NetworkSnapshot` copy is normalized by sorting the `accounts` and `contracts` slices.
+2. The normalized `NetworkSnapshot` is serialized into a compact, whitespace-insensitive JSON format using `serde_json`.
+3. A `SHA-256` hash is calculated over the resulting serialized JSON string.
+4. The final fingerprint is represented as a lower-case hex-encoded string.
+
+## How to use it for comparison
+
+You can retrieve the fingerprint of a snapshot by invoking the `fingerprint()` method on a `NetworkSnapshot` instance.
+
+```rust
+let snapshot = NetworkSnapshot::new(100, "Test Network", 1234567890);
+
+// Get the fingerprint:
+let fingerprint = snapshot.fingerprint();
+
+// Compare two states:
+if snapshot1.fingerprint() == snapshot2.fingerprint() {
+    println!("The states are identical!");
+} else {
+    println!("The states have differences.");
+}
+```
+
+This fingerprint will also automatically be displayed whenever two snapshots are diffed using `SnapshotManager::diff_snapshots` or `SnapshotDiff::format_summary()`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1400,6 +1400,14 @@ pub struct ScenarioArgs {
     /// Use 0 to disable the timeout entirely.
     #[arg(long)]
     pub timeout: Option<u64>,
+
+    /// Only run steps that have at least one of these tags (comma-separated)
+    #[arg(long)]
+    pub tags: Option<String>,
+
+    /// Skip steps that have any of these tags (comma-separated)
+    #[arg(long)]
+    pub exclude_tags: Option<String>,
 }
 
 /// Arguments for the doctor/health command

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -47,6 +47,8 @@ pub struct ScenarioStep {
     /// Later steps can reference the value using `{{var_name}}` in their `args` or
     /// `expected_return` fields.
     pub capture: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub notes: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -154,8 +156,37 @@ pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
     let mut all_passed = true;
     let mut variables: HashMap<String, String> = HashMap::new();
 
+    let include_tags: Option<Vec<String>> = args.tags.as_ref().map(|s| s.split(',').map(|t| t.trim().to_string()).collect());
+    let exclude_tags: Option<Vec<String>> = args.exclude_tags.as_ref().map(|s| s.split(',').map(|t| t.trim().to_string()).collect());
+
     for (i, step) in steps.iter().enumerate() {
         let step_label = step.name.as_deref().unwrap_or(&step.function);
+        
+        // Tag filtering logic
+        let step_tags = step.tags.as_deref().unwrap_or(&[]);
+        
+        // Skip if there are exclude tags and the step has any of them
+        if let Some(excludes) = &exclude_tags {
+            if step_tags.iter().any(|t| excludes.contains(t)) {
+                println!(
+                    "{}",
+                    Formatter::info(format!("Skipping Step {} ({}): excluded by tag", i + 1, step_label))
+                );
+                continue;
+            }
+        }
+        
+        // Skip if there are include tags and the step has none of them
+        if let Some(includes) = &include_tags {
+            if !step_tags.iter().any(|t| includes.contains(t)) {
+                println!(
+                    "{}",
+                    Formatter::info(format!("Skipping Step {} ({}): does not match included tags", i + 1, step_label))
+                );
+                continue;
+            }
+        }
+
         let effective_timeout = resolve_step_timeout(
             step.timeout_secs,
             root_scenario.defaults.timeout_secs,
@@ -166,6 +197,13 @@ pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
             "{}",
             Formatter::info(format!("Step {}: {}", i + 1, step_label))
         );
+
+        if let Some(notes) = &step.notes {
+            println!("  {}", Formatter::info(format!("Notes: {}", notes)));
+        }
+        if let Some(tags) = &step.tags {
+            println!("  {}", Formatter::info(format!("Tags: [{}]", tags.join(", "))));
+        }
 
         let resolved_args = if let Some(args_json) = &step.args {
             Some(interpolate_variables(args_json, &variables)?)
@@ -581,16 +619,23 @@ mod tests {
             [[steps]]
             function = "get"
             expected_return = "{{my_result}}"
+            tags = ["smoke", "fast"]
+            notes = "This step is important"
         "#;
 
         let scenario: Scenario = toml::from_str(toml_str).unwrap();
         assert_eq!(scenario.defaults, ScenarioDefaults::default());
         assert_eq!(scenario.steps[0].capture.as_deref(), Some("my_result"));
+        assert!(scenario.steps[0].tags.is_none());
+        assert!(scenario.steps[0].notes.is_none());
+        
         assert!(scenario.steps[1].capture.is_none());
         assert_eq!(
             scenario.steps[1].expected_return.as_deref(),
             Some("{{my_result}}")
         );
+        assert_eq!(scenario.steps[1].tags.as_deref(), Some(vec!["smoke".to_string(), "fast".to_string()].as_slice()));
+        assert_eq!(scenario.steps[1].notes.as_deref(), Some("This step is important"));
     }
 
     #[test]

--- a/src/simulator/snapshot.rs
+++ b/src/simulator/snapshot.rs
@@ -86,6 +86,10 @@ impl SnapshotManager {
 /// Represents the differences between two network snapshots
 #[derive(Debug, Clone)]
 pub struct SnapshotDiff {
+    /// State fingerprints
+    pub old_fingerprint: String,
+    pub new_fingerprint: String,
+
     /// Ledger sequence changes
     pub ledger_sequence_changed: bool,
     pub old_sequence: Option<u32>,
@@ -111,6 +115,8 @@ impl SnapshotDiff {
     /// Compute diff between two snapshots
     fn compute(before: &NetworkSnapshot, after: &NetworkSnapshot) -> Self {
         let mut diff = SnapshotDiff {
+            old_fingerprint: before.fingerprint(),
+            new_fingerprint: after.fingerprint(),
             ledger_sequence_changed: before.ledger.sequence != after.ledger.sequence,
             old_sequence: Some(before.ledger.sequence),
             new_sequence: Some(after.ledger.sequence),
@@ -214,6 +220,13 @@ impl SnapshotDiff {
     /// Format diff as human-readable string
     pub fn format_summary(&self) -> String {
         let mut output = String::new();
+
+        // Fingerprints
+        output.push_str(&format!(
+            "State Fingerprint: {} → {}\n",
+            self.old_fingerprint,
+            self.new_fingerprint
+        ));
 
         // Ledger changes
         if self.ledger_sequence_changed {

--- a/src/simulator/state.rs
+++ b/src/simulator/state.rs
@@ -159,6 +159,33 @@ impl NetworkSnapshot {
         self.ledger.validate()?;
         Ok(())
     }
+
+    /// Calculate a deterministic SHA-256 fingerprint of the current state.
+    /// This fingerprint uniquely represents the state and is stable across runs.
+    /// It is insensitive to the ordering of accounts and contracts.
+    pub fn fingerprint(&self) -> String {
+        // Create a normalized copy of the snapshot
+        let mut normalized = self.clone();
+        
+        // Sort accounts by address for determinism
+        normalized.accounts.sort_by(|a, b| a.address.cmp(&b.address));
+        
+        // Sort contracts by contract_id for determinism
+        normalized.contracts.sort_by(|a, b| a.contract_id.cmp(&b.contract_id));
+        
+        // Data maps (BTreeMap) and Storage maps (BTreeMap) are already sorted by keys.
+        // Serialize to compact JSON which does not rely on whitespace
+        let json = serde_json::to_string(&normalized).expect("Failed to serialize normalized state");
+        
+        // Compute SHA-256 hash
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(json.as_bytes());
+        let result = hasher.finalize();
+        
+        // Return as a hex string
+        hex::encode(result)
+    }
 }
 
 /// Ledger metadata (sequence, timestamp, network info)
@@ -421,5 +448,40 @@ mod tests {
             contract.get_storage("balance"),
             Some(&serde_json::json!(1000))
         );
+    }
+
+    #[test]
+    fn test_fingerprint_determinism() {
+        let mut snapshot1 = NetworkSnapshot::new(100, "Test Network", 1234567890);
+        let mut snapshot2 = NetworkSnapshot::new(100, "Test Network", 1234567890);
+
+        let acc1 = AccountState::new("GABCD123", "1000000", 1);
+        let acc2 = AccountState::new("GXYZ789", "500000", 2);
+
+        // Add in different order
+        snapshot1.add_account(acc1.clone()).unwrap();
+        snapshot1.add_account(acc2.clone()).unwrap();
+
+        snapshot2.add_account(acc2).unwrap();
+        snapshot2.add_account(acc1).unwrap();
+
+        let contract1 = ContractState::new("C111", "aaaa");
+        let contract2 = ContractState::new("C222", "bbbb");
+
+        // Add in different order
+        snapshot1.add_contract(contract1.clone()).unwrap();
+        snapshot1.add_contract(contract2.clone()).unwrap();
+
+        snapshot2.add_contract(contract2).unwrap();
+        snapshot2.add_contract(contract1).unwrap();
+
+        // The fingerprints should be exactly the same despite insertion order
+        assert_eq!(snapshot1.fingerprint(), snapshot2.fingerprint());
+
+        // Modify a state detail should change fingerprint
+        let mut snapshot3 = snapshot1.clone();
+        snapshot3.get_account_mut("GABCD123").unwrap().balance = "1000001".to_string();
+        
+        assert_ne!(snapshot1.fingerprint(), snapshot3.fingerprint());
     }
 }


### PR DESCRIPTION
## Summary

This PR implements two assigned issues as part of Drips Wave 4.

---

### Issue 1 — Deterministic State Fingerprints
Closes #859

- Added `fingerprint()` method to `NetworkSnapshot` (SHA-256, deterministic, insertion-order insensitive)
- Fingerprints are computed by sorting accounts and contracts canonically before hashing
- `SnapshotDiff` now computes and surfaces both `old_fingerprint` and `new_fingerprint` in diff summaries
- Added tests validating that identical states produce identical fingerprints and different states produce different fingerprints
- Created `docs/state-fingerprints.md`

---

### Issue 2 — Scenario Step Tags and Annotations
Closes #843

- Added optional `tags: Option<Vec<String>>` and `notes: Option<String>` fields to `ScenarioStep`
- Added `--tags` and `--exclude-tags` CLI flags to `ScenarioArgs` for runtime step filtering
- Steps with matching exclude tags are skipped; steps without matching include tags are skipped
- Tags and notes are printed during execution for operator visibility
- Added tests for tag/notes deserialization
- Created `docs/scenario-tags.md`
- Updated `README.md`
