### PR TITLE
docs/plugin-command-namespaces.md-is-not-linked

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -14,6 +14,7 @@ The Soroban Debugger plugin system allows developers to extend the debugger's fu
 8. [Hot-Reload Support](#hot-reload-support)
 9. [Best Practices](#best-practices)
 10. [Examples](#examples)
+11. [Command Namespace Rules](#command-namespace-rules)
 
 ## Overview
 
@@ -282,6 +283,8 @@ fn execute_command(&mut self, command: &str, args: &[String]) -> PluginResult<St
     }
 }
 ```
+
+> **Name collisions between plugins**: When two plugins register a command with the same name, the debugger resolves the conflict deterministically. Core commands always take precedence, then plugins are ordered by manifest name. See [Plugin Command Namespace Policy](plugin-command-namespaces.md) for the full precedence rules, normalization behavior, and the recommended `plugin_name:command_name` style.
 
 ### Hot-Reload Support
 
@@ -733,8 +736,26 @@ For details on manifest file versioning, see Plugin Manifest Versioning.
 - Verify `on_event` is implemented correctly
 - Check that the event type you're expecting is actually fired
 
+## Command Namespace Rules
+
+When multiple plugins provide commands, name collisions are resolved deterministically:
+
+1. **Core commands always win** — no plugin can shadow a built-in command.
+2. **Plugins are ordered by manifest name** (alphabetically). The first plugin in that order wins for execution; all others are recorded as conflicts.
+3. **Names are normalized** — whitespace is trimmed and names are lowercased before comparison.
+4. **Conflict warnings** are emitted once at plugin load time, not on every invocation. You can inspect active conflicts via `command_conflicts()` and `formatter_conflicts()` on the registry.
+
+To avoid collisions entirely, use a namespaced style:
+
+```text
+plugin_name:command_name
+```
+
+For the complete policy, including formatter name resolution and example warning output, see [Plugin Command Namespace Policy](plugin-command-namespaces.md).
+
 ## Additional Resources
 
+- [Plugin Command Namespace Policy](plugin-command-namespaces.md)
 - [Example Logger Plugin](../examples/plugins/example_logger/)
 - [Plugin API Reference](https://docs.rs/soroban-debugger/latest/soroban_debugger/plugin/)
 - [GitHub Issues](https://github.com/Timi16/soroban-debugger/issues)

--- a/docs/plugin-command-namespaces.md
+++ b/docs/plugin-command-namespaces.md
@@ -1,5 +1,7 @@
 # Plugin Command Namespace Policy
 
+> This page is part of the plugin system reference. For the full plugin API, see [Plugin System API Documentation](plugin-api.md#command-namespace-rules).
+
 ## Problem
 
 Plugins can provide custom CLI commands and output formatters, but name collisions between plugins make behavior unpredictable.


### PR DESCRIPTION
## Description

<!-- A clear and concise summary of the change and its motivation. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Test / CI improvement

---

## CI/Test Behavior Changes

<!-- REQUIRED — fill in or mark N/A. -->

**What changed in CI or test behavior?**

<!-- Describe any changes to CI jobs, test configuration, test infrastructure, new or removed tests,
     changed test commands, updated thresholds, or any other shift in how tests run or what they check.
     If nothing changed, write: N/A — no CI/test behavior changes -->

N/A — no CI/test behavior changes

**Migration notes**

<!-- If this change requires contributors or CI environments to take action (e.g. install a new tool,
     update a local cache, re-run a setup script, change a local command), document those steps here.
     If no migration is needed, write: N/A -->

N/A

--- closes #939

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR description mentions the related issue(s)
- [ ] CI/test behavior changes documented above (or marked N/A)
- [ ] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed
