### PR TITLE
feat(debugger,analyzer): call-stack truncation, sha256 checksum context, rule metadata in JSON (#1270, #1271, #1272)

### DIFF
--- a/extensions/vscode/src/dap/adapter.ts
+++ b/extensions/vscode/src/dap/adapter.ts
@@ -392,14 +392,36 @@ export class SorobanDebugSession extends DebugSession {
     }
   }
 
+  // Default page size when the client doesn't supply args.levels. Keeps the
+  // default display compact while still allowing clients to request more.
+  private static readonly STACK_TRACE_DEFAULT_LEVELS = 50;
+  private static readonly STACK_TRACE_MAX_LEVELS = 500;
+
   protected async stackTraceRequest(
     response: DebugProtocol.StackTraceResponse,
     args: DebugProtocol.StackTraceArguments
   ): Promise<void> {
     const stackFrames = this.state.callStack || [];
+    const totalFrames = stackFrames.length;
+
+    const startFrame = Math.max(0, args.startFrame ?? 0);
+    const requestedLevels = args.levels ?? SorobanDebugSession.STACK_TRACE_DEFAULT_LEVELS;
+    // DAP: levels=0 means "all". Cap regardless so a deep stack can't
+    // produce a runaway response.
+    const effectiveLevels =
+      requestedLevels === 0
+        ? SorobanDebugSession.STACK_TRACE_MAX_LEVELS
+        : Math.min(requestedLevels, SorobanDebugSession.STACK_TRACE_MAX_LEVELS);
+
+    const endFrame = Math.min(totalFrames, startFrame + effectiveLevels);
+    const sliced = stackFrames.slice(startFrame, endFrame);
+    const omitted = totalFrames - sliced.length;
 
     response.body = {
-      stackFrames: stackFrames.slice(0, 50).map(frame => ({
+      // #1270: totalFrames lets the client render "showing N of M" instead of
+      // silently hiding frames past the page.
+      totalFrames,
+      stackFrames: sliced.map(frame => ({
         id: frame.id,
         name: frame.name,
         source: {
@@ -411,6 +433,16 @@ export class SorobanDebugSession extends DebugSession {
         instructionPointerReference: frame.instructionPointerReference
       }))
     };
+
+    if (omitted > 0) {
+      this.sendEvent(
+        new OutputEvent(
+          `Call stack truncated: showing ${sliced.length} of ${totalFrames} frames ` +
+            `(${omitted} omitted). Request more via stackTraceRequest{startFrame, levels}.\n`,
+          'console'
+        )
+      );
+    }
 
     this.sendResponse(response);
   }

--- a/src/analyzer/security.rs
+++ b/src/analyzer/security.rs
@@ -43,10 +43,18 @@ pub struct RuleMetadata {
     pub name: String,
     pub description: String,
     pub severity: Severity,
+    /// Stable category key for downstream filtering (e.g. "security", "upgrade").
+    /// Defaults to "security" when a rule doesn't override it.
+    #[serde(default = "default_rule_category")]
+    pub category: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rationale: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remediation: Option<String>,
+}
+
+fn default_rule_category() -> String {
+    "security".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -80,6 +88,10 @@ pub trait SecurityRule {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn severity(&self) -> Severity;
+    /// Stable category key for downstream filtering. Defaults to "security".
+    fn category(&self) -> &str {
+        "security"
+    }
     fn rationale(&self) -> Option<&str> {
         None
     }
@@ -93,6 +105,7 @@ pub trait SecurityRule {
             name: self.name().to_string(),
             description: self.description().to_string(),
             severity: self.severity(),
+            category: self.category().to_string(),
             rationale: self.rationale().map(|s| s.to_string()),
             remediation: self.remediation().map(|s| s.to_string()),
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -83,6 +83,10 @@ struct DynamicAnalysisMetadata {
 #[derive(serde::Serialize)]
 struct AnalyzeCommandOutput {
     findings: Vec<crate::analyzer::security::SecurityFinding>,
+    /// Rule metadata keyed by rule id (#1272). Lets downstream tools resolve a
+    /// finding's `rule_id` to stable id/name/severity/category/remediation
+    /// fields for filtering. A BTreeMap keeps the JSON ordering deterministic.
+    rules: std::collections::BTreeMap<String, crate::analyzer::security::RuleMetadata>,
     dynamic_analysis: Option<DynamicAnalysisMetadata>,
     warnings: Vec<String>,
     suppressed_count: usize,
@@ -2599,6 +2603,7 @@ pub fn analyze(args: AnalyzeArgs, _verbosity: Verbosity) -> Result<()> {
     )?;
     let output = AnalyzeCommandOutput {
         findings: report.findings,
+        rules: report.rules.into_iter().collect(),
         dynamic_analysis,
         warnings,
         suppressed_count: report.metadata.suppressed_count,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,10 @@ pub enum DebuggerError {
     )]
     StorageError(String),
 
-    #[error("WASM checksum mismatch.\n  Expected : {0}\n  Computed : {1}")]
+    #[error("WASM checksum mismatch (algorithm: sha256).\n  Expected (sha256): {0}\n  Computed (sha256): {1}")]
     #[diagnostic(
         code(debugger::checksum_mismatch),
-        help("Action: If you recompiled the contract, supply its new hash or run without the hash verification flag.\nContext: The provided file hash does not match expected remote or snapshot hash.")
+        help("Action: Hashes use SHA-256 (lower-case hex). If you recompiled the contract, supply its new sha256 hash or run without the hash verification flag.\nContext: The provided file hash does not match the expected remote or snapshot SHA-256 hash.")
     )]
     ChecksumMismatch(String, String),
 

--- a/src/utils/wasm.rs
+++ b/src/utils/wasm.rs
@@ -1458,6 +1458,22 @@ mod tests {
         assert!(verify_wasm_hash(computed, None).is_ok());
     }
 
+    #[test]
+    fn test_checksum_mismatch_message_includes_sha256() {
+        // #1271: hash algorithm context must be explicit in mismatch errors so
+        // callers can supply the right hash format.
+        let computed = "abcdef123456";
+        let expected = Some("wronghash999".to_string());
+        let err = verify_wasm_hash(computed, expected.as_ref()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.to_lowercase().contains("sha256"),
+            "expected sha256 algorithm context in error, got: {msg}"
+        );
+        assert!(msg.contains("wronghash999"), "expected hash missing from message: {msg}");
+        assert!(msg.contains("abcdef123456"), "computed hash missing from message: {msg}");
+    }
+
     // ── WASM test-module builder ──────────────────────────────────────────────
 
     /// Encode `value` as an unsigned LEB128 byte sequence.

--- a/tests/schemas/analyze_output.json
+++ b/tests/schemas/analyze_output.json
@@ -10,9 +10,41 @@
     "result": {
       "type": ["object", "null"],
       "properties": {
-        "findings": { "type": "array" },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Each finding references a rule via `rule_id`; resolve it against the top-level `rules` map for stable metadata.",
+            "properties": {
+              "rule_id": { "type": "string" },
+              "severity": { "type": "string" },
+              "location": { "type": "string" },
+              "description": { "type": "string" },
+              "remediation": { "type": "string" }
+            },
+            "required": ["rule_id", "severity"]
+          }
+        },
+        "rules": {
+          "type": "object",
+          "description": "Rule metadata contract (#1272), keyed by rule id. Downstream tools join findings[].rule_id to this map for stable filtering. Keys are sorted (BTreeMap) for deterministic output.",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["id", "name", "severity", "category"],
+            "properties": {
+              "id": { "type": "string", "description": "Stable rule identifier (matches findings[].rule_id)." },
+              "name": { "type": "string", "description": "Human-readable rule title." },
+              "description": { "type": "string" },
+              "severity": { "type": "string" },
+              "category": { "type": "string", "description": "Stable category key for filtering (e.g. \"security\", \"upgrade\"). Defaults to \"security\"." },
+              "rationale": { "type": ["string", "null"] },
+              "remediation": { "type": ["string", "null"] }
+            }
+          }
+        },
         "dynamic_analysis": { "type": ["object", "null"] },
-        "warnings": { "type": "array", "items": { "type": "string" } }
+        "warnings": { "type": "array", "items": { "type": "string" } },
+        "suppressed_count": { "type": "integer" }
       }
     },
     "error": {


### PR DESCRIPTION
## Summary

Three diagnostics/observability gaps in the debugger + analyzer.

closes #1270
closes #1271
closes #1272

## #1270 — call stack truncation diagnostics
`stackTraceRequest` now honours `startFrame`/`levels` (default **50**, capped at 500; `levels=0` ⇒ all-up-to-cap), reports `totalFrames` in the DAP response, and emits a console hint — `"Call stack truncated: showing N of M frames (K omitted)…"` — when frames are omitted, so the slice is no longer silent. The CLI renders the full stack (no truncation there), so the diagnostic lives where truncation actually occurs: the VS Code view.

## #1271 — sha256 context in checksum mismatch errors
`ChecksumMismatch` now reads `WASM checksum mismatch (algorithm: sha256)` with `Expected (sha256)` / `Computed (sha256)` hashes and SHA-256 guidance in the `help()`. Covers all paths that verify `--expected-hash`. Test: `test_checksum_mismatch_message_includes_sha256`.

## #1272 — rule metadata in JSON findings
- `RuleMetadata` gains a stable **`category`** field (`SecurityRule::category()`, defaults to `"security"`).
- The analyze JSON output now includes a top-level **`rules`** map (sorted `BTreeMap`, deterministic) keyed by rule id with `id / name / severity / category / rationale / remediation`. Downstream tools join `findings[].rule_id` → `rules[id]` for stable filtering. Text output is unchanged/readable.
- `tests/schemas/analyze_output.json` documents the contract (findings `rule_id` + the `rules` map shape).

## Test plan
- `cargo build` clean.
- `json_schema_validation::analyze_json_output_matches_versioned_schema` passes (real analyze output validates against the updated schema, including `rules`).
- `test_checksum_mismatch_message_includes_sha256` passes; **33** analyzer security tests pass.

## Caveats
- The VS Code (`adapter.ts`) change uses the already-imported `OutputEvent` and standard DAP fields (`totalFrames`, `startFrame`, `levels`). I couldn't run `tsc` locally (no `node_modules`; install is heavy) — it relies on the existing **VS Code Extension** CI job. The truncation hint was verified by tracing the DAP flow; there's no adapter test harness in the repo, so per the issue's "documented manual verification" allowance this is noted rather than unit-tested.
- Pre-existing repo CI note: the **Code Coverage** and **Benchmark** jobs fail on every fork PR here regardless of content (token-permission + a `--noplot`/lib-bench config bug on `main`) — unrelated to this change.
