### PR TITLE
Batch: optimize JSON output, scenario tag validation, replay schema check, host-host design doc

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,7 +86,7 @@ graph TD
 
 ## Key Design Decisions
 
-1. **Direct `soroban-env-host` Integration**: We integrate directly with the Soroban host environment to get fine-grained control and access to internal states (budget, storage) that higher-level SDKs might abstract away.
+1. **Direct `soroban-env-host` Integration**: We integrate directly with the Soroban host environment to get fine-grained control and access to internal states (budget, storage) that higher-level SDKs might abstract away. See [`docs/design-soroban-env-host.md`](docs/design-soroban-env-host.md) for the full rationale, tradeoffs we accept, and the rules that govern when SDK-level dependencies are still appropriate (fixtures, sample tests).
 2. **Separation of Engine and Executor**: By decoupling the debugging logic (`DebuggerEngine`) from the execution environment (`ContractExecutor`), we make the system more modular and easier to test.
 3. **Inspector Pattern**: Using dedicated inspector modules allows us to add new ways to visualize contract state without cluttering the core execution logic.
 

--- a/docs/design-soroban-env-host.md
+++ b/docs/design-soroban-env-host.md
@@ -1,0 +1,132 @@
+# Design Note: Direct Use of `soroban-env-host`
+
+> Backlog reference: `docs/issues/backlog-100-issues.md` — item **I-016**, Section B (Architecture and Design Docs).
+
+## Context
+
+`soroban-debugger` invokes Soroban contracts from a host process. There are
+two practical entry points for doing so:
+
+1. **`soroban-sdk` testutils** — the high-level testing harness exposed by the
+   contract SDK (`soroban_sdk::testutils::*`, `Env::with_default_*`). It is
+   intentionally ergonomic: it hides the underlying host, registers a contract
+   under a generated id, and gives back typed return values.
+2. **`soroban-env-host` directly** — the low-level host that `soroban-sdk`
+   itself wraps. It exposes the budget, storage map, footprint, diagnostic
+   events, and the raw `Val`/`HostObject` machinery as first-class API.
+
+The debugger uses option 2.
+
+## Decision
+
+`soroban-debugger` depends on `soroban-env-host` directly and treats
+`soroban-sdk` strictly as a build/test dependency for fixture contracts.
+
+```toml
+# Cargo.toml
+soroban-sdk      = { version = "...", features = ["testutils"] }   # fixtures only
+soroban-env-host = { version = "...", features = ["testutils"] }   # runtime
+soroban-env-common = "..."
+```
+
+The choice was made deliberately, not by accident, and is enforced by the
+module layout: `src/runtime/`, `src/inspector/`, and `src/repl/` import only
+`soroban-env-host` / `soroban-env-common`. Application code that depends on
+`soroban-sdk` lives under `examples/` and the fixture crates under
+`tests/`.
+
+## Why direct, not via `soroban-sdk`
+
+A debugger has different goals from a contract author's test. We need:
+
+1. **Step-level execution control.** The runtime must be able to invoke a
+   single host function, observe the result, and pause — so that breakpoints,
+   stepping, and time-travel inspection (`src/runtime/instrumentation.rs`,
+   `src/runtime/instruction.rs`) can run between WASM operations.
+   `soroban-sdk::Env` is designed to invoke a contract end-to-end and return a
+   typed result. There is no public seam to inject between operations.
+
+2. **Direct access to the budget.** The Inspector module
+   (`src/inspector/budget.rs`) reads `host.budget_ref()` to render CPU and
+   memory deltas per checkpoint. The SDK exposes only the aggregate after a
+   call returns; we need to sample it mid-call.
+
+3. **Direct access to storage and the footprint.**
+   `src/inspector/storage.rs` walks the storage map and the
+   read/write footprint to compare states. The SDK abstracts ledger storage
+   behind typed accessors; the host exposes the raw `Storage` and
+   `Footprint`, which is what `inspect`, `compare`, and `replay` actually
+   need.
+
+4. **Diagnostic events without a contract context.**
+   `src/inspector/events.rs` reads `host.get_events()` directly, including
+   the diagnostic level. The SDK's user-facing test API filters and
+   transforms these.
+
+5. **Replay determinism.** `src/runtime/loader.rs` and `src/runtime/parser.rs`
+   need to recreate the *exact* host state used in a captured trace
+   (`src/compare/trace.rs`). That means seeding the storage map, the budget
+   limits, and the network passphrase on a fresh `Host`. The SDK constructs a
+   `Host` internally with conventions of its own; bypassing it removes a
+   layer of behavior we would otherwise have to mirror or work around.
+
+6. **Stable types for IPC.** The remote debug server
+   (`src/server/debug_server.rs`) serializes host values across a transport
+   (`src/server/protocol.rs`). The host's `Val` / `ScVal` and the
+   `soroban-env-common` types are the stable, versioned surface for that —
+   the SDK's higher-level wrappers are not.
+
+## Tradeoffs we accept
+
+This choice is not free. The costs are:
+
+- **Tighter version coupling.** When `soroban-env-host` releases a breaking
+  change we have to react, even if `soroban-sdk` has not yet caught up. We
+  manage this by pinning `soroban-env-host`, `soroban-env-common`, and
+  `soroban-sdk` to compatible majors in `Cargo.toml` and gating updates in
+  CI.
+
+- **More boilerplate at the call site.** Things the SDK does for free
+  (registering a contract, allocating an id, wrapping return values) are
+  done explicitly in `src/runtime/executor.rs` and
+  `src/runtime/invoker.rs`. We accept this in exchange for the visibility
+  that the inspectors need.
+
+- **Lower-level error surfaces.** Host errors come back as
+  `HostError`/`Status` rather than the friendly SDK errors. The
+  `src/cli/output.rs` layer normalises these into the diagnostic format used
+  by the rest of the CLI.
+
+## When to reach for `soroban-sdk` instead
+
+There are still good reasons to depend on the SDK in *some* parts of this
+repo:
+
+- **Fixture contracts** (under `examples/` and `tests/fixtures/`) are normal
+  Soroban contracts. They use `soroban-sdk` like any other contract,
+  precisely because that is what the debugger is debugging.
+
+- **Sample / integration tests** that want to exercise the public,
+  user-facing surface (rather than reach into the host) may use
+  `soroban-sdk::testutils`.
+
+A future contributor who wants to add SDK-based assertions in test code
+should not feel obligated to switch to the lower-level host API. The rule is
+only that runtime/inspector/protocol code stays on the host directly.
+
+## Out of scope
+
+- We do not vendor or fork `soroban-env-host`. We track upstream majors.
+- We do not provide a "use either" abstraction layer over the SDK and the
+  host. The cost of maintaining that layer would be larger than the cost of
+  reading the host API directly in the few modules that need it.
+
+## Related
+
+- `ARCHITECTURE.md` — overall module breakdown (refers back to this doc for
+  the host-vs-SDK rationale).
+- `src/runtime/executor.rs` — primary consumer of the direct host API.
+- `src/inspector/` — modules that depend on host internals
+  (`budget.rs`, `storage.rs`, `events.rs`).
+- `src/compare/trace.rs` — trace schema that requires deterministic host
+  state to replay.

--- a/docs/optimization-guide.md
+++ b/docs/optimization-guide.md
@@ -72,6 +72,26 @@ Top consumers (CPU):
 soroban-debugger budget-diff --before baseline.json --after optimized.json
 ```
 
+### Choosing a report format for `optimize`
+
+The `optimize` command writes the same content in two formats; pick the one
+your downstream consumer expects:
+
+```bash
+# Default: human-readable markdown (existing behavior)
+soroban-debugger optimize --contract contract.wasm --function transfer
+
+# Structured JSON for CI gates, IDE plugins, or dashboards
+soroban-debugger optimize --contract contract.wasm --function transfer \
+  --format json --output optimize.json
+```
+
+`--format` is independent of `--output`: `--format` chooses the content
+(`pretty` markdown or `json`); `--output` chooses the destination (stdout
+when omitted, a file when set). JSON output is keyed by `schema_version`,
+`metadata`, `hotspots`, and `suggestions`, so consumers can pin to a
+schema version and ignore fields they don't understand.
+
 ---
 
 ## 3. Optimization Pattern 1: Redundant Storage Reads

--- a/man/man1/soroban-debug-optimize.1
+++ b/man/man1/soroban-debug-optimize.1
@@ -4,7 +4,7 @@
 .SH NAME
 optimize \- Analyze contract and generate gas optimization suggestions
 .SH SYNOPSIS
-\fBoptimize\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-network\-snapshot\fR] [\fB\-\-expected\-hash\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBoptimize\fR <\fB\-c\fR|\fB\-\-contract\fR> [\fB\-f\fR|\fB\-\-function\fR] [\fB\-a\fR|\fB\-\-args\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-s\fR|\fB\-\-storage\fR] [\fB\-\-network\-snapshot\fR] [\fB\-\-expected\-hash\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Analyze contract and generate gas optimization suggestions
 .SH OPTIONS
@@ -29,6 +29,19 @@ Network snapshot file to load before analysis
 .TP
 \fB\-\-expected\-hash\fR \fI<EXPECTED_HASH>\fR
 Expected SHA\-256 hash of the WASM file. If provided, loading will fail if the computed hash does not match
+.TP
+\fB\-\-format\fR \fI<FORMAT>\fR [default: pretty]
+Output format for the optimization report (pretty markdown or structured JSON). Pretty is the default and preserves prior behavior. JSON emits suggestions, hotspots, and metadata in a single object so the report can be piped into other tools
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pretty
+.IP \(bu 2
+json
+.RE
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -763,6 +763,13 @@ pub struct OptimizeArgs {
     /// Deprecated: use --network-snapshot instead
     #[arg(long, hide = true, alias = "snapshot")]
     pub snapshot: Option<PathBuf>,
+
+    /// Output format for the optimization report (pretty markdown or structured JSON).
+    /// Pretty is the default and preserves prior behavior. JSON emits suggestions,
+    /// hotspots, and metadata in a single object so the report can be piped into
+    /// other tools.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+    pub format: OutputFormat,
 }
 
 #[cfg(test)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1167,6 +1167,7 @@ fn build_execution_trace(
     }
 
     crate::compare::ExecutionTrace {
+        schema_version: Some(crate::output::SCHEMA_VERSION.to_string()),
         label: Some(format!("Execution of {} on {}", function, contract_path)),
         contract: Some(contract_path.to_string()),
         function: Some(function.to_string()),
@@ -1692,10 +1693,14 @@ pub fn optimize(args: OptimizeArgs, _verbosity: Verbosity) -> Result<()> {
 
     let contract_path_str = args.contract.to_string_lossy().to_string();
     let report = optimizer.generate_report(&contract_path_str);
-    let markdown = optimizer.generate_markdown_report(&report);
+
+    let rendered = match args.format {
+        OutputFormat::Pretty => optimizer.generate_markdown_report(&report),
+        OutputFormat::Json => render_optimize_report_json(&report)?,
+    };
 
     if let Some(output_path) = &args.output {
-        fs::write(output_path, &markdown).map_err(|e| {
+        fs::write(output_path, &rendered).map_err(|e| {
             DebuggerError::FileError(format!(
                 "Failed to write report to {:?}: {}",
                 output_path, e
@@ -1707,10 +1712,72 @@ pub fn optimize(args: OptimizeArgs, _verbosity: Verbosity) -> Result<()> {
         ));
         logging::log_optimization_report(&output_path.to_string_lossy());
     } else {
-        logging::log_display(&markdown, logging::LogLevel::Info);
+        logging::log_display(&rendered, logging::LogLevel::Info);
     }
 
     Ok(())
+}
+
+/// Serialize an `OptimizationReport` to a stable JSON document for the
+/// `optimize --format json` flag. The shape is intentionally flat and uses
+/// strings (not enum discriminants) for `priority` and `category` so external
+/// tools — dashboards, CI gates, IDE plugins — can consume it without needing
+/// to track internal enum names.
+fn render_optimize_report_json(
+    report: &crate::profiler::analyzer::OptimizationReport,
+) -> Result<String> {
+    let suggestions: Vec<serde_json::Value> = report
+        .suggestions
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "category": s.category,
+                "title": s.title,
+                "description": s.description,
+                "estimated_cpu_savings": s.estimated_cpu_savings,
+                "estimated_memory_savings": s.estimated_memory_savings,
+                "location": s.location,
+                "priority": s.priority.to_string(),
+            })
+        })
+        .collect();
+
+    let hotspots: Vec<serde_json::Value> = report
+        .functions
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "name": f.name,
+                "cpu_instructions": f.total_cpu,
+                "memory_bytes": f.total_memory,
+                "wall_time_ms": f.wall_time_ms as u64,
+            })
+        })
+        .collect();
+
+    let doc = serde_json::json!({
+        "schema_version": crate::output::SCHEMA_VERSION,
+        "kind": "optimize_report",
+        "contract": report.contract_path,
+        "metadata": {
+            "total_cpu_instructions": report.total_cpu,
+            "total_memory_bytes": report.total_memory,
+            "potential_cpu_savings": report.potential_cpu_savings,
+            "potential_memory_savings": report.potential_memory_savings,
+            "suggestion_count": report.suggestions.len(),
+            "function_count": report.functions.len(),
+        },
+        "hotspots": hotspots,
+        "suggestions": suggestions,
+    });
+
+    serde_json::to_string_pretty(&doc).map_err(|e| {
+        DebuggerError::FileError(format!(
+            "Failed to serialize optimize report as JSON: {}",
+            e
+        ))
+        .into()
+    })
 }
 
 /// ✅ Execute the profile command (hotspots + suggestions)
@@ -1859,16 +1926,26 @@ pub fn replay(args: ReplayArgs, verbosity: Verbosity) -> Result<()> {
     print_info(format!("Loading trace file: {:?}", args.trace_file));
     let original_trace = crate::compare::ExecutionTrace::from_file(&args.trace_file)?;
 
-    // Determine which contract to use
+    // Fail fast on malformed or unsupported-schema traces before touching the
+    // executor. validate_for_replay knows whether --contract covers a missing
+    // trace.contract, so it does the contract-existence check for us.
+    original_trace.validate_for_replay(args.contract.as_deref())?;
+
+    if let Some(version) = original_trace.schema_version.as_deref() {
+        print_info(format!("Trace schema version: {}", version));
+    }
+
+    // Determine which contract to use (validate_for_replay guarantees at
+    // least one of the two is set).
     let contract_path = if let Some(path) = &args.contract {
         path.clone()
-    } else if let Some(contract_str) = &original_trace.contract {
-        std::path::PathBuf::from(contract_str)
     } else {
-        return Err(DebuggerError::ExecutionError(
-            "No contract path specified and trace file does not contain contract path".to_string(),
+        std::path::PathBuf::from(
+            original_trace
+                .contract
+                .as_deref()
+                .expect("validate_for_replay guarantees a contract source"),
         )
-        .into());
     };
 
     print_info(format!("Loading contract: {:?}", contract_path));
@@ -3056,6 +3133,68 @@ mod tests {
         assert!(json.get("plugins").is_some());
         assert!(json.get("protocol").is_some());
         assert!(json.get("vscode_extension").is_some());
+    }
+
+    #[test]
+    fn optimize_report_json_shape_is_stable() {
+        use crate::profiler::analyzer::{
+            FunctionProfile, OptimizationReport, OptimizationSuggestion, Priority,
+        };
+        use std::collections::HashMap;
+
+        let suggestion = OptimizationSuggestion {
+            category: "Expensive Operations".to_string(),
+            title: "High CPU usage in function 'transfer'".to_string(),
+            description: "Function uses many CPU instructions.".to_string(),
+            estimated_cpu_savings: 250,
+            estimated_memory_savings: 64,
+            location: "transfer".to_string(),
+            priority: Priority::High,
+        };
+        let function = FunctionProfile {
+            name: "transfer".to_string(),
+            total_cpu: 2_500,
+            total_memory: 640,
+            wall_time_ms: 7,
+            operations: Vec::new(),
+            storage_accesses: HashMap::new(),
+            call_tree: None,
+            timeline: None,
+        };
+        let report = OptimizationReport {
+            contract_path: "fixtures/transfer.wasm".to_string(),
+            functions: vec![function],
+            suggestions: vec![suggestion],
+            total_cpu: 2_500,
+            total_memory: 640,
+            potential_cpu_savings: 250,
+            potential_memory_savings: 64,
+        };
+
+        let rendered = render_optimize_report_json(&report).expect("json render");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
+
+        assert_eq!(value["kind"], "optimize_report");
+        assert_eq!(value["contract"], "fixtures/transfer.wasm");
+        assert!(value["schema_version"].is_string());
+        assert_eq!(value["metadata"]["total_cpu_instructions"], 2_500);
+        assert_eq!(value["metadata"]["potential_cpu_savings"], 250);
+        assert_eq!(value["metadata"]["suggestion_count"], 1);
+        assert_eq!(value["metadata"]["function_count"], 1);
+
+        let hotspots = value["hotspots"].as_array().expect("hotspots is array");
+        assert_eq!(hotspots.len(), 1);
+        assert_eq!(hotspots[0]["name"], "transfer");
+        assert_eq!(hotspots[0]["cpu_instructions"], 2_500);
+        assert_eq!(hotspots[0]["wall_time_ms"], 7);
+
+        let suggestions = value["suggestions"]
+            .as_array()
+            .expect("suggestions is array");
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0]["priority"], "High");
+        assert_eq!(suggestions[0]["category"], "Expensive Operations");
+        assert_eq!(suggestions[0]["estimated_cpu_savings"], 250);
     }
 }
 //

--- a/src/compare/engine.rs
+++ b/src/compare/engine.rs
@@ -673,6 +673,7 @@ mod tests {
 
     fn make_trace_a() -> ExecutionTrace {
         ExecutionTrace {
+            schema_version: Some(crate::output::SCHEMA_VERSION.to_string()),
             label: Some("v1.0 baseline".to_string()),
             contract: Some("token.wasm".to_string()),
             function: Some("transfer".to_string()),
@@ -721,6 +722,7 @@ mod tests {
 
     fn make_trace_b() -> ExecutionTrace {
         ExecutionTrace {
+            schema_version: Some(crate::output::SCHEMA_VERSION.to_string()),
             label: Some("v1.1 optimized".to_string()),
             contract: Some("token.wasm".to_string()),
             function: Some("transfer".to_string()),

--- a/src/compare/trace.rs
+++ b/src/compare/trace.rs
@@ -9,9 +9,22 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Trace schema versions this build accepts when validating a replay input.
+/// The current writer always stamps traces with [`crate::output::SCHEMA_VERSION`]
+/// (see `to_replay_artifact_manifest`); legacy traces written before
+/// versioning was added carry no `schema_version` field and are accepted via
+/// the absent-version code path in [`ExecutionTrace::validate_for_replay`].
+pub const SUPPORTED_TRACE_SCHEMA_MAJORS: &[&str] = &["1"];
+
 /// Top-level execution trace that is serialized to / deserialized from JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionTrace {
+    /// Trace file schema version (semver-like). Optional for backward
+    /// compatibility with traces written before the field existed; new
+    /// writers always populate it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+
     /// Human-readable label for this trace (e.g. "v1.0 transfer test")
     #[serde(default)]
     pub label: Option<String>,
@@ -113,9 +126,79 @@ impl ExecutionTrace {
             crate::DebuggerError::FileError(format!("Failed to read trace file {:?}: {}", path, e))
         })?;
         let trace: ExecutionTrace = serde_json::from_str(&contents).map_err(|e| {
-            crate::DebuggerError::FileError(format!("Failed to parse trace file {:?}: {}", path, e))
+            crate::DebuggerError::FileError(format!(
+                "Failed to parse trace file {:?} as JSON: {}. \
+                 The file may be truncated, written by an incompatible version, \
+                 or not actually a trace file.",
+                path, e
+            ))
         })?;
         Ok(trace)
+    }
+
+    /// Validate that this trace is well-formed enough to be replayed and that
+    /// its declared schema version is one this build understands.
+    ///
+    /// `contract_override` reflects an out-of-band `--contract` flag: when
+    /// supplied, the trace does not need to carry its own contract path.
+    ///
+    /// Returns an error early so replay fails fast on malformed input rather
+    /// than blowing up partway through execution. See `tests/schemas/` for
+    /// fixtures covering the failure modes.
+    pub fn validate_for_replay(&self, contract_override: Option<&Path>) -> crate::Result<()> {
+        // 1. Schema version compatibility — absent means legacy and is allowed.
+        if let Some(version) = self.schema_version.as_deref() {
+            let major = version.split('.').next().unwrap_or("");
+            if major.is_empty() {
+                return Err(crate::DebuggerError::FileError(format!(
+                    "Trace declares an unparseable schema_version {:?}. \
+                     Expected a semver-like string such as \"1.0.0\".",
+                    version
+                ))
+                .into());
+            }
+            if !SUPPORTED_TRACE_SCHEMA_MAJORS.contains(&major) {
+                return Err(crate::DebuggerError::FileError(format!(
+                    "Trace schema version {} is not supported by this build. \
+                     Supported major versions: {}. \
+                     Suggestion: re-capture the trace with the current debugger version, \
+                     or upgrade/downgrade the debugger to a compatible release.",
+                    version,
+                    SUPPORTED_TRACE_SCHEMA_MAJORS.join(", ")
+                ))
+                .into());
+            }
+        }
+
+        // 2. Required fields for a replay to even start.
+        let function = self.function.as_deref().unwrap_or("").trim();
+        if function.is_empty() {
+            return Err(crate::DebuggerError::FileError(
+                "Trace is missing the required `function` field — \
+                 cannot replay without knowing which entry point to call. \
+                 Suggestion: re-capture the trace; this usually means the original \
+                 run was aborted before the function was recorded."
+                    .to_string(),
+            )
+            .into());
+        }
+
+        // Contract may come from the trace itself OR a CLI override.
+        let has_trace_contract = self
+            .contract
+            .as_deref()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        if !has_trace_contract && contract_override.is_none() {
+            return Err(crate::DebuggerError::FileError(
+                "Trace does not record a `contract` path and no --contract was supplied. \
+                 Suggestion: pass --contract <path/to/contract.wasm> on the command line."
+                    .to_string(),
+            )
+            .into());
+        }
+
+        Ok(())
     }
 
     /// Serialize this trace to a pretty-printed JSON string.
@@ -147,5 +230,98 @@ impl ExecutionTrace {
                 compression: None,
             }],
         }
+    }
+}
+
+#[cfg(test)]
+mod validate_for_replay_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn minimal_valid() -> ExecutionTrace {
+        ExecutionTrace {
+            schema_version: Some(crate::output::SCHEMA_VERSION.to_string()),
+            label: None,
+            contract: Some("contract.wasm".to_string()),
+            function: Some("transfer".to_string()),
+            args: None,
+            storage: BTreeMap::new(),
+            budget: None,
+            return_value: None,
+            call_sequence: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn current_version_trace_passes() {
+        let trace = minimal_valid();
+        assert!(trace.validate_for_replay(None).is_ok());
+    }
+
+    #[test]
+    fn legacy_trace_without_schema_version_passes() {
+        let mut trace = minimal_valid();
+        trace.schema_version = None;
+        assert!(trace.validate_for_replay(None).is_ok());
+    }
+
+    #[test]
+    fn unsupported_major_is_rejected_with_actionable_message() {
+        let mut trace = minimal_valid();
+        trace.schema_version = Some("2.0.0".to_string());
+        let err = trace.validate_for_replay(None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("2.0.0"),
+            "error should name the bad version: {msg}"
+        );
+        assert!(
+            msg.contains("re-capture") || msg.contains("upgrade"),
+            "error should suggest a remediation: {msg}"
+        );
+    }
+
+    #[test]
+    fn unparseable_schema_version_is_rejected() {
+        let mut trace = minimal_valid();
+        trace.schema_version = Some(String::new());
+        let err = trace.validate_for_replay(None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unparseable"), "got: {msg}");
+    }
+
+    #[test]
+    fn missing_function_is_rejected() {
+        let mut trace = minimal_valid();
+        trace.function = None;
+        let err = trace.validate_for_replay(None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("`function`"), "got: {msg}");
+        assert!(msg.contains("re-capture"));
+    }
+
+    #[test]
+    fn whitespace_function_is_rejected() {
+        let mut trace = minimal_valid();
+        trace.function = Some("   ".to_string());
+        assert!(trace.validate_for_replay(None).is_err());
+    }
+
+    #[test]
+    fn missing_contract_with_no_override_is_rejected() {
+        let mut trace = minimal_valid();
+        trace.contract = None;
+        let err = trace.validate_for_replay(None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("--contract"), "got: {msg}");
+    }
+
+    #[test]
+    fn missing_contract_is_accepted_when_override_provided() {
+        let mut trace = minimal_valid();
+        trace.contract = None;
+        let override_path = PathBuf::from("override.wasm");
+        assert!(trace.validate_for_replay(Some(&override_path)).is_ok());
     }
 }

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -156,14 +156,11 @@ pub fn run_scenario(args: ScenarioArgs, _verbosity: Verbosity) -> Result<()> {
     let mut all_passed = true;
     let mut variables: HashMap<String, String> = HashMap::new();
 
-    let include_tags: Option<Vec<String>> = args
-        .tags
-        .as_ref()
-        .map(|s| s.split(',').map(|t| t.trim().to_string()).collect());
-    let exclude_tags: Option<Vec<String>> = args
-        .exclude_tags
-        .as_ref()
-        .map(|s| s.split(',').map(|t| t.trim().to_string()).collect());
+    let include_tags: Option<Vec<String>> = args.tags.as_deref().map(parse_tag_list);
+    let exclude_tags: Option<Vec<String>> = args.exclude_tags.as_deref().map(parse_tag_list);
+
+    validate_tag_selection(include_tags.as_deref(), exclude_tags.as_deref())?;
+    print_tag_summary(include_tags.as_deref(), exclude_tags.as_deref());
 
     for (i, step) in steps.iter().enumerate() {
         let step_label = step.name.as_deref().unwrap_or(&step.function);
@@ -559,6 +556,78 @@ fn resolve_step_timeout(
         .or(scenario_default_timeout_secs)
         .or(cli_timeout_secs)
         .unwrap_or(DEFAULT_EXECUTION_TIMEOUT_SECS)
+}
+
+/// Parse a comma-separated list of tags into a normalized, de-duplicated Vec.
+/// Whitespace around each tag is trimmed and empty entries are dropped. The
+/// original ordering of first appearance is preserved so error messages match
+/// what the user typed.
+pub(crate) fn parse_tag_list(raw: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for piece in raw.split(',') {
+        let trimmed = piece.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if seen.insert(trimmed.to_string()) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+/// Reject a tag selection where the include and exclude sets overlap. An
+/// overlap would mean the same step is required to be both kept and dropped,
+/// which is almost always a CLI typo and should fail fast with a clear
+/// message rather than silently dropping every step that carries the
+/// conflicting tag.
+pub(crate) fn validate_tag_selection(
+    include: Option<&[String]>,
+    exclude: Option<&[String]>,
+) -> Result<()> {
+    let (Some(includes), Some(excludes)) = (include, exclude) else {
+        return Ok(());
+    };
+    let exclude_set: HashSet<&str> = excludes.iter().map(String::as_str).collect();
+    let mut conflicts: Vec<&str> = includes
+        .iter()
+        .map(String::as_str)
+        .filter(|tag| exclude_set.contains(tag))
+        .collect();
+    conflicts.sort();
+    conflicts.dedup();
+    if conflicts.is_empty() {
+        return Ok(());
+    }
+    Err(DebuggerError::ExecutionError(format!(
+        "Tag selection conflict: tag(s) [{}] appear in both --tags and --exclude-tags. \
+         Pick a side: include the tag (and drop it from --exclude-tags) or exclude it \
+         (and drop it from --tags).",
+        conflicts.join(", ")
+    ))
+    .into())
+}
+
+/// Print which tags will be included / excluded so the user can confirm the
+/// effective filter before any steps run. Silent when neither flag is set.
+pub(crate) fn print_tag_summary(include: Option<&[String]>, exclude: Option<&[String]>) {
+    if let Some(includes) = include {
+        if !includes.is_empty() {
+            println!(
+                "{}",
+                Formatter::info(format!("Including tags: [{}]", includes.join(", ")))
+            );
+        }
+    }
+    if let Some(excludes) = exclude {
+        if !excludes.is_empty() {
+            println!(
+                "{}",
+                Formatter::info(format!("Excluding tags: [{}]", excludes.join(", ")))
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1016,5 +1085,62 @@ function = "increment"
         assert_eq!(err.len(), 2);
         assert!(err[0].contains("CPU budget assertion failed"));
         assert!(err[1].contains("Memory budget assertion failed"));
+    }
+
+    #[test]
+    fn parse_tag_list_trims_whitespace_and_drops_empty() {
+        assert_eq!(
+            parse_tag_list("  smoke ,fast,   ,fast  ,perf"),
+            vec!["smoke".to_string(), "fast".to_string(), "perf".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_tag_list_handles_empty_input() {
+        assert!(parse_tag_list("").is_empty());
+        assert!(parse_tag_list("   ").is_empty());
+        assert!(parse_tag_list(",,, ,").is_empty());
+    }
+
+    #[test]
+    fn validate_tag_selection_allows_disjoint_sets() {
+        let include = vec!["smoke".to_string(), "fast".to_string()];
+        let exclude = vec!["slow".to_string()];
+        assert!(validate_tag_selection(Some(&include), Some(&exclude)).is_ok());
+    }
+
+    #[test]
+    fn validate_tag_selection_allows_either_unset() {
+        let include = vec!["smoke".to_string()];
+        assert!(validate_tag_selection(Some(&include), None).is_ok());
+        assert!(validate_tag_selection(None, Some(&include)).is_ok());
+        assert!(validate_tag_selection(None, None).is_ok());
+    }
+
+    #[test]
+    fn validate_tag_selection_rejects_overlap() {
+        let include = vec!["smoke".to_string(), "fast".to_string()];
+        let exclude = vec!["slow".to_string(), "fast".to_string()];
+        let err = validate_tag_selection(Some(&include), Some(&exclude))
+            .expect_err("overlap must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("fast"),
+            "error should name conflicting tag, got: {msg}"
+        );
+        assert!(msg.contains("Tag selection conflict"));
+    }
+
+    #[test]
+    fn validate_tag_selection_reports_all_conflicts_once() {
+        let include = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let exclude = vec!["c".to_string(), "a".to_string(), "a".to_string()];
+        let err = validate_tag_selection(Some(&include), Some(&exclude)).unwrap_err();
+        let msg = format!("{err}");
+        // both 'a' and 'c' conflict; 'a' must not be duplicated in the message
+        assert!(
+            msg.contains("a, c"),
+            "expected sorted unique conflicts in: {msg}"
+        );
     }
 }

--- a/tests/replay_validation_tests.rs
+++ b/tests/replay_validation_tests.rs
@@ -1,0 +1,70 @@
+//! End-to-end fixture coverage for `ExecutionTrace::validate_for_replay`.
+//!
+//! The unit tests in `src/compare/trace.rs` exercise the validator against
+//! in-memory structs. These tests cover the on-disk path: deserialization +
+//! validation against pinned fixtures under `tests/schemas/replay_traces/`,
+//! which is the same code path the `replay` CLI command goes through.
+
+use std::path::PathBuf;
+
+use soroban_debugger::compare::ExecutionTrace;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("schemas")
+        .join("replay_traces")
+        .join(name)
+}
+
+#[test]
+fn valid_current_schema_trace_loads_and_validates() {
+    let trace =
+        ExecutionTrace::from_file(fixture("valid_current.json")).expect("fixture must parse");
+    assert_eq!(trace.schema_version.as_deref(), Some("1.0.0"));
+    trace
+        .validate_for_replay(None)
+        .expect("current-schema fixture must validate");
+}
+
+#[test]
+fn legacy_trace_without_schema_version_still_validates() {
+    let trace = ExecutionTrace::from_file(fixture("valid_legacy_no_version.json"))
+        .expect("legacy fixture must parse");
+    assert!(trace.schema_version.is_none());
+    trace
+        .validate_for_replay(None)
+        .expect("legacy trace must remain replayable");
+}
+
+#[test]
+fn malformed_trace_missing_function_is_rejected_fast() {
+    let trace = ExecutionTrace::from_file(fixture("malformed_missing_function.json"))
+        .expect("fixture must parse JSON even if logically invalid");
+    let err = trace
+        .validate_for_replay(None)
+        .expect_err("missing function must be rejected before replay starts");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("`function`"),
+        "error should name the missing field, got: {msg}"
+    );
+}
+
+#[test]
+fn unsupported_schema_version_is_rejected_with_versioning_hint() {
+    let trace = ExecutionTrace::from_file(fixture("unsupported_future_schema.json"))
+        .expect("fixture must parse");
+    let err = trace
+        .validate_for_replay(None)
+        .expect_err("future major schema version must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("2.0.0"),
+        "error should name the version: {msg}"
+    );
+    assert!(
+        msg.contains("Supported"),
+        "error should mention supported versions: {msg}"
+    );
+}

--- a/tests/schemas/replay_traces/README.md
+++ b/tests/schemas/replay_traces/README.md
@@ -1,0 +1,12 @@
+# Replay Trace Fixtures
+
+Fixtures consumed by the replay-validation tests. See
+`src/compare/trace.rs::validate_for_replay` and
+`tests/replay_validation_tests.rs`.
+
+| File | Purpose |
+|---|---|
+| `valid_current.json` | Well-formed trace stamped with the current schema version. Must validate. |
+| `valid_legacy_no_version.json` | Pre-versioning trace (no `schema_version` field). Must validate. |
+| `malformed_missing_function.json` | Required `function` field absent. Must fail validation. |
+| `unsupported_future_schema.json` | `schema_version: "2.0.0"` (one major ahead of what this build supports). Must fail with a versioning error. |

--- a/tests/schemas/replay_traces/malformed_missing_function.json
+++ b/tests/schemas/replay_traces/malformed_missing_function.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1.0.0",
+  "label": "malformed: no function recorded",
+  "contract": "fixtures/token.wasm",
+  "storage": {},
+  "call_sequence": [],
+  "events": []
+}

--- a/tests/schemas/replay_traces/unsupported_future_schema.json
+++ b/tests/schemas/replay_traces/unsupported_future_schema.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "2.0.0",
+  "label": "from a future debugger build",
+  "contract": "fixtures/token.wasm",
+  "function": "transfer",
+  "storage": {},
+  "call_sequence": [],
+  "events": []
+}

--- a/tests/schemas/replay_traces/valid_current.json
+++ b/tests/schemas/replay_traces/valid_current.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0.0",
+  "label": "transfer fixture",
+  "contract": "fixtures/token.wasm",
+  "function": "transfer",
+  "args": "[\"Alice\",\"Bob\",100]",
+  "storage": {},
+  "budget": null,
+  "return_value": null,
+  "call_sequence": [],
+  "events": []
+}

--- a/tests/schemas/replay_traces/valid_legacy_no_version.json
+++ b/tests/schemas/replay_traces/valid_legacy_no_version.json
@@ -1,0 +1,9 @@
+{
+  "label": "legacy transfer trace (pre-versioning)",
+  "contract": "fixtures/token.wasm",
+  "function": "transfer",
+  "args": "[\"Alice\",\"Bob\",100]",
+  "storage": {},
+  "call_sequence": [],
+  "events": []
+}


### PR DESCRIPTION
## Description

Batched contribution targeting four recently-assigned issues in `cli`,
`scenario`, `compare`, and the architecture docs. Each change is small,
scoped, and verified by tests. Commits are split one-per-issue so they
can be reviewed (or reverted) independently.

## Related Issue

closes #927
closes #1280
closes #1282
closes #1288

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test / CI improvement

## Changes

- **#927 — Architecture: direct `soroban-env-host` design note.**
  New `docs/design-soroban-env-host.md` explains why the runtime,
  inspector, and protocol layers depend on `soroban-env-host` directly
  rather than going through `soroban-sdk` testutils, the tradeoffs we
  accept (tighter version coupling, lower-level error surfaces), and the
  rule that keeps SDK-level dependencies appropriate for fixtures and
  sample tests. `ARCHITECTURE.md`'s existing one-line mention now links
  to the new doc.

- **#1280 — `optimize --format json` for structured reports.**
  Adds a `format: OutputFormat` field to `OptimizeArgs` (`pretty` is the
  default and preserves prior behavior) and a `render_optimize_report_json`
  helper that emits a stable JSON document keyed by `schema_version`,
  `kind`, `contract`, `metadata`, `hotspots`, and `suggestions`.
  `--output` semantics are unchanged: it still controls destination
  (stdout vs. file) independently of `--format`. JSON is built with
  `serde_json::json!` so the existing report types do not need new
  `Serialize` derives — keeps the change surface minimal. Unit test in
  `commands.rs` pins the JSON shape (`kind`, metadata keys, hotspots,
  suggestions, priority spelling). `docs/optimization-guide.md`
  documents how `--format` composes with `--output`. The `optimize` man
  page is regenerated by `build.rs` to reflect the new flag.

- **#1282 — Scenario: reject `--tags` / `--exclude-tags` overlap with
  a summary.** The runner previously accepted overlapping tag sets and
  silently dropped every step carrying the conflicting tag — almost
  always a CLI typo. Now overlap is rejected fast with an actionable
  message that names every conflicting tag (sorted, de-duplicated), and
  the effective include/exclude lists are echoed before any steps run.
  Tag normalization is consolidated in a single `parse_tag_list` helper
  that trims whitespace, drops empty entries, and dedupes while
  preserving first-appearance ordering (matters for message stability).
  Tests cover whitespace, duplicates, disjoint sets (allowed),
  single-sided selection (allowed), overlap detection, and dedupe in
  the error message.

- **#1288 — Replay: validate trace schema and required fields before
  execution.** Adds a `schema_version: Option<String>` field to
  `ExecutionTrace` (`#[serde(default, skip_serializing_if = "Option::is_none")]`
  so the on-disk format stays backward-compatible with pre-versioning
  traces). New `validate_for_replay(contract_override)` method runs at
  the top of `cli::commands::replay` and:
  * accepts traces with no `schema_version` (legacy);
  * accepts traces whose major matches `SUPPORTED_TRACE_SCHEMA_MAJORS`;
  * rejects unparseable or unsupported versions with a remediation hint
    (re-capture, or upgrade/downgrade the debugger);
  * requires a non-empty `function` field;
  * requires a contract path either in the trace or via `--contract`.
  `from_file` parse-error message is improved to mention the file may
  be truncated, written by an incompatible version, or not a trace.
  Newly-written traces are stamped with `output::SCHEMA_VERSION` in
  `build_execution_trace`. The test-fixture trace builders in
  `compare/engine.rs` are updated for the new field. Adds four pinned
  fixtures under `tests/schemas/replay_traces/` (valid current, valid
  legacy with no version, malformed missing function, unsupported
  future major) plus an integration test that loads them from disk and
  hits the same validation path the CLI uses.

## CI/Test Behavior Changes

**What changed in CI or test behavior?**

Adds a new integration-test crate (`tests/replay_validation_tests.rs`)
and new unit tests in `src/cli/commands.rs`, `src/compare/trace.rs`, and
`src/scenario.rs`. No existing tests were modified except the two
`ExecutionTrace` literal-constructors in `src/compare/engine.rs` tests,
which gained the new `schema_version` field.

**Migration notes**

N/A. The new `schema_version` field on `ExecutionTrace` uses
`#[serde(default, skip_serializing_if = "Option::is_none")]`, so old
trace files on disk continue to load and round-trip cleanly.

## Test plan

- [x] `cargo build --lib` — clean
- [x] `cargo check --tests` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo test --lib` — 516 passed, 0 failed (full lib suite)
- [x] `cargo test --test replay_validation_tests` — 4 passed
- [x] New unit tests pass:
  - `scenario::tests::parse_tag_list_*`
  - `scenario::tests::validate_tag_selection_*`
  - `compare::trace::validate_for_replay_tests::*` (7 cases)
  - `cli::commands::tests::optimize_report_json_shape_is_stable`
- [x] Man page for `optimize` regenerated by `build.rs`; the regenerated
  `.1` file is committed.

## Checklist

- [x] All tests pass locally
- [x] Code is formatted
- [x] Clippy is clean
- [x] Commit messages follow Conventional Commits (one commit per issue)
- [x] PR description mentions related issues with `closes #N` lines
- [x] CI/test behavior changes documented above
- [x] Regenerated man page committed (only `optimize` was affected)
