### PR TITLE
Docs/plugin failure handling.md covers session level

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -14,6 +14,7 @@ The Soroban Debugger plugin system allows developers to extend the debugger's fu
 8. [Hot-Reload Support](#hot-reload-support)
 9. [Best Practices](#best-practices)
 10. [Examples](#examples)
+11. [Command Namespace Rules](#command-namespace-rules)
 
 ## Overview
 
@@ -282,6 +283,8 @@ fn execute_command(&mut self, command: &str, args: &[String]) -> PluginResult<St
     }
 }
 ```
+
+> **Name collisions between plugins**: When two plugins register a command with the same name, the debugger resolves the conflict deterministically. Core commands always take precedence, then plugins are ordered by manifest name. See [Plugin Command Namespace Policy](plugin-command-namespaces.md) for the full precedence rules, normalization behavior, and the recommended `plugin_name:command_name` style.
 
 ### Hot-Reload Support
 
@@ -733,8 +736,26 @@ For details on manifest file versioning, see Plugin Manifest Versioning.
 - Verify `on_event` is implemented correctly
 - Check that the event type you're expecting is actually fired
 
+## Command Namespace Rules
+
+When multiple plugins provide commands, name collisions are resolved deterministically:
+
+1. **Core commands always win** — no plugin can shadow a built-in command.
+2. **Plugins are ordered by manifest name** (alphabetically). The first plugin in that order wins for execution; all others are recorded as conflicts.
+3. **Names are normalized** — whitespace is trimmed and names are lowercased before comparison.
+4. **Conflict warnings** are emitted once at plugin load time, not on every invocation. You can inspect active conflicts via `command_conflicts()` and `formatter_conflicts()` on the registry.
+
+To avoid collisions entirely, use a namespaced style:
+
+```text
+plugin_name:command_name
+```
+
+For the complete policy, including formatter name resolution and example warning output, see [Plugin Command Namespace Policy](plugin-command-namespaces.md).
+
 ## Additional Resources
 
+- [Plugin Command Namespace Policy](plugin-command-namespaces.md)
 - [Example Logger Plugin](../examples/plugins/example_logger/)
 - [Plugin API Reference](https://docs.rs/soroban-debugger/latest/soroban_debugger/plugin/)
 - [GitHub Issues](https://github.com/Timi16/soroban-debugger/issues)

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -15,6 +15,7 @@ The Soroban Debugger plugin system allows developers to extend the debugger's fu
 9. [Best Practices](#best-practices)
 10. [Examples](#examples)
 11. [Command Namespace Rules](#command-namespace-rules)
+12. [Failure Handling and Circuit Breaker](plugin-failure-handling.md)
 
 ## Overview
 
@@ -464,6 +465,8 @@ Policy behavior:
 
 In `enforce` mode, a plugin must either be explicitly allowlisted or provide a valid Ed25519 signature from an allowed signer.
 
+For details on what happens when a plugin that passes trust checks later panics or times out at runtime — including how in-flight events are handled and how the session-level circuit breaker works — see [Plugin Failure Handling](plugin-failure-handling.md).
+
 ## Installation and Loading
 
 ### Manual Installation
@@ -756,6 +759,7 @@ For the complete policy, including formatter name resolution and example warning
 ## Additional Resources
 
 - [Plugin Command Namespace Policy](plugin-command-namespaces.md)
+- [Plugin Failure Handling and Circuit Breaker](plugin-failure-handling.md)
 - [Example Logger Plugin](../examples/plugins/example_logger/)
 - [Plugin API Reference](https://docs.rs/soroban-debugger/latest/soroban_debugger/plugin/)
 - [GitHub Issues](https://github.com/Timi16/soroban-debugger/issues)

--- a/docs/plugin-command-namespaces.md
+++ b/docs/plugin-command-namespaces.md
@@ -1,5 +1,7 @@
 # Plugin Command Namespace Policy
 
+> This page is part of the plugin system reference. For the full plugin API, see [Plugin System API Documentation](plugin-api.md#command-namespace-rules).
+
 ## Problem
 
 Plugins can provide custom CLI commands and output formatters, but name collisions between plugins make behavior unpredictable.

--- a/docs/plugin-failure-handling.md
+++ b/docs/plugin-failure-handling.md
@@ -25,6 +25,97 @@ When a plugin panics or exceeds its execution budget:
 This is intentionally explicit so users are not misled into thinking that a
 plugin crash means the Soroban debugger itself became unstable.
 
+## What Happens To In-Flight Events When The Circuit Opens
+
+Understanding what happens to the event that was being dispatched at the moment
+a plugin trips the circuit breaker is important for reasoning about plugin
+output and session state.
+
+### Panics
+
+A panic is caught synchronously inside `catch_unwind` during the current
+dispatch call. The sequence is:
+
+1. The plugin's `on_event` handler panics.
+2. `catch_unwind` catches the panic before it can unwind into the debugger.
+3. The panic is converted to a `PluginError::Panic` and passed to
+   `record_outcome`.
+4. `record_outcome` immediately sets `circuit_open = true` and
+   `session_disabled = true` for that plugin.
+5. An incident report is emitted and a `Panic` telemetry entry is appended to
+   the current `EventContext`.
+6. The dispatch loop moves on to the next plugin in the same cycle — **other
+   plugins are not affected**.
+
+The triggering event is therefore **partially processed**: the panicking plugin
+did not complete its handler, but every other plugin that was registered before
+it in the dispatch order already ran, and every plugin registered after it
+still runs normally.
+
+### Timeouts
+
+Timeout detection is **post-hoc**: the plugin runs to completion and its result
+is returned, but if the elapsed time exceeds the configured budget the result
+is discarded and the plugin is session-disabled. The sequence is:
+
+1. The plugin's `on_event` handler returns `Ok(())`.
+2. `record_outcome` compares elapsed time against `hook_timeout`
+   (default: 250 ms).
+3. If elapsed > timeout, the successful return value is discarded, the plugin
+   is session-disabled, and a `Timeout` incident report is emitted.
+4. A `Timeout` telemetry entry is appended to the current `EventContext`.
+5. The dispatch loop continues normally for all other plugins.
+
+Because the plugin already ran to completion, any side effects it produced
+(writes to its own internal state, log output, etc.) are **not rolled back**.
+Only the return value is discarded.
+
+### Subsequent Events After Disablement
+
+Once a plugin is session-disabled, every subsequent dispatch call checks
+`circuit_open || session_disabled` at the top of `run_hook_with_policy` before
+doing any work:
+
+- If the circuit is open, the hook is **skipped entirely** — `on_event` is
+  never called.
+- A `SkippedCircuitOpen` telemetry entry is appended to the `EventContext` so
+  the skip is visible in telemetry.
+- Commands and formatters from a disabled plugin return
+  `PluginError::SessionDisabled` or `PluginError::CircuitOpen` immediately.
+
+The plugin remains disabled for the lifetime of the process. There is no
+automatic reset or retry within a session.
+
+### Circuit-Open vs. Session-Disabled
+
+The registry tracks two related but distinct flags per plugin:
+
+| Flag | Set by | Meaning |
+|------|--------|---------|
+| `circuit_open` | Panic, timeout, or N consecutive failures | Invocations are skipped |
+| `session_disabled` | Panic or timeout (incident-level events only) | Permanent skip for this session; shown in incident report |
+
+A plugin can have `circuit_open = true` without `session_disabled = true` if
+it accumulated enough consecutive soft failures (default threshold: 3). In that
+case the circuit may reset on a subsequent success. A plugin with
+`session_disabled = true` will never reset within the session regardless of
+later behavior.
+
+### Telemetry Visibility
+
+Every skipped or failed invocation appends a `PluginTelemetryEvent` to the
+`EventContext` that was passed into the dispatch call. The telemetry entry
+includes:
+
+- plugin name,
+- invocation kind (`Hook`, `Command`, or `Formatter`),
+- outcome (`Panic`, `Timeout`, `Failure`, `SkippedCircuitOpen`, or `Success`),
+- elapsed duration in milliseconds,
+- a human-readable message (the incident summary line for panics and timeouts).
+
+This means the caller always has a record of what happened, even when the
+plugin was silently skipped.
+
 ## Session Disablement
 
 Session disablement is intentionally conservative:
@@ -61,3 +152,8 @@ The expected answer after a contained incident is:
 
 - yes, the plugin failed,
 - yes, the core debugger is still available.
+
+## Related Documentation
+
+- [Plugin System API Documentation](plugin-api.md) — full plugin trait reference
+- [Plugin Command Namespace Policy](plugin-command-namespaces.md) — command name conflict resolution


### PR DESCRIPTION
## Description

<!-- A clear and concise summary of the change and its motivation. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Test / CI improvement

---

## CI/Test Behavior Changes

<!-- REQUIRED — fill in or mark N/A. -->

**What changed in CI or test behavior?**

<!-- Describe any changes to CI jobs, test configuration, test infrastructure, new or removed tests,
     changed test commands, updated thresholds, or any other shift in how tests run or what they check.
     If nothing changed, write: N/A — no CI/test behavior changes -->

N/A — no CI/test behavior changes

**Migration notes**

<!-- If this change requires contributors or CI environments to take action (e.g. install a new tool,
     update a local cache, re-run a setup script, change a local command), document those steps here.
     If no migration is needed, write: N/A -->

N/A

--- closes #938

## Checklist

- [ ] All tests pass locally (`cargo test --workspace --all-features`)
- [ ] Code is formatted (`cargo fmt --all -- --check`)
- [ ] Clippy is clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR description mentions the related issue(s)
- [ ] CI/test behavior changes documented above (or marked N/A)
- [ ] If CLI flags/subcommands/help text changed, man pages regenerated (`make regen-man`) and `.1` files committed
