### PR TITLE
docs: add VS Code setup and config guidance

### DIFF
--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -154,7 +154,7 @@ This matrix is derived from:
 
 Related CI contract checks:
 - Coverage enforcement in `.github/workflows/ci.yml` validates `cargo llvm-cov --json --summary-only` schema and requires `.data[0].totals.lines.percent` to exist as a numeric field.
-- Missing-field behavior is regression-tested by `bash scripts/check_benchmark_regressions.sh selftest-coverage-missing-field` to keep schema drift failures actionable.
+- Missing-field behavior is regression-tested by `bash scripts/check_benchmark_regressions.sh selftest-coverage-missing-field`; see [Benchmark regression policy](performance-regressions.md#coverage-parser-self-test) for the exact contract that self-test enforces.
 
 When adding a new CLI flag or DAP capability, update this file alongside the
 implementation to keep gaps explicit rather than implicit.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Welcome to the Soroban Debugger documentation. This index helps you navigate the
 ## 🏁 Getting Started
 - [Getting Started Guide](getting-started.md) — Your first steps with the debugger.
 - [First Debug Session](tutorials/first-debug.md) — A step-by-step walkthrough.
+- [VS Code Extension Setup](tutorials/vscode-extension-setup.md) — Install the extension, write `launch.json`, and set your first breakpoints.
 - [Installation Guide](installation.md) — Detailed installation instructions for all platforms.
 
 ## 🛠️ Core Features
@@ -39,5 +40,6 @@ Welcome to the Soroban Debugger documentation. This index helps you navigate the
 
 ## 📄 Reference
 - [CLI Command Index](cli-command-groups.md) — Detailed reference for all CLI subcommands.
+- [Benchmark Regression Policy](performance-regressions.md) — CI baseline comparison and coverage parser self-test behavior.
 - [Trace JSON Schema](trace-schema.md) — Format of exported execution traces.
 - [Plugin API](plugin-api.md) — Documentation for the debugger plugin system.

--- a/docs/performance-regressions.md
+++ b/docs/performance-regressions.md
@@ -46,3 +46,19 @@ cargo bench --benches -- --noplot
 cargo run --bin bench-regression -- compare --baseline .bench/baseline.json --criterion target/criterion
 ```
 
+## Coverage parser self-test
+
+The benchmark helper script also contains a schema-regression self-test for coverage parsing:
+
+```bash
+bash scripts/check_benchmark_regressions.sh selftest-coverage-missing-field
+```
+
+This mode does not run Criterion benchmarks. Instead, it feeds intentionally incomplete coverage JSON into `coverage-percent-from-json` and verifies two behaviors:
+
+- The parser exits with a failure when `.data[0].totals.lines.percent` is missing.
+- The error message explicitly names the missing numeric field so CI failures remain actionable when the `cargo llvm-cov --json --summary-only` schema drifts.
+
+Run this self-test when you change the coverage parsing logic, the CI workflow around coverage extraction, or the docs that describe the coverage contract. This is the self-test referenced in [Feature Matrix](feature-matrix.md#maintaining-this-document).
+
+`jq` must be available on `PATH`; the script will fail early if it is missing.

--- a/docs/tutorials/first-debug.md
+++ b/docs/tutorials/first-debug.md
@@ -87,7 +87,24 @@ soroban contract build
 
 Verify that your WASM file was generated at `target/wasm32-unknown-unknown/release/hello_world.wasm`. Because debug symbols are included, the file size will be significantly larger than a heavily optimized production build.
 
-## 4. Starting the Debugger
+## 4. Save Project Defaults in `.soroban-debug.toml`
+
+Before you start the debugger, add a project-local config file so repeated sessions keep the same defaults. Create `.soroban-debug.toml` in the project root:
+
+```toml
+[debug]
+breakpoints = ["increment"]
+verbosity = 1
+
+[output]
+show_events = true
+```
+
+The debugger loads this file automatically when it starts. It is a good place to keep default breakpoints, verbosity, and output settings that you want every contributor to share.
+
+If you prefer debugging from VS Code, keep this file alongside a `.vscode/launch.json` and follow [Set Up the VS Code Extension](vscode-extension-setup.md) for the editor-side setup.
+
+## 5. Starting the Debugger
 
 Launch the debugger and pass the path to your compiled WASM file.
 
@@ -104,7 +121,7 @@ Debug symbols loaded successfully.
 
 You are now in the interactive debugging prompt. Type `help` to see all available basic debugger commands (`run`, `step`, `next`, `break`, `print`, `storage`).
 
-## 5. Setting Breakpoints
+## 6. Setting Breakpoints
 
 Before running the contract, we need to tell the debugger where to pause execution. You can set breakpoints by function name or by file and line number.
 
@@ -122,7 +139,7 @@ Breakpoint 1 set at src/lib.rs:13
 ![Setting a Breakpoint](./images/debugger-breakpoint.png)
 *(Screenshot: Terminal showing the breakpoint confirmation and the interactive prompt)*
 
-## 6. Running and Stepping Through Code
+## 7. Running and Stepping Through Code
 
 To trigger the execution, we use the `invoke` command, simulating a call to the contract.
 
@@ -146,7 +163,7 @@ Execute the current line and move to the next one using the `next` (or `n`) comm
 (soroban-debug) next
 ```
 
-## 7. Inspecting Storage and Variables
+## 8. Inspecting Storage and Variables
 
 Now that we have stepped past line 13, the `count` variable has been initialized. Let's inspect it using the `print` command:
 
@@ -216,4 +233,4 @@ Return value: U32(1)
 * **Host Environment:** The debugger runs a mock Soroban environment. State does not persist between `soroban-debugger` CLI sessions unless you export the ledger state to a JSON file.
 
 ---
-*Return to the [Docs Index](../../README.md) for more tutorials.*
+*Return to the [Docs Index](../index.md) for more tutorials.*

--- a/docs/tutorials/vscode-extension-setup.md
+++ b/docs/tutorials/vscode-extension-setup.md
@@ -1,0 +1,114 @@
+# Tutorial: Set Up the VS Code Extension
+
+This tutorial walks through the full VS Code debugger setup: install the extension, create a `launch.json`, place breakpoints in Rust source, and start a Soroban debug session without leaving the editor.
+
+## Prerequisites
+
+- VS Code installed locally.
+- A Soroban contract workspace with a compiled WASM artifact that still contains debug symbols.
+- The `soroban-debug` CLI available either on your `PATH` or built in this repository at `target/debug/soroban-debug`.
+
+If you have not built a debug-friendly contract yet, start with [First Debug Session](first-debug.md) and return here once you have a `.wasm` file under `target/wasm32-unknown-unknown/release/`.
+
+## 1. Install the extension
+
+The repository currently documents a local install flow based on a packaged VSIX.
+
+Build the extension from the repository:
+
+```bash
+cd extensions/vscode
+npm install
+npm run build
+vsce package
+```
+
+This produces a file named `soroban-debugger-<VERSION>.vsix`.
+
+Install that VSIX in VS Code:
+
+1. Open VS Code.
+2. Open the Extensions view.
+3. Run `Extensions: Install from VSIX...` from the Command Palette.
+4. Select the generated `soroban-debugger-<VERSION>.vsix` file.
+
+For extension internals and the full argument reference, see the [VS Code extension README](../../extensions/vscode/README.md).
+
+## 2. Create `.vscode/launch.json`
+
+Create a `.vscode/launch.json` file in your contract workspace:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Soroban: Debug hello_world",
+      "type": "soroban",
+      "request": "launch",
+      "contractPath": "${workspaceFolder}/target/wasm32-unknown-unknown/release/hello_world.wasm",
+      "snapshotPath": "${workspaceFolder}/snapshot.json",
+      "entrypoint": "increment",
+      "args": [],
+      "trace": false
+    }
+  ]
+}
+```
+
+Adjust these fields for your project:
+
+- `contractPath`: compiled contract you want to debug.
+- `entrypoint`: exported Soroban function to invoke.
+- `args`: JSON-compatible argument list passed to that entrypoint.
+- `binaryPath`: add this only when the adapter cannot find `soroban-debug` on your `PATH`, for example when you want VS Code to use a specific local build of the CLI.
+
+`.soroban-debug.toml` complements `launch.json`; use the TOML file for shared debugger defaults such as breakpoints or output behavior, and `launch.json` for VS Code session wiring.
+
+## 3. Validate the launch configuration
+
+Before starting a session, run the built-in preflight check:
+
+1. Open the Command Palette.
+2. Run `Soroban: Run Launch Preflight Check`.
+3. Pick the Soroban launch configuration you just created.
+
+Use this whenever you change `contractPath`, `binaryPath`, or argument structure. The preflight check catches invalid launch settings before the adapter starts.
+
+## 4. Set breakpoints in Rust source
+
+Open the Rust file that corresponds to the contract you want to debug, for example `contracts/hello_world/src/lib.rs`.
+
+Set breakpoints in the editor gutter on executable lines such as:
+
+- The first line inside `increment`.
+- The storage write line where state changes are committed.
+
+You can confirm the breakpoints in the **Run and Debug** panel before you launch the session.
+
+If a breakpoint stays gray or shows as unverified:
+
+1. Open the file where the breakpoint is set.
+2. Run `Soroban: Diagnose Source Maps for Current File`.
+3. Move the breakpoint to the nearest executable statement if the diagnostic reports a source-mapping gap.
+
+## 5. Start the session and inspect state
+
+Start the `Soroban: Debug hello_world` configuration from the **Run and Debug** view.
+
+When execution stops at a breakpoint:
+
+- Use `F10`, `F11`, and `Shift+F11` for stepping.
+- Inspect storage and locals in the **Variables** panel.
+- Review the call stack in the **Call Stack** panel.
+- Watch adapter output in the **Debug Console** if you enabled `"trace": true`.
+
+## 6. Keep the setup repeatable
+
+Store editor-specific session settings in `.vscode/launch.json`, and keep repo-wide debugger defaults in `.soroban-debug.toml`. That split keeps the VS Code adapter configuration explicit while still giving new contributors sensible defaults when they start with the CLI.
+
+Next steps:
+
+- [First Debug Session](first-debug.md) for the CLI-first walkthrough.
+- [Breakpoints Reference](../breakpoints.md) for source and function breakpoint behavior.
+- [VS Code extension README](../../extensions/vscode/README.md) for the full launch/attach schema.

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -66,6 +66,8 @@ The extension will be published to the VS Code Marketplace. Once available, sear
 
 ## Quick Start
 
+For an end-to-end setup walkthrough, including extension installation, `.vscode/launch.json`, and first breakpoints, see [docs/tutorials/vscode-extension-setup.md](../../docs/tutorials/vscode-extension-setup.md).
+
 ### 1. Create a Debug Configuration
 
 Add the following to your project's `.vscode/launch.json`:


### PR DESCRIPTION
## Summary
- add a new VS Code setup tutorial covering extension install, launch.json, preflight, and breakpoints
- introduce  early in the first debug tutorial and cross-link the new VS Code guide
- document the coverage parser self-test and wire related docs links so the docs tree stays consistent

## Testing
- Not run (per request)

Closes #958
Closes #952
Closes #951