### PR TITLE
docs: make Epic J roadmap easier to execute

### DIFF
--- a/docs/issues/backlog-100-issues.md
+++ b/docs/issues/backlog-100-issues.md
@@ -22,7 +22,19 @@
 
 ---
 
+## Planning Workflow
+
+Use this file as the inventory, then move into the roadmap for execution decisions:
+
+1. Read the relevant section here to understand the raw issue list and context.
+2. Switch to [roadmap-priorities.md](roadmap-priorities.md#section-rollup) for the section rollup, then use the [Priority Table](roadmap-priorities.md#priority-table) and [Wave Plan](roadmap-priorities.md#wave-plan) to decide sequencing.
+3. When editing this backlog, update the corresponding roadmap row in the same commit so the two files stay in sync.
+
+---
+
 ## Section A — README and Landing Docs (Issues 1–12)
+
+Roadmap view: [Section A priorities](roadmap-priorities.md#section-a--readme-and-landing-docs)
 
 - **I-001** `[IA]` README table of contents is missing; readers must scroll through 420 lines to locate sections.
 - **I-002** `[DOC]` README "Troubleshooting" table has only 3 rows; the full list lives in `docs/remote-troubleshooting.md` without a cross-link from the table.
@@ -41,6 +53,8 @@
 
 ## Section B — Architecture and Design Docs (Issues 13–22)
 
+Roadmap view: [Section B priorities](roadmap-priorities.md#section-b--architecture-and-design-docs)
+
 - **I-013** `[DOC]` `ARCHITECTURE.md` describes `Stepper` as "(Planned)" with no follow-up issue or tracking link; its current implementation status is unknown.
 - **I-014** `[DOC]` `ARCHITECTURE.md` "Extension Points" section lists four items but omits the plugin system, remote server, and batch executor — all of which now exist.
 - **I-015** `[DOC]` No architecture-level doc covers the VS Code extension / DAP adapter; `ARCHITECTURE.md` only covers the Rust CLI.
@@ -55,6 +69,8 @@
 ---
 
 ## Section C — Feature Reference Docs (Issues 23–40)
+
+Roadmap view: [Section C priorities](roadmap-priorities.md#section-c--feature-reference-docs)
 
 - **I-023** `[DOC]` `docs/instruction-stepping.md` (11 KB) covers the feature thoroughly but has no link back to the feature matrix — readers don't know which surfaces support it.
 - **I-024** `[DOC]` `docs/remote-debugging.md` covers TLS setup but doesn't show a complete `launch.json` snippet for the VS Code attach flow.
@@ -79,6 +95,8 @@
 
 ## Section D — Tutorials (Issues 41–52)
 
+Roadmap view: [Section D priorities](roadmap-priorities.md#section-d--tutorials)
+
 - **I-041** `[DOC]` `docs/tutorials/first-debug.md` doesn't reference the `.soroban-debug.toml` config file, which new users would benefit from knowing about early.
 - **I-042** `[DOC]` `docs/tutorials/scenario-runner.md` shows TOML structure but doesn't document all TOML keys (e.g., `timeout`, `expected_events`, `skip`).
 - **I-043** `[DOC]` `docs/tutorials/debug-auth-errors.md` has empty checkbox items that suggest the tutorial is incomplete.
@@ -95,6 +113,8 @@
 ---
 
 ## Section E — Contributor Workflow (Issues 53–70)
+
+Roadmap view: [Section E priorities](roadmap-priorities.md#section-e--contributor-workflow)
 
 - **I-053** `[CONTRIB]` `CONTRIBUTING.md` says "Check the issue tracker for open issues and labels like `good first issue`" but doesn't link to the actual filtered GitHub URL.
 - **I-054** `[CONTRIB]` `CONTRIBUTING.md` "Areas for Contribution" lists items in free text; it should link to concrete open GitHub issues or project board columns.
@@ -119,6 +139,8 @@
 
 ## Section F — Release Operations (Issues 71–82)
 
+Roadmap view: [Section F priorities](roadmap-priorities.md#section-f--release-operations)
+
 - **I-071** `[RELEASE]` `docs/release-checklist.md` requires `CHANGELOG.md` to be updated but provides no example entry format, no link to `cliff.toml`, and no `git-cliff` invocation command.
 - **I-072** `[RELEASE]` The release checklist sign-off section uses `@____` placeholder syntax; there is no documented process for assigning owners before a release cycle begins.
 - **I-073** `[RELEASE]` The benchmark threshold (10%/20%) is hardcoded in the release checklist but the actual values are also set in CI scripts — the two can drift without detection.
@@ -136,6 +158,8 @@
 
 ## Section G — Repo Health and Meta (Issues 83–93)
 
+Roadmap view: [Section G priorities](roadmap-priorities.md#section-g--repo-health-and-meta)
+
 - **I-083** `[META]` Several implementation-summary files (`BATCH_EXECUTION_SUMMARY.md`, `IMPLEMENTATION_SUMMARY.md`, `PLUGIN_RELOAD_DIFF_IMPLEMENTATION.md`, `FLAMEGRAPH_IMPLEMENTATION.md`) live in the root and appear to be one-off delivery notes rather than living documentation; a policy for these files is needed.
 - **I-084** `[META]` `PR_DESCRIPTION.md` lives in the repo root — it appears to be a leftover from a PR and should be removed or archived.
 - **I-085** `[META]` No `SECURITY.md` file exists; GitHub displays a warning and security researchers have no disclosed contact point.
@@ -151,6 +175,8 @@
 ---
 
 ## Section H — DX and Tooling Quality (Issues 94–100)
+
+Roadmap view: [Section H priorities](roadmap-priorities.md#section-h--dx-and-tooling-quality)
 
 - **I-094** `[DX]` `docs/getting-started.md` (3001 bytes) is the natural entry point for new users but is not linked from the README "Quick Start" section.
 - **I-095** `[DX]` The `feature-matrix.md` "Maintaining This Document" section tells editors which source files to check but doesn't describe a process to detect drift (e.g., a CI check that flags undocumented flags).

--- a/docs/issues/roadmap-priorities.md
+++ b/docs/issues/roadmap-priorities.md
@@ -23,6 +23,25 @@
 
 ---
 
+## Section Rollup
+
+Use this table before you dive into the 100-row priority matrix. It gives each
+backlog section a recommended entry point so maintainers can open issues in a
+useful order instead of re-triaging the whole epic every time.
+
+| Section | Backlog slice | Planning focus | Start with | Why this is the entry point |
+|---------|---------------|----------------|------------|-----------------------------|
+| **A** | [README and Landing Docs](backlog-100-issues.md#section-a--readme-and-landing-docs) | New-user discoverability and release-facing repo hygiene | `I-009`, then `I-007` | `I-009` is a P0 FAQ gap; `I-007` unlocks several later navigation fixes. |
+| **B** | [Architecture and Design Docs](backlog-100-issues.md#section-b--architecture-and-design-docs) | Fill missing system-shape docs before dependent tutorials land | `I-015` | The VS Code / DAP architecture doc unblocks `I-024` and `I-048`. |
+| **C** | [Feature Reference Docs](backlog-100-issues.md#section-c--feature-reference-docs) | Close reference gaps that affect discoverability and advanced workflows | `I-023`, then `I-030` | `I-023` is a fast cross-link win; `I-030` unlocks plugin tutorial work. |
+| **D** | [Tutorials](backlog-100-issues.md#section-d--tutorials) | Repair broken learning paths, then add missing workflows | `I-043`, then `I-046` | `I-043` is the only P0 in this section; `I-046` improves tutorial discoverability immediately. |
+| **E** | [Contributor Workflow](backlog-100-issues.md#section-e--contributor-workflow) | Remove contributor blockers, then formalize process | `I-058`, then `I-053` | `I-058` fixes a missing referenced file; `I-053` is an easy on-ramp for contribution flow. |
+| **F** | [Release Operations](backlog-100-issues.md#section-f--release-operations) | Establish release-critical documentation before automation depth | `I-071` | It is P0 and also unblocks follow-on `git-cliff` docs in contributor guidance. |
+| **G** | [Repo Health and Meta](backlog-100-issues.md#section-g--repo-health-and-meta) | Clean repo-level trust and navigation issues | `I-085`, then `I-083` | `I-085` is security-critical; `I-083` prevents future root-level doc sprawl. |
+| **H** | [DX and Tooling Quality](backlog-100-issues.md#section-h--dx-and-tooling-quality) | Improve entry points first, then automate drift detection | `I-094` | It is a P0 fix on the primary onboarding path and is independent of later tooling work. |
+
+---
+
 ## Priority Table
 
 ### Section A — README and Landing Docs
@@ -314,3 +333,11 @@ acceptance criteria.
 5. **Review this file** at the end of each wave — demote any issues that turn out
    to be lower value than expected, and promote anything the wave work revealed
    as higher priority.
+
+---
+
+## Maintenance Rules
+
+1. When adding or removing an issue in [backlog-100-issues.md](backlog-100-issues.md), update the matching roadmap row in the same commit.
+2. Keep the short title in this file close to the backlog wording so maintainers can grep for an ID and compare the two documents quickly.
+3. When a dependency changes, update both the `Depends on` column and the relevant wave summary so the wave plan stays executable rather than historical.


### PR DESCRIPTION
## Summary
- add a section rollup to the Epic J roadmap so maintainers have a clear start-here view by backlog section
- add maintenance rules to keep the backlog and roadmap in sync as issues change
- add backlog-side planning guidance and direct roadmap links for each section

## Testing
- Not run (per request)

Closes #894