### PR TITLE
Add budget deltas summary to normal output

### DIFF
--- a/src/inspector/budget.rs
+++ b/src/inspector/budget.rs
@@ -6,6 +6,24 @@ use std::collections::VecDeque;
 /// Tracks resource usage (CPU and memory budget)
 pub struct BudgetInspector;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetDelta {
+    pub cpu_delta: u64,
+    pub mem_delta: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetDeltaCheckpoint {
+    /// Index into the original checkpoints slice (for correlation/debugging)
+    pub index: usize,
+    pub timestamp_ms: u64,
+    pub location_name: String,
+    pub cpu_total: u64,
+    pub mem_total: u64,
+    pub cpu_delta: u64,
+    pub mem_delta: u64,
+}
+
 impl BudgetInspector {
     /// Get CPU instruction usage from host
     pub fn get_cpu_usage(host: &Host) -> BudgetInfo {
@@ -179,6 +197,66 @@ impl BudgetInspector {
             location_name: location,
         }
     }
+
+    /// Convert a raw checkpoint timeline into per-checkpoint deltas.
+    ///
+    /// The returned vector has length `timeline.len().saturating_sub(1)` and
+    /// each element represents the delta from `timeline[i-1]` to `timeline[i]`.
+    pub fn deltas_from_checkpoints(timeline: &[ResourceCheckpoint]) -> Vec<BudgetDeltaCheckpoint> {
+        if timeline.len() < 2 {
+            return Vec::new();
+        }
+
+        let mut out = Vec::with_capacity(timeline.len().saturating_sub(1));
+        for (idx, window) in timeline.windows(2).enumerate() {
+            let prev = &window[0];
+            let curr = &window[1];
+            out.push(BudgetDeltaCheckpoint {
+                index: idx + 1,
+                timestamp_ms: curr.timestamp_ms,
+                location_name: curr.location_name.clone(),
+                cpu_total: curr.cpu_instructions,
+                mem_total: curr.memory_bytes,
+                cpu_delta: curr.cpu_instructions.saturating_sub(prev.cpu_instructions),
+                mem_delta: curr.memory_bytes.saturating_sub(prev.memory_bytes),
+            });
+        }
+        out
+    }
+
+    /// Return the top-N checkpoints by CPU delta, memory delta, and a combined score.
+    ///
+    /// Combined score is a simple ranker intended for "spike triage" in normal output:
+    /// \(score = cpu_delta + mem_delta\).
+    pub fn top_spikes(
+        deltas: &[BudgetDeltaCheckpoint],
+        top_n: usize,
+    ) -> BudgetSpikeSummary {
+        let mut by_cpu: Vec<BudgetDeltaCheckpoint> = deltas.to_vec();
+        by_cpu.sort_by_key(|d| std::cmp::Reverse(d.cpu_delta));
+        by_cpu.truncate(top_n);
+
+        let mut by_mem: Vec<BudgetDeltaCheckpoint> = deltas.to_vec();
+        by_mem.sort_by_key(|d| std::cmp::Reverse(d.mem_delta));
+        by_mem.truncate(top_n);
+
+        let mut by_combined: Vec<BudgetDeltaCheckpoint> = deltas.to_vec();
+        by_combined.sort_by_key(|d| std::cmp::Reverse(d.cpu_delta.saturating_add(d.mem_delta)));
+        by_combined.truncate(top_n);
+
+        BudgetSpikeSummary {
+            by_cpu,
+            by_mem,
+            by_combined,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetSpikeSummary {
+    pub by_cpu: Vec<BudgetDeltaCheckpoint>,
+    pub by_mem: Vec<BudgetDeltaCheckpoint>,
+    pub by_combined: Vec<BudgetDeltaCheckpoint>,
 }
 
 /// Severity level for budget warnings

--- a/src/output.rs
+++ b/src/output.rs
@@ -679,3 +679,65 @@ pub fn format_resource_timeline(
     }
     output
 }
+
+/// Formats a compact "spike triage" view over a resource checkpoint timeline.
+///
+/// Intended for normal debugger output: quickly identify where budget spikes happened
+/// without switching to the full profiler.
+pub fn format_budget_delta_summary(timeline: &[ResourceCheckpoint], top_n: usize) -> String {
+    let deltas = BudgetInspector::deltas_from_checkpoints(timeline);
+    if deltas.is_empty() {
+        return String::new();
+    }
+
+    let spikes = BudgetInspector::top_spikes(&deltas, top_n.max(1));
+
+    fn format_row(d: &crate::inspector::budget::BudgetDeltaCheckpoint) -> String {
+        let loc = if d.location_name.len() > 36 {
+            format!("{}…", &d.location_name[..35])
+        } else {
+            d.location_name.clone()
+        };
+
+        format!(
+            "  {t:>4}ms  cpu +{cpu:<10} mem +{mem:<10}  {loc}",
+            t = d.timestamp_ms,
+            cpu = crate::ui::formatter::Formatter::format_compact_u64(d.cpu_delta),
+            mem = crate::ui::formatter::Formatter::format_bytes(d.mem_delta),
+            loc = loc
+        )
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "=== Budget deltas (top spikes) ===");
+    let _ = writeln!(
+        &mut out,
+        "Captured {} checkpoints ({} deltas).",
+        timeline.len(),
+        deltas.len()
+    );
+    let _ = writeln!(&mut out);
+
+    let _ = writeln!(&mut out, "-- CPU spikes (top {}) --", spikes.by_cpu.len());
+    for d in &spikes.by_cpu {
+        let _ = writeln!(&mut out, "{}", format_row(d));
+    }
+
+    let _ = writeln!(&mut out);
+    let _ = writeln!(&mut out, "-- Memory spikes (top {}) --", spikes.by_mem.len());
+    for d in &spikes.by_mem {
+        let _ = writeln!(&mut out, "{}", format_row(d));
+    }
+
+    let _ = writeln!(&mut out);
+    let _ = writeln!(
+        &mut out,
+        "-- Combined spikes (cpu_delta + mem_delta, top {}) --",
+        spikes.by_combined.len()
+    );
+    for d in &spikes.by_combined {
+        let _ = writeln!(&mut out, "{}", format_row(d));
+    }
+
+    out
+}


### PR DESCRIPTION
Closes: #818 
This branch improves the normal debugger output so operators can quickly answer: “Where did the budget spike happen?” without immediately switching to profiling mode.

Today, the debugger surfaces budget totals (CPU instructions and memory bytes consumed), plus warnings when usage approaches limits. That’s useful for knowing whether a run was expensive, but it doesn’t show where the expensive jump occurred. This change adds a lightweight “delta view” that highlights CPU and memory deltas between checkpoints and prints a top-spikes summary.

Key points:

Budget delta model: Introduces a structured representation of per-checkpoint deltas derived from the existing ResourceCheckpoint timeline. Each delta record includes:

checkpoint index and timestamp
location label (step/frame/checkpoint label)
total CPU/memory at that point
delta CPU and delta memory since the previous checkpoint
Spike ranking: Adds a simple ranking pass to extract the top-N spikes by:

CPU delta
memory delta
combined score (
c
p
u
_
d
e
l
t
a
+
m
e
m
_
d
e
l
t
a
cpu_delta+mem_delta) for quick triage
Shared formatting: Adds a formatter for a compact “Budget deltas (top spikes)” section that can be reused across presentation layers (CLI output and any other exported views).

Operator outcome: After a single run, users can immediately see:

which checkpoint label corresponded to the largest CPU jump
which checkpoint label corresponded to the largest memory jump
which checkpoints were “worst overall” when considering both dimensions
This reduces time-to-diagnosis and makes it clear whether the next action is re-run with profiler, optimize a specific call, or reduce input size.
Commit message (detailed, with rationale)
Add budget deltas summary to normal output
Compute CPU/memory deltas per checkpoint and surface top spike steps so operators can pinpoint budget jumps without switching to profiler mode.
Why: Totals alone don’t identify where the spike occurred.
What: Compute deltas from checkpoints, rank spikes, and format a compact summary for standard output.
Impact: Faster triage; less reliance on profiler for first-pass diagnosis.