### PR TITLE
docs(readme): add --locked flag to cargo install command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ cargo test --test <test_file>
 Reproduce the benchmark regression gate locally without checking out `main` in place:
 
 ```bash
-cargo install critcmp --version 0.1.7
+cargo install --locked critcmp --version 0.1.7
 bash scripts/check_benchmark_regressions.sh
 ```
 
@@ -162,7 +162,7 @@ Fuzzing helps discover crashes and panics in critical code paths like WASM parsi
 **Prerequisites:**
 Install `cargo-fuzz`:
 ```bash
-cargo install cargo-fuzz
+cargo install --locked cargo-fuzz
 ```
 
 **Running a fuzz target:**

--- a/Readme.md
+++ b/Readme.md
@@ -28,14 +28,16 @@ A command-line debugger for Soroban smart contracts on the Stellar network. Debu
 
 #### Using Cargo (Recommended)
 ```bash
-cargo install soroban-debugger
+cargo install --locked soroban-debugger
 ```
+
+> The `--locked` flag pins dependency versions to those tested by the maintainers, ensuring a reproducible install.
 
 #### From Source
 ```bash
 git clone https://github.com/Timi16/soroban-debugger.git
 cd soroban-debugger
-cargo install --path .
+cargo install --locked --path .
 ```
 
 ### 2. Your First Debug Run

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ If you have Rust installed, you can install the debugger directly from source or
 
 ```bash
 # Install from crates.io
-cargo install soroban-debugger
+cargo install --locked soroban-debugger
 ```
 
 ### Option B: Download Pre-built Binaries

--- a/docs/tutorials/first-debug.md
+++ b/docs/tutorials/first-debug.md
@@ -16,7 +16,7 @@ To step through Soroban WebAssembly (WASM) execution, you need the Soroban debug
 Install it via Cargo by running the following command in your terminal:
 
 ```bash
-cargo install soroban-debugger
+cargo install --locked soroban-debugger
 ```
 
 Verify the installation was successful by checking the version:


### PR DESCRIPTION
Closes: #922 

The quick-start installation command in README.md used `cargo install`
without the `--locked` flag. This means users could silently receive a
build with different transitive dependency versions than those tested and
shipped by the maintainers, leading to hard-to-reproduce bugs or install
failures between releases.

Changes made:
- Add `--locked` to every `cargo install` invocation in README.md
- Add a brief inline note explaining what the flag does and why it matters
- Apply the same flag fix to any adjacent docs (getting-started.md,
  installation.md, CONTRIBUTING.md) where the same pattern appeared

No prose was rewritten. No Rust source files, Cargo.toml, or CI
configuration were modified. This is a documentation-only change.

Backlog: I-010
