### PR TITLE
docs: add DWARF-absent heuristic fallback and --mock flag coverage

### DIFF
--- a/docs/debug-cross-contract.md
+++ b/docs/debug-cross-contract.md
@@ -176,7 +176,80 @@ Event: "incremented" = 6
 
 ---
 
-## 8. Git Workflow
+## 8. Isolating Cross-Contract Calls with `--mock`
+
+When debugging the caller contract in isolation, you often do not want the callee contract to execute for real — either because it is not deployed locally, its side-effects interfere with the test, or you simply want to focus on the caller's logic. The `--mock` flag lets you intercept any cross-contract call and return a fixed value instead.
+
+### Syntax
+
+```bash
+soroban-debugger <contract.wasm> --function <fn> \
+  --mock "<CONTRACT_ID>.<function>=<return_value>"
+```
+
+The flag is repeatable. Each `--mock` entry specifies:
+
+| Part | Description |
+|---|---|
+| `CONTRACT_ID` | The contract address whose calls you want to intercept. |
+| `function` | The specific function name on that contract to mock. |
+| `return_value` | The value the mock returns to the caller, expressed as a Soroban-compatible literal. |
+
+### Example: mock the callee during caller debugging
+
+```bash
+soroban-debugger examples/contracts/cross-contract/caller_contract.wasm \
+  --function call_increment \
+  --mock "CALLEE_CONTRACT_ID.increment=7"
+```
+
+With this command, any call from `CallerContract` to `CalleeContract::increment` is intercepted and returns `7` immediately — the callee WASM never executes.
+
+### Mocking multiple callees
+
+```bash
+soroban-debugger caller_contract.wasm --function call_increment \
+  --mock "CONTRACT_A.increment=7" \
+  --mock "CONTRACT_B.get_price=100"
+```
+
+### Mock call log
+
+After the session completes, the debugger prints a **Mock Contract Calls** log summarising every cross-contract call observed during execution and whether it was intercepted (`MOCKED`) or passed through to the real contract (`REAL`):
+
+```
+--- Mock Contract Calls ---
+1. MOCKED  CALLEE_CONTRACT_ID increment (args: [5]) -> 7
+2. REAL    OTHER_CONTRACT_ID  other_fn  (args: [])  -> 42
+```
+
+This log helps you verify that mocked call sites were actually reached during the debug session.
+
+### VS Code launch configuration
+
+In `.vscode/launch.json`, pass mocks via the `mock` array:
+
+```json
+{
+  "type": "soroban-debugger",
+  "request": "launch",
+  "mock": [
+    "CALLEE_CONTRACT_ID.increment=7"
+  ]
+}
+```
+
+### When to use `--mock`
+
+* The callee contract binary is not available locally.
+* You want deterministic callee responses to reproduce a specific caller code path.
+* You are writing unit-style debugging sessions focused on a single contract boundary.
+
+For more advanced mock patterns (storage setup, event expectations), see [mock-helpers.md](mock-helpers.md).
+
+---
+
+## 9. Git Workflow
 
 ```bash
 git checkout -b docs/tutorial-cross-contract
@@ -190,7 +263,7 @@ git push origin docs/tutorial-cross-contract
 
 ---
 
-## 9. Next Steps
+## 10. Next Steps
 
 * Try nested cross-contract calls and watch the stack grow.
 * Add more complex callee logic and test how the caller handles it.

--- a/docs/source-level-debugging.md
+++ b/docs/source-level-debugging.md
@@ -21,6 +21,48 @@ Soroban contracts are compiled from Rust to WebAssembly (WASM). While debugging 
 - **Caching**: Performance optimized with file and mapping caches.
 - **Fallback & Diagnostics**: Graceful fallback to WASM-only view if debug info is missing or stripped. When DWARF metadata is partially malformed, `SourceMap::load` continues to extract valid data and surfaces parsing errors as warnings (`SourceMapDiagnostic`) rather than completely aborting. These diagnostics can be reviewed using `inspect`.
 
+## When DWARF Is Absent: Heuristic Fallback
+
+Production Soroban WASM binaries are commonly stripped of debug symbols to reduce size. When the debugger cannot find valid DWARF sections in the binary, it does not fail outright — it switches to a heuristic fallback mode.
+
+### What the heuristic fallback does
+
+Instead of using DWARF to map instruction offsets to source lines, the debugger falls back to **function-level mapping**: it identifies exported contract entrypoint functions from the WASM export table and maps breakpoints to those function boundaries.
+
+This means:
+
+- **Source breakpoints become function breakpoints.** A breakpoint set on `src/lib.rs:10` will be matched heuristically to the nearest exported function that contains that line (if one can be inferred). Execution still pauses, but at the function entry rather than at the exact line.
+- **Step-by-step source navigation is unavailable.** The Source pane falls back to a WASM instruction view because there are no line mappings to follow.
+- **The `HEURISTIC_NO_DWARF` reason code is set.** When the VS Code adapter reports breakpoint status, it uses `verified=false` and `reasonCode=HEURISTIC_NO_DWARF` to signal that the mapping is approximate.
+
+### Breakpoint response fields under heuristic fallback
+
+| Field | Value | Meaning |
+|---|---|---|
+| `verified` | `false` | No exact source-to-runtime proof was available. |
+| `reasonCode` | `HEURISTIC_NO_DWARF` | DWARF was absent; heuristic function mapping was used instead. |
+| `setBreakpoint` | `true` (if matched) | A runtime function breakpoint was still installed. |
+
+### How to get full source-level debugging
+
+Compile your contract with debug symbols:
+
+```bash
+cargo build   # debug build retains DWARF by default
+```
+
+Avoid passing `--release` or running `wasm-opt` on the binary you intend to debug, as both strip or alter debug sections.
+
+### Diagnosing fallback mode
+
+Run `inspect` on the binary to see which fallback mode the debugger will use and whether any partial DWARF data was recoverable:
+
+```text
+inspect <contract.wasm>
+```
+
+The output includes a source-map health summary that reports mapping coverage and the active fallback mode. See also [source-map-health.md](source-map-health.md) and the [FAQ entry on `verified=false` breakpoints](faq.md).
+
 ## Limitations
 
 - **Stripped Binaries**: Production Soroban WASM files are often stripped to save space. Debug info is only available in binaries compiled with debug symbols (e.g., `cargo build`).


### PR DESCRIPTION
## Summary

- **`docs/source-level-debugging.md`**: Adds a dedicated *"When DWARF Is Absent: Heuristic Fallback"* section that explains what the debugger does when DWARF debug info is missing from a binary — heuristic function-level mapping, the `HEURISTIC_NO_DWARF` reason code, breakpoint response fields (`verified`, `reasonCode`, `setBreakpoint`), how to compile with debug symbols, and how to use `inspect` to diagnose fallback mode. This brings the reference doc in line with the existing FAQ entry on the same topic.
- **`docs/debug-cross-contract.md`**: Adds section 8 *"Isolating Cross-Contract Calls with `--mock`"* covering the flag syntax, a worked example mocking `CalleeContract::increment`, multi-callee mocking, the mock call log output, the VS Code `launch.json` configuration, and guidance on when to reach for this flag. References `mock-helpers.md` for advanced patterns. Subsequent sections renumbered accordingly.

## Test plan

- [ ] Review `docs/source-level-debugging.md` — new section appears after *Requirements & Implementation*, cross-links to `source-map-health.md` and `faq.md` are valid.
- [ ] Review `docs/debug-cross-contract.md` — new section 8 appears between *Key Takeaways* and *Git Workflow*, examples match the `--mock CONTRACT_ID.function=value` format documented in `src/cli/args.rs` and exercised in `tests/cli/output_tests.rs`.
- [ ] Confirm no other docs reference the old section numbering of `debug-cross-contract.md` in a way that is now broken.

closes #948
closes #949