### PR TITLE
docs: enhance scenario runner, fix auth tutorial checklist and link contribution areas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,7 +273,7 @@ Tips:
 
 ## Claiming and Working on Issues
 
-- Check the issue tracker for open issues and labels like `good first issue` or `help wanted`.
+- Check the [issue tracker](https://github.com/Timi16/soroban-debugger/issues) for open issues and labels like [good first issue](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) or [help wanted](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 - Before starting, comment on the issue to say you want to work on it.
 - If an issue is already assigned, coordinate in the thread before beginning work.
 - Keep one issue per PR when possible, and link the PR to the issue.
@@ -349,22 +349,22 @@ When suggesting a feature, please include:
 We welcome contributions in the following areas:
 
 **Current Focus:**
-- CLI improvements
-- Enhanced error messages
-- Storage inspection
-- Budget tracking
+- [CLI improvements](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3ACLI)
+- [Enhanced error messages](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3A%22error+messages%22)
+- [Storage inspection](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Astorage)
+- [Budget tracking](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Abudget)
 
 **Upcoming:**
-- Breakpoint management
-- Terminal UI enhancements
-- Call stack visualization
-- Execution replay
+- [Breakpoint management](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Abreakpoints)
+- [Terminal UI enhancements](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3ATUI)
+- [Call stack visualization](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3A%22call+stack%22)
+- [Execution replay](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Areplay)
 
 **Future:**
-- WASM instrumentation
-- Source map support
-- Memory profiling
-- Performance analysis
+- [WASM instrumentation](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Ainstrumentation)
+- [Source map support](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3A%22source+maps%22)
+- [Memory profiling](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Aprofiling)
+- [Performance analysis](https://github.com/Timi16/soroban-debugger/issues?q=is%3Aopen+is%3Aissue+label%3Aperformance)
 
 If you have ideas outside these areas, feel free to discuss them by opening an issue.
 

--- a/docs/tutorials/debug-auth-errors.md
+++ b/docs/tutorials/debug-auth-errors.md
@@ -479,12 +479,12 @@ soroban-debug run \
 
 Before deploying your contract, verify:
 
-- [ ] All state-modifying functions check authorization
-- [ ] The correct address is verified (sender, not recipient)
-- [ ] Admin functions verify caller is admin
-- [ ] Cross-contract calls propagate authorization
-- [ ] Tests verify auth is actually enforced (don't just use `mock_all_auths()`)
-- [ ] Error messages are clear about which auth failed
+- [x] All state-modifying functions check authorization
+- [x] The correct address is verified (sender, not recipient)
+- [x] Admin functions verify caller is admin
+- [x] Cross-contract calls propagate authorization
+- [x] Tests verify auth is actually enforced (don't just use `mock_all_auths()`)
+- [x] Error messages are clear about which auth failed
 
 ## Best Practices
 

--- a/docs/tutorials/scenario-runner.md
+++ b/docs/tutorials/scenario-runner.md
@@ -36,10 +36,18 @@ Each step in a scenario supports the following fields:
 |-------|------|----------|-------------|
 | `name` | String | Optional | Human-readable name for the step (defaults to function name) |
 | `function` | String | Required | Name of the contract function to call |
-| `args` | String | Optional | JSON array of arguments to pass to the function |
-| `timeout_secs` | Integer | Optional | Per-step execution timeout override in seconds. `0` disables the timeout |
-| `expected_return` | String | Optional | Expected return value (string comparison) |
+| `args` | String | Optional | JSON array of arguments to pass to the function. Supports `{{var}}` interpolation. |
+| `timeout_secs` | Integer | Optional | Per-step execution timeout override in seconds (alias: `timeout`). `0` disables the timeout |
+| `expected_return` | String | Optional | Expected return value (string comparison). Supports `{{var}}` interpolation. |
 | `expected_storage` | Table | Optional | Map of storage keys to expected values |
+| `expected_events` | Array | Optional | List of event assertions (see [Event Assertions](#event-assertions)) |
+| `expected_error` | String | Optional | Expected error message substring (if the step should fail) |
+| `expected_panic` | String | Optional | Expected panic message substring (if the step should panic) |
+| `capture` | String | Optional | Variable name to store the return value for use in later steps |
+| `tags` | Array | Optional | List of category tags for filtering (see [Scenario Tags](../scenario-tags.md)) |
+| `notes` | String | Optional | Documentation note for the step |
+| `skip` | Boolean | Optional | If `true`, the step is skipped during execution |
+| `budget_limits` | Table | Optional | Max budget constraints (see [Budget Limits](#budget-limits)) |
 
 ### Timeout Defaults and Overrides
 
@@ -66,6 +74,42 @@ The `expected_storage` field uses TOML table syntax:
 ```
 
 **Note**: Storage keys and values are compared as strings after trimming whitespace.
+
+### Event Assertions
+
+The `expected_events` field allows you to verify contract events:
+
+```toml
+[[steps.expected_events]]
+topics = ["TOPIC_1", "TOPIC_2"]
+data = "EXPECTED_DATA"
+contract_id = "OPTIONAL_CONTRACT_ID"
+```
+
+### Budget Limits
+
+You can enforce resource limits on a per-step basis:
+
+```toml
+[steps.budget_limits]
+max_cpu_instructions = 1000000
+max_memory_bytes = 1048576
+```
+
+### Variables and Capturing
+
+You can capture a return value and use it in subsequent steps:
+
+```toml
+[[steps]]
+function = "get_id"
+capture = "my_id"
+
+[[steps]]
+function = "process"
+args = '["{{my_id}}", 100]'
+expected_return = "{{my_id}}"
+```
 
 ## Complete Worked Example
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -26,6 +26,7 @@ pub struct Scenario {
 
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ScenarioDefaults {
+    #[serde(alias = "timeout")]
     pub timeout_secs: Option<u64>,
 }
 
@@ -34,6 +35,7 @@ pub struct ScenarioStep {
     pub name: Option<String>,
     pub function: String,
     pub args: Option<String>,
+    #[serde(alias = "timeout")]
     pub timeout_secs: Option<u64>,
     pub expected_return: Option<String>,
     pub expected_storage: Option<HashMap<String, String>>,
@@ -49,6 +51,8 @@ pub struct ScenarioStep {
     pub capture: Option<String>,
     pub tags: Option<Vec<String>>,
     pub notes: Option<String>,
+    #[serde(default)]
+    pub skip: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -185,6 +189,14 @@ pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
                 );
                 continue;
             }
+        }
+
+        if step.skip {
+            println!(
+                "{}",
+                Formatter::info(format!("Skipping Step {} ({}): skip field set to true", i + 1, step_label))
+            );
+            continue;
         }
 
         let effective_timeout = resolve_step_timeout(
@@ -636,6 +648,23 @@ mod tests {
         );
         assert_eq!(scenario.steps[1].tags.as_deref(), Some(vec!["smoke".to_string(), "fast".to_string()].as_slice()));
         assert_eq!(scenario.steps[1].notes.as_deref(), Some("This step is important"));
+    }
+
+    #[test]
+    fn test_skip_field_deserialization() {
+        let toml_str = r#"
+            [[steps]]
+            function = "skipped"
+            skip = true
+
+            [[steps]]
+            function = "run"
+            skip = false
+        "#;
+
+        let scenario: Scenario = toml::from_str(toml_str).unwrap();
+        assert!(scenario.steps[0].skip);
+        assert!(!scenario.steps[1].skip);
     }
 
     #[test]


### PR DESCRIPTION


## Description
This PR addresses several documentation gaps and improves the contributor workflow by resolving issues #953, #954, #963, and #964.

### Key Changes

#### 1. Scenario Runner Enhancements & Documentation
- **Implemented `skip` field**: Added support for a `skip` boolean in scenario TOML steps to allow developers to bypass specific test steps.
- **Added `timeout` alias**: Added a `timeout` alias for the `timeout_secs` field to match CLI terminology.
- **Comprehensive Docs**: Updated the Scenario Runner tutorial to include previously undocumented keys: `expected_events`, `budget_limits`, `capture`, `tags`, `notes`, and the new `skip` field.
- **Closes #953**

#### 2. Auth Tutorial Polish
- **Checklist Completion**: Completed the "Authorization Checklist" checkboxes in the `debug-auth-errors.md` tutorial to ensure the guide looks polished and complete to end-users.
- **Closes #954**

#### 3. Contributor Workflow Improvements
- **"Good First Issue" Linking**: Added a direct, filtered GitHub URL for `good first issue` and `help wanted` labels to lower the barrier for new contributors.
- **Closes #963**
- **Contribution Area Deep Links**: Converted the free-text "Areas for Contribution" list into a series of links to filtered GitHub issues, helping contributors find relevant tasks faster.
- **Closes #964**

## Verification Results
- Verified that `cargo check` passes for the library with the new `skip` field and `serde` aliases.
- Manually reviewed all documentation changes for formatting and link accuracy.
