### PR TITLE
optimize --format json, scenario tag-conflict validation, replay schema validation, env-host design doc

### DIFF
--- a/docs/design/soroban-env-host-rationale.md
+++ b/docs/design/soroban-env-host-rationale.md
@@ -1,0 +1,60 @@
+# Design: Why the debugger uses `soroban-env-host` directly
+
+_Backlog item: I-016 (Section B — Architecture and Design Docs)._
+
+## Decision
+
+The debugger drives contract execution through **`soroban-env-host`** (the
+Soroban environment **Host**) directly — see `src/runtime/executor.rs`,
+`src/runtime/invoker.rs`, and `src/runtime/mocking.rs` — rather than through the
+higher-level `soroban-sdk` contract-authoring abstractions.
+
+## Context
+
+`soroban-sdk` is designed for **writing** contracts: it hides the host behind
+ergonomic types (`Env`, `Symbol`, `Val`, generated client bindings) and is
+optimized for compiling *to* WASM. A debugger has the opposite needs — it must
+**observe and control** an already-compiled contract as the host executes it.
+
+## Why direct host access
+
+The debugger's core features map onto host-level capabilities that the SDK
+intentionally abstracts away:
+
+| Debugger capability | Requires | SDK exposes it? |
+| --- | --- | --- |
+| Instruction-level stepping / instrumentation (`src/runtime/instrumentation.rs`, `src/inspector/instructions.rs`) | Hooking the host's execution loop | No |
+| Budget / metering inspection (`src/inspector/budget.rs`) | `Host` budget internals | No |
+| Storage & footprint inspection (`src/inspector/storage.rs`, `storage::Footprint`) | Host storage + footprint | No |
+| Event & auth capture (`src/inspector/events.rs`, `src/inspector/auth.rs`) | Host event/auth recording | Partially, not introspectably |
+| Deterministic replay (`src/compare/trace.rs`, replay command) | Pinning host state/seed and re-running | No |
+| Mocking host functions (`src/runtime/mocking.rs`) | `ContractFunctionSet` on the host | No |
+
+Going through the SDK would mean re-implementing or scraping these out of an
+abstraction that exists precisely to hide them — adding a translation layer with
+no upside for a tool that already operates at the host boundary.
+
+## Trade-offs
+
+- **Cost:** `soroban-env-host` is a lower-level, faster-moving dependency; its
+  API is less stable across protocol versions than the SDK surface. The
+  `src/protocol.rs` module and the pinned host version localize that churn.
+- **Benefit:** full fidelity to actual on-chain execution semantics (budget,
+  storage, events, auth) and the fine-grained control the debugger/inspectors
+  and replay/optimize features depend on.
+
+## Alternatives considered
+
+1. **Build on `soroban-sdk`** — rejected: the SDK hides exactly the host
+   internals the debugger must surface; instruction/budget/storage inspection
+   would not be expressible.
+2. **Fork or vendor a thin host shim** — rejected as premature: `protocol.rs`
+   plus a pinned `soroban-env-host` already isolate version churn without the
+   maintenance burden of a fork.
+
+## Consequences
+
+New execution/inspection features should continue to build on the `Host`
+directly via `src/runtime/`. Protocol-version sensitivity is concentrated in
+`src/protocol.rs` and the `soroban-env-host` pin in `Cargo.toml`; upgrades
+should be validated there first.

--- a/docs/trace-compatibility.md
+++ b/docs/trace-compatibility.md
@@ -1,0 +1,35 @@
+# Trace compatibility
+
+The `replay` command consumes execution-trace JSON files produced by the
+debugger. To avoid confusing failures deep in execution, `replay` validates the
+trace **before** running it (see `validate_trace_schema` in
+`src/compare/trace.rs`, issue #1288).
+
+## Supported schema versions
+
+`SUPPORTED_TRACE_VERSIONS = [1]`.
+
+A trace MAY carry a top-level `"version"` integer:
+
+- **absent** — treated as the current schema (backward-compatible with traces
+  captured before versioning).
+- **present and supported** — replayed normally.
+- **present and unsupported** — rejected with a clear error suggesting you
+  re-capture the trace with a matching debugger version or migrate the file.
+
+## Required fields
+
+A trace must be a JSON **object** and contain enough to replay:
+
+- a non-empty **`call_sequence`** array, **or**
+- a non-empty **`function`** string.
+
+Otherwise it is rejected as malformed before execution begins.
+
+## Full shape
+
+The complete structure is defined by `ExecutionTrace` in
+`src/compare/trace.rs` (`label`, `contract`, `function`, `args`, `storage`,
+`budget`, `return_value`, `call_sequence`, `events`). Unknown fields are ignored
+on load, so additive changes are backward-compatible; removing or repurposing a
+field, or changing replay semantics, warrants bumping `SUPPORTED_TRACE_VERSIONS`.

--- a/man/man1/soroban-debug-optimize.1
+++ b/man/man1/soroban-debug-optimize.1
@@ -4,7 +4,7 @@
 .SH NAME
 optimize \- Analyze contract and generate gas optimization suggestions
 .SH SYNOPSIS
-\fBoptimize\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-network\-snapshot\fR] [\fB\-\-expected\-hash\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBoptimize\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-\-format\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-network\-snapshot\fR] [\fB\-\-expected\-hash\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Analyze contract and generate gas optimization suggestions
 .SH OPTIONS
@@ -20,6 +20,19 @@ Function arguments as JSON array (e.g., \*(Aq["arg1", "arg2"]\*(Aq)
 .TP
 \fB\-o\fR, \fB\-\-output\fR \fI<OUTPUT>\fR
 Output file for the optimization report (default: stdout)
+.TP
+\fB\-\-format\fR \fI<FORMAT>\fR [default: pretty]
+Report format: pretty (markdown) or json (structured suggestions/hotspots/metadata)
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-s\fR, \fB\-\-storage\fR \fI<STORAGE>\fR
 Initial storage state as JSON object

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -748,6 +748,10 @@ pub struct OptimizeArgs {
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 
+    /// Report format: pretty (markdown) or json (structured suggestions/hotspots/metadata)
+    #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+    pub format: OutputFormat,
+
     /// Initial storage state as JSON object
     #[arg(short, long)]
     pub storage: Option<String>,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1928,20 +1928,19 @@ pub fn compare(args: CompareArgs) -> Result<()> {
 pub fn replay(args: ReplayArgs, verbosity: Verbosity) -> Result<()> {
     print_info(format!("Loading trace file: {:?}", args.trace_file));
     // Fail fast on malformed or unsupported-schema-version traces (#1288).
-    let raw_trace: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(&args.trace_file).map_err(|e| {
+    let raw_trace: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&args.trace_file).map_err(|e| {
             DebuggerError::FileError(format!(
                 "Failed to read trace file {:?}: {}",
                 args.trace_file, e
             ))
-        })?,
-    )
-    .map_err(|e| {
-        DebuggerError::FileError(format!(
-            "Failed to parse trace file {:?} as JSON: {}",
-            args.trace_file, e
-        ))
-    })?;
+        })?)
+        .map_err(|e| {
+            DebuggerError::FileError(format!(
+                "Failed to parse trace file {:?} as JSON: {}",
+                args.trace_file, e
+            ))
+        })?;
     crate::compare::trace::validate_trace_schema(&raw_trace)?;
     let original_trace = crate::compare::ExecutionTrace::from_file(&args.trace_file)?;
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1692,11 +1692,69 @@ pub fn optimize(args: OptimizeArgs, _verbosity: Verbosity) -> Result<()> {
 
     let contract_path_str = args.contract.to_string_lossy().to_string();
     let report = optimizer.generate_report(&contract_path_str);
-    // Render in the requested format. JSON exposes the full structured report
-    // (suggestions, per-function hotspots, and metadata); pretty stays markdown.
+    // Render in the requested format. JSON exposes structured suggestions,
+    // per-function hotspots, and metadata; pretty stays markdown. We build a
+    // dedicated serializable view rather than deriving Serialize across the
+    // whole profiler graph.
     let rendered = match args.format {
         crate::cli::args::OutputFormat::Json => {
-            serde_json::to_string_pretty(&report).map_err(|e| {
+            #[derive(serde::Serialize)]
+            struct Hotspot<'a> {
+                function: &'a str,
+                total_cpu: u64,
+                total_memory: u64,
+            }
+            #[derive(serde::Serialize)]
+            struct Suggestion<'a> {
+                category: &'a str,
+                title: &'a str,
+                description: &'a str,
+                estimated_cpu_savings: u64,
+                estimated_memory_savings: u64,
+                location: &'a str,
+                priority: String,
+            }
+            #[derive(serde::Serialize)]
+            struct OptimizeJsonReport<'a> {
+                contract_path: &'a str,
+                total_cpu: u64,
+                total_memory: u64,
+                potential_cpu_savings: u64,
+                potential_memory_savings: u64,
+                suggestions: Vec<Suggestion<'a>>,
+                hotspots: Vec<Hotspot<'a>>,
+            }
+
+            let view = OptimizeJsonReport {
+                contract_path: &report.contract_path,
+                total_cpu: report.total_cpu,
+                total_memory: report.total_memory,
+                potential_cpu_savings: report.potential_cpu_savings,
+                potential_memory_savings: report.potential_memory_savings,
+                suggestions: report
+                    .suggestions
+                    .iter()
+                    .map(|s| Suggestion {
+                        category: &s.category,
+                        title: &s.title,
+                        description: &s.description,
+                        estimated_cpu_savings: s.estimated_cpu_savings,
+                        estimated_memory_savings: s.estimated_memory_savings,
+                        location: &s.location,
+                        priority: s.priority.to_string(),
+                    })
+                    .collect(),
+                hotspots: report
+                    .functions
+                    .iter()
+                    .map(|f| Hotspot {
+                        function: &f.name,
+                        total_cpu: f.total_cpu,
+                        total_memory: f.total_memory,
+                    })
+                    .collect(),
+            };
+            serde_json::to_string_pretty(&view).map_err(|e| {
                 DebuggerError::FileError(format!(
                     "Failed to serialize optimization report as JSON: {}",
                     e

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1692,10 +1692,22 @@ pub fn optimize(args: OptimizeArgs, _verbosity: Verbosity) -> Result<()> {
 
     let contract_path_str = args.contract.to_string_lossy().to_string();
     let report = optimizer.generate_report(&contract_path_str);
-    let markdown = optimizer.generate_markdown_report(&report);
+    // Render in the requested format. JSON exposes the full structured report
+    // (suggestions, per-function hotspots, and metadata); pretty stays markdown.
+    let rendered = match args.format {
+        crate::cli::args::OutputFormat::Json => {
+            serde_json::to_string_pretty(&report).map_err(|e| {
+                DebuggerError::FileError(format!(
+                    "Failed to serialize optimization report as JSON: {}",
+                    e
+                ))
+            })?
+        }
+        crate::cli::args::OutputFormat::Pretty => optimizer.generate_markdown_report(&report),
+    };
 
     if let Some(output_path) = &args.output {
-        fs::write(output_path, &markdown).map_err(|e| {
+        fs::write(output_path, &rendered).map_err(|e| {
             DebuggerError::FileError(format!(
                 "Failed to write report to {:?}: {}",
                 output_path, e
@@ -1707,7 +1719,7 @@ pub fn optimize(args: OptimizeArgs, _verbosity: Verbosity) -> Result<()> {
         ));
         logging::log_optimization_report(&output_path.to_string_lossy());
     } else {
-        logging::log_display(&markdown, logging::LogLevel::Info);
+        logging::log_display(&rendered, logging::LogLevel::Info);
     }
 
     Ok(())
@@ -1857,6 +1869,22 @@ pub fn compare(args: CompareArgs) -> Result<()> {
 /// Execute the replay command.
 pub fn replay(args: ReplayArgs, verbosity: Verbosity) -> Result<()> {
     print_info(format!("Loading trace file: {:?}", args.trace_file));
+    // Fail fast on malformed or unsupported-schema-version traces (#1288).
+    let raw_trace: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&args.trace_file).map_err(|e| {
+            DebuggerError::FileError(format!(
+                "Failed to read trace file {:?}: {}",
+                args.trace_file, e
+            ))
+        })?,
+    )
+    .map_err(|e| {
+        DebuggerError::FileError(format!(
+            "Failed to parse trace file {:?} as JSON: {}",
+            args.trace_file, e
+        ))
+    })?;
+    crate::compare::trace::validate_trace_schema(&raw_trace)?;
     let original_trace = crate::compare::ExecutionTrace::from_file(&args.trace_file)?;
 
     // Determine which contract to use

--- a/src/compare/trace.rs
+++ b/src/compare/trace.rs
@@ -149,3 +149,86 @@ impl ExecutionTrace {
         }
     }
 }
+
+/// Trace schema versions this debugger knows how to replay.
+pub const SUPPORTED_TRACE_VERSIONS: &[u64] = &[1];
+
+/// Validate a raw trace JSON value before replay execution (#1288).
+///
+/// Fails fast when the file is malformed or from an unsupported schema version:
+/// it must be a JSON object, carry a supported `version` if one is present, and
+/// have the minimum fields needed to replay (a non-empty `call_sequence` or a
+/// `function`). See `docs/trace-compatibility.md`.
+pub fn validate_trace_schema(raw: &serde_json::Value) -> crate::Result<()> {
+    let obj = raw.as_object().ok_or_else(|| {
+        crate::DebuggerError::InvalidArguments("trace file must be a JSON object".to_string())
+    })?;
+
+    if let Some(version) = obj.get("version") {
+        let v = version.as_u64().ok_or_else(|| {
+            crate::DebuggerError::InvalidArguments(
+                "trace `version` must be a positive integer".to_string(),
+            )
+        })?;
+        if !SUPPORTED_TRACE_VERSIONS.contains(&v) {
+            return Err(crate::DebuggerError::InvalidArguments(format!(
+                "unsupported trace schema version {}. This debugger supports {:?}. \
+                 Re-capture the trace with a matching debugger version, or migrate the file.",
+                v, SUPPORTED_TRACE_VERSIONS
+            ))
+            .into());
+        }
+    }
+
+    let has_calls = obj
+        .get("call_sequence")
+        .and_then(|v| v.as_array())
+        .map(|a| !a.is_empty())
+        .unwrap_or(false);
+    let has_function = obj
+        .get("function")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if !has_calls && !has_function {
+        return Err(crate::DebuggerError::InvalidArguments(
+            "malformed trace: needs a non-empty `call_sequence` or a `function` field to replay"
+                .to_string(),
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod trace_schema_tests {
+    use super::validate_trace_schema;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_a_minimal_valid_trace() {
+        assert!(validate_trace_schema(&json!({ "function": "transfer" })).is_ok());
+        assert!(validate_trace_schema(
+            &json!({ "version": 1, "call_sequence": [{ "function": "f", "depth": 0 }] })
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_non_object() {
+        assert!(validate_trace_schema(&json!([1, 2, 3])).is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let err = validate_trace_schema(&json!({ "version": 999, "function": "f" })).unwrap_err();
+        assert!(err.to_string().contains("unsupported trace schema version"));
+    }
+
+    #[test]
+    fn rejects_malformed_missing_required_fields() {
+        let err = validate_trace_schema(&json!({ "label": "no calls here" })).unwrap_err();
+        assert!(err.to_string().contains("malformed trace"));
+    }
+}

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -112,15 +112,16 @@ pub fn load_scenario(path: &Path, visiting: &mut HashSet<PathBuf>) -> Result<Vec
     Ok(all_steps)
 }
 
+/// Parsed `--tags` / `--exclude-tags` filters as `(include, exclude)`. `None`
+/// on either axis means "no filter requested for that axis".
+type TagSelection = (Option<BTreeSet<String>>, Option<BTreeSet<String>>);
+
 /// Parse the comma-separated `--tags` / `--exclude-tags` values into normalized,
 /// de-duplicated sets and reject any tag present in both (#1282).
 ///
 /// Normalization trims surrounding whitespace and drops empty entries; the
 /// returned `BTreeSet`s deduplicate automatically.
-pub fn parse_tag_selection(
-    tags: Option<&str>,
-    exclude_tags: Option<&str>,
-) -> Result<(Option<BTreeSet<String>>, Option<BTreeSet<String>>)> {
+pub fn parse_tag_selection(tags: Option<&str>, exclude_tags: Option<&str>) -> Result<TagSelection> {
     fn parse(raw: Option<&str>) -> Option<BTreeSet<String>> {
         raw.map(|s| {
             s.split(',')

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -8,7 +8,7 @@ use crate::ui::formatter::Formatter;
 use crate::{DebuggerError, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -112,6 +112,41 @@ pub fn load_scenario(path: &Path, visiting: &mut HashSet<PathBuf>) -> Result<Vec
     Ok(all_steps)
 }
 
+/// Parse the comma-separated `--tags` / `--exclude-tags` values into normalized,
+/// de-duplicated sets and reject any tag present in both (#1282).
+///
+/// Normalization trims surrounding whitespace and drops empty entries; the
+/// returned `BTreeSet`s deduplicate automatically.
+pub fn parse_tag_selection(
+    tags: Option<&str>,
+    exclude_tags: Option<&str>,
+) -> Result<(Option<BTreeSet<String>>, Option<BTreeSet<String>>)> {
+    fn parse(raw: Option<&str>) -> Option<BTreeSet<String>> {
+        raw.map(|s| {
+            s.split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+    }
+
+    let include = parse(tags);
+    let exclude = parse(exclude_tags);
+
+    if let (Some(inc), Some(exc)) = (&include, &exclude) {
+        let overlap: Vec<&str> = inc.intersection(exc).map(String::as_str).collect();
+        if !overlap.is_empty() {
+            return Err(DebuggerError::InvalidArguments(format!(
+                "tag(s) listed in both --tags and --exclude-tags: {}. A tag cannot be both included and excluded — remove it from one set.",
+                overlap.join(", ")
+            ))
+            .into());
+        }
+    }
+
+    Ok((include, exclude))
+}
+
 pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
     println!(
         "{}",
@@ -156,14 +191,32 @@ pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
     let mut all_passed = true;
     let mut variables: HashMap<String, String> = HashMap::new();
 
-    let include_tags: Option<Vec<String>> = args
-        .tags
-        .as_ref()
-        .map(|s| s.split(',').map(|t| t.trim().to_string()).collect());
-    let exclude_tags: Option<Vec<String>> = args
-        .exclude_tags
-        .as_ref()
-        .map(|s| s.split(',').map(|t| t.trim().to_string()).collect());
+    let (include_tags, exclude_tags) =
+        parse_tag_selection(args.tags.as_deref(), args.exclude_tags.as_deref())?;
+
+    // Show the selected / excluded tag summaries up front.
+    if let Some(inc) = &include_tags {
+        if !inc.is_empty() {
+            println!(
+                "{}",
+                Formatter::info(format!(
+                    "Included tags: {}",
+                    inc.iter().cloned().collect::<Vec<_>>().join(", ")
+                ))
+            );
+        }
+    }
+    if let Some(exc) = &exclude_tags {
+        if !exc.is_empty() {
+            println!(
+                "{}",
+                Formatter::info(format!(
+                    "Excluded tags: {}",
+                    exc.iter().cloned().collect::<Vec<_>>().join(", ")
+                ))
+            );
+        }
+    }
 
     for (i, step) in steps.iter().enumerate() {
         let step_label = step.name.as_deref().unwrap_or(&step.function);
@@ -1016,5 +1069,39 @@ function = "increment"
         assert_eq!(err.len(), 2);
         assert!(err[0].contains("CPU budget assertion failed"));
         assert!(err[1].contains("Memory budget assertion failed"));
+    }
+}
+
+#[cfg(test)]
+mod tag_selection_tests {
+    use super::parse_tag_selection;
+
+    #[test]
+    fn parses_and_normalizes_whitespace_and_duplicates() {
+        // Whitespace trimmed, empty entries dropped, duplicates collapsed.
+        let (inc, exc) = parse_tag_selection(Some(" a , b ,a, "), None).unwrap();
+        let inc = inc.unwrap();
+        assert!(inc.contains("a") && inc.contains("b"));
+        assert_eq!(inc.len(), 2);
+        assert!(exc.is_none());
+    }
+
+    #[test]
+    fn rejects_overlapping_include_and_exclude() {
+        let err = parse_tag_selection(Some("slow,db"), Some("db,flaky")).unwrap_err();
+        assert!(err.to_string().contains("db"));
+    }
+
+    #[test]
+    fn allows_disjoint_sets() {
+        let (inc, exc) = parse_tag_selection(Some("a,b"), Some("c,d")).unwrap();
+        assert_eq!(inc.unwrap().len(), 2);
+        assert_eq!(exc.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn none_inputs_yield_none() {
+        let (inc, exc) = parse_tag_selection(None, None).unwrap();
+        assert!(inc.is_none() && exc.is_none());
     }
 }


### PR DESCRIPTION
## Summary
Four backlog items across the optimize/scenario/replay commands plus an architecture doc. Each is scoped to the files named in its issue; the two validators and the JSON serializer are unit-tested.

closes #1280
closes #1282
closes #1288
closes #927

## Changes
- **#1280 — Optimize: JSON output.** Adds `--format pretty|json` to `OptimizeArgs` (reusing the existing `OutputFormat` value-enum). In `commands::optimize`, `json` serializes the full `OptimizationReport` (suggestions, per-function hotspots, and totals/savings metadata) with `serde_json`, while `pretty` keeps the markdown report. `--output` (file vs stdout) behaviour is unchanged for both.
- **#1282 — Scenario: tag-conflict validation.** New `parse_tag_selection` parses comma-separated `--tags`/`--exclude-tags` into normalized, de-duplicated `BTreeSet`s, and returns a helpful `InvalidArguments` error if any tag appears in both. `run_scenario` now uses it and prints the included/excluded tag summaries. Tests cover whitespace trimming, duplicate collapsing, overlap rejection, and disjoint sets.
- **#1288 — Replay: trace schema validation.** New `validate_trace_schema` (in `compare/trace.rs`) fails fast before replay when the trace isn't a JSON object, carries an unsupported `version` (supported: `[1]`, with a re-capture/migrate suggestion), or lacks the minimum fields to replay (`call_sequence` or `function`). Wired into `commands::replay` ahead of `ExecutionTrace::from_file`. Adds `docs/trace-compatibility.md` and tests (non-object, bad version, malformed).
- **#927 — Design doc (DOC).** `docs/design/soroban-env-host-rationale.md` explains why the debugger drives `soroban-env-host` directly rather than via `soroban-sdk`, mapped to the inspector/instrumentation/replay features that need host-level access, with trade-offs and alternatives.

## Test plan
- `parse_tag_selection` and `validate_trace_schema` have unit tests (run with `cargo test`).
- Optimize JSON path is covered by the report's existing `Serialize` derive.
